### PR TITLE
[FIX] web_widget_google_map: filter autocomplete field updates

### DIFF
--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## 18.0.1.0.2
+Fix issue with autocomplete updating fields that are not in the view
 
 ## 18.0.1.0.1
 Fix lodash function, replace `_.defaults` with `Object.assign`

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -13,7 +13,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.1',
+    'version': '1.0.2',
     'depends': ['base_google_map'],
     'assets': {
         'web.assets_backend': [

--- a/web_widget_google_map/static/src/widgets/BaseGoogleAutocomplete/base_google_autocomplete.js
+++ b/web_widget_google_map/static/src/widgets/BaseGoogleAutocomplete/base_google_autocomplete.js
@@ -213,7 +213,14 @@ export class BaseGoogleAutocomplete extends Component {
     }
 
     _update(values) {
-        this.props.record.update(values);
+        const filterChanges = {};
+        // Only update the fields that exist in the record (defined in the view)
+        for (const key in values) {
+            if (this.props.record.fields.hasOwnProperty(key)) {
+                filterChanges[key] = values[key];
+            }
+        }
+        this.props.record.update(filterChanges);
     }
 
     get shouldTrim() {


### PR DESCRIPTION
Fix issue where the Google Maps autocomplete widget attempts to update fields that are not defined in the current view, which causes errors.

The _update method now filters the values object to only include fields that exist in the record's field definitions before calling record.update().

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)