### PR TITLE
18.0 Maintenance

### DIFF
--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.1',
+    'version': '1.0.2',
     'depends': ['base_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map/static/src/views/google_map/components/search_places/search_places.js
+++ b/web_view_google_map/static/src/views/google_map/components/search_places/search_places.js
@@ -3,6 +3,10 @@ import { Component, useEffect, useRef, onWillDestroy } from '@odoo/owl';
 import { useService } from '@web/core/utils/hooks';
 import { debounce } from '@web/core/utils/timing';
 
+const DEFAULT_ZOOM_LEVEL = 17;
+const INFO_WINDOW_MAX_WIDTH = '400px';
+
+
 export class GoogleMapSearchPlaces extends Component {
     static template = 'web_view_google_map.SearchPlaces';
     static props = ['googleMap'];
@@ -14,6 +18,7 @@ export class GoogleMapSearchPlaces extends Component {
         this.marker = null;
         this.infoWindow = null;
         this.debouncedHandlePlaceSelect = debounce(this.handlePlaceSelect, 300);
+        this.boundsChangedListener = null;
         useEffect(
             (googleMap, searchEl) => {
                 if (googleMap && searchEl) {
@@ -41,6 +46,9 @@ export class GoogleMapSearchPlaces extends Component {
         if (this.placeAutocomplete) {
             this.placeAutocomplete.remove();
             google.maps.event.clearListeners(this.placeAutocomplete, 'gmp-select');
+        }
+        if (this.boundsChangedListener) {
+            google.maps.event.removeListener(this.boundsChangedListener);
         }
     }
 
@@ -102,7 +110,7 @@ export class GoogleMapSearchPlaces extends Component {
                     });
                 });
 
-                this.props.googleMap.addListener('bounds_changed', () => {
+                this.boundsChangedListener = this.props.googleMap.addListener('bounds_changed', () => {
                     if (this.placeAutocomplete) {
                         this.placeAutocomplete.locationRestriction =
                             this.props.googleMap.getBounds();
@@ -128,33 +136,29 @@ export class GoogleMapSearchPlaces extends Component {
      * @returns {Promise<void>}
      */
     async handlePlaceSelect({ placePrediction }) {
-        const place = placePrediction.toPlace();
-        await place.fetchFields({ fields: ['displayName', 'formattedAddress', 'location'] });
+        try {
+            const place = placePrediction.toPlace();
+            await place.fetchFields({ fields: ['displayName', 'formattedAddress', 'location'] });
 
-        if (place.viewport) {
-            this.props.googleMap.fitBounds(place.viewport);
-        } else {
-            this.props.googleMap.setCenter(place.location);
-            this.props.googleMap.setZoom(17);
+            if (place.viewport) {
+                this.props.googleMap.fitBounds(place.viewport);
+            } else {
+                this.props.googleMap.setCenter(place.location);
+                this.props.googleMap.setZoom(DEFAULT_ZOOM_LEVEL);
+            }
+            const content = this._createInfoWindowContent(place);
+            this.updateInfoWindow(content, place.location);
+            if (!this.markerPlacesSearch.map) {
+                this.markerPlacesSearch.map = this.props.googleMap;
+            }
+            this.markerPlacesSearch.position = place.location;
+        } catch (error) {
+            console.error('Error handling place select:', error);
+            this.notificationService.add(
+                _t('Failed to fetch Google place detail.'),
+                { type: 'warning' }
+            );
         }
-        const content = document.createElement('div');
-        content.classList.add('p-4', 'mt-4');
-        content.style.maxWidth = '400px';
-        content.innerHTML = `
-            <div id="infowindow-content">
-                <span id="place-displayname" class="fs-4 fw-bolder">
-                    ${place.displayName}
-                </span><br />
-                <span id="place-address">
-                    ${place.formattedAddress}
-                </span>
-            </div>
-        `;
-        this.updateInfoWindow(content, place.location);
-        if (!this.markerPlacesSearch.map) {
-            this.markerPlacesSearch.map = this.props.googleMap;
-        }
-        this.markerPlacesSearch.position = place.location;
     }
 
     /**
@@ -174,5 +178,27 @@ export class GoogleMapSearchPlaces extends Component {
         this.markerInfoWindow.addListener('closeclick', () => {
             this.markerPlacesSearch.map = null;
         });
+    }
+ 
+    /**
+     * Create the content for the info window
+     * @param {Object} place - The place object containing displayName and formattedAddress
+     * @returns {HTMLElement} - The content element for the info window
+     */
+    _createInfoWindowContent(place) {
+        const content = document.createElement('div');
+        content.classList.add('p-4', 'mt-4');
+        content.style.maxWidth = INFO_WINDOW_MAX_WIDTH;
+        content.innerHTML = `
+            <div id="infowindow-content">
+                <span id="place-displayname" class="fs-4 fw-bolder">
+                    ${place.displayName}
+                </span><br />
+                <span id="place-address">
+                    ${place.formattedAddress}
+                </span>
+            </div>
+        `;
+        return content;
     }
 }

--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
 
+## 18.0.1.0.1
+Fix lodash function, replace `_.defaults` with `Object.assign`
+
 ## 18.0.1.0.0
 Migration to version 18.0

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -13,7 +13,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.0',
+    'version': '1.0.1',
     'depends': ['base_google_map'],
     'assets': {
         'web.assets_backend': [

--- a/web_widget_google_map/static/src/widgets/BaseGoogleAutocomplete/base_google_autocomplete.js
+++ b/web_widget_google_map/static/src/widgets/BaseGoogleAutocomplete/base_google_autocomplete.js
@@ -117,13 +117,13 @@ export class BaseGoogleAutocomplete extends Component {
         if (!readonly && options) {
             this.force_override = options.force_override || false;
             if (options.hasOwnProperty('component_form')) {
-                this.component_form = _.defaults({}, options.component_form, this.component_form);
+                this.component_form = Object.assign({}, this.component_form, options.component_form);
             }
             if (options.hasOwnProperty('delimiter')) {
-                this.fillfields_delimiter = _.defaults(
+                this.fillfields_delimiter = Object.assign(
                     {},
-                    options.delimiter,
-                    this.fillfields_delimiter
+                    this.fillfields_delimiter,
+                    options.delimiter
                 );
             }
             if (options.hasOwnProperty('lat')) {
@@ -136,7 +136,7 @@ export class BaseGoogleAutocomplete extends Component {
                 if (this.force_override) {
                     this.address_form = options.address_form;
                 } else {
-                    this.address_form = _.defaults({}, options.address_form, this.address_form);
+                    this.address_form = Object.assign({}, this.address_form, options.address_form);
                 }
             }
             if (options.hasOwnProperty('display_name')) {

--- a/web_widget_google_map/static/src/widgets/GooglePlaceAutocomplete/google_place_autocomplete.js
+++ b/web_widget_google_map/static/src/widgets/GooglePlaceAutocomplete/google_place_autocomplete.js
@@ -72,10 +72,10 @@ export class GooglePlaceAutocompleteField extends BaseGoogleAutocomplete {
                             this.address_form = options.fillfields.address;
                             this.fillfields['address'] = options.fillfields.address;
                         } else {
-                            const address_fields = _.defaults(
+                            const address_fields = Object.assign(
                                 {},
-                                options.fillfields.address,
-                                this.fillfields.address
+                                this.fillfields.address,
+                                options.fillfields.address
                             );
                             this.address_form = address_fields;
                             this.fillfields['address'] = address_fields;
@@ -86,10 +86,10 @@ export class GooglePlaceAutocompleteField extends BaseGoogleAutocomplete {
                         if (this.force_override) {
                             this.fillfields['general'] = options.fillfields.general;
                         } else {
-                            this.fillfields['general'] = _.defaults(
+                            this.fillfields['general'] = Object.assign(
                                 {},
-                                options.fillfields.general,
-                                this.fillfields.general
+                                this.fillfields.general,
+                                options.fillfields.general
                             );
                         }
                     }

--- a/web_widget_google_map/static/src/widgets/GooglePlaceAutocomplete/google_place_autocomplete.js
+++ b/web_widget_google_map/static/src/widgets/GooglePlaceAutocomplete/google_place_autocomplete.js
@@ -74,7 +74,7 @@ export class GooglePlaceAutocompleteField extends BaseGoogleAutocomplete {
                         } else {
                             const address_fields = Object.assign(
                                 {},
-                                this.fillfields.address,
+                                this.fillfields.address || {},
                                 options.fillfields.address
                             );
                             this.address_form = address_fields;
@@ -88,7 +88,7 @@ export class GooglePlaceAutocompleteField extends BaseGoogleAutocomplete {
                         } else {
                             this.fillfields['general'] = Object.assign(
                                 {},
-                                this.fillfields.general,
+                                this.fillfields.general || {},
                                 options.fillfields.general
                             );
                         }


### PR DESCRIPTION
[IMP] web_widget_google_map: replace lodash _.defaults with Object.assign

Replace deprecated lodash _.defaults function with native Object.assign for better compatibility and reduced dependencies. Updated version to 1.0.1.


This pull request updates the `web_widget_google_map` module to fix issues with the use of lodash's `_.defaults` function by replacing it with JavaScript's native `Object.assign`. This change improves compatibility and reliability by removing the dependency on lodash for object property merging. The module version is also incremented to reflect the update.

**Dependency and Compatibility Improvements:**

* Replaced all instances of `_.defaults` with `Object.assign` in `base_google_autocomplete.js` and `google_place_autocomplete.js` to handle object merging, improving compatibility and removing reliance on lodash. [[1]](diffhunk://#diff-b80ea917af3c36272d33174966e7de325a9af022abb92029a82987aa170edcc7L120-R126) [[2]](diffhunk://#diff-b80ea917af3c36272d33174966e7de325a9af022abb92029a82987aa170edcc7L139-R139) [[3]](diffhunk://#diff-7f520b1171c5042b82844f28d7d8724f2bb64c4a135ddc804a02b4ce37c83744L75-R78) [[4]](diffhunk://#diff-7f520b1171c5042b82844f28d7d8724f2bb64c4a135ddc804a02b4ce37c83744L89-R92)

**Version and Documentation Updates:**

* Updated the module version from `1.0.0` to `1.0.1` in `__manifest__.py` to reflect the bug fix.
* Added a changelog entry describing the replacement of `_.defaults` with `Object.assign`.