### PR TITLE
[IMP] web_view_google_map: see CHANGELOG.md

### DIFF
--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 17.0.1.0.2
+* Improvement:    
+    An improvement to address the previous case when opening a form view triggered from marker info window. Now we will check if the active action has window view (`ir.actions.act_window.view`) linked.
+
 ## 17.0.1.0.1
 * Bug fixes:    
     Fix the error thrown when save a form view opened from the marker info window.

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '17.0.1.0.1',
+    'version': '17.0.1.0.2',
     'depends': ['base_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map/models/google_map_view_mixin.py
+++ b/web_view_google_map/models/google_map_view_mixin.py
@@ -37,4 +37,17 @@ class GoogleMapViewMixins(models.AbstractModel):
             return False
 
         action = self.env['ir.actions.actions']._for_xml_id(action_name)
-        return dict(action, view_mode='form', res_id=res_id, views=[(False, 'form')])
+        form_view = (
+            self.env['ir.actions.act_window.view']
+            .sudo()
+            .search(
+                [('view_mode', '=', 'form'), ('act_window_id', '=', action_id)],
+                limit=1,
+            )
+        )
+        if form_view and form_view.view_id:
+            views = [(form_view.view_id.id, 'form')]
+        else:
+            views = [(False, 'form')]
+
+        return dict(action, view_mode='form', res_id=res_id, views=views)


### PR DESCRIPTION
An improvement to address the previous case when opening a form view triggered from marker info window.
Now we will check if the active action has window view (`ir.actions.act_window.view`) linked to it.