### PR TITLE
[19.0] web_widget_google_place_autocomplete improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.1 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps widget |
-| [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete Element |
+| [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.1 | Implementation of Google Places Autocomplete Element |
 
 
 ## Usage

--- a/contacts_google_autocomplete/__init__.py
+++ b/contacts_google_autocomplete/__init__.py
@@ -130,6 +130,7 @@ def _post_install_hook_configure_contact_google_place_mapping(env):
             'code': secrets.token_urlsafe(6),
             'model_id': model_contact_id,
             'mode': 'address',
+            'gplace_options': "{'includedPrimaryTypes': ['route', 'street_address']}",
             'gplace_address_fetch_fields': "['addressComponents', 'location']",
             'latitude': field_latitude_id,
             'longitude': field_longitude_id,

--- a/crm_google_autocomplete/__init__.py
+++ b/crm_google_autocomplete/__init__.py
@@ -129,6 +129,7 @@ def _post_install_hook_configure_crm_google_place_mapping(env):
             'code': secrets.token_urlsafe(6),
             'model_id': model_crm_lead_id,
             'mode': 'address',
+            'gplace_options': "{'includedPrimaryTypes': ['route', 'street_address']}",
             'gplace_address_fetch_fields': "['addressComponents', 'location']",
             'latitude': field_latitude_id,
             'longitude': field_longitude_id,

--- a/web_widget_google_place_autocomplete/README.md
+++ b/web_widget_google_place_autocomplete/README.md
@@ -1,9 +1,33 @@
 # Web Widget Google Place Autocomplete
 
-The `web_widget_google_place_autocomplete` module provides a new widget implementation using Google's NEW Places API. It offers enhanced autocomplete functionality with improved address mapping capabilities and configurable field mappings per country through a dedicated configuration interface.
+The `web_widget_google_place_autocomplete` module provides a new widget implementation using Google's Places API(New) [https://developers.google.com/maps/documentation/javascript/place-autocomplete-new](https://developers.google.com/maps/documentation/javascript/place-autocomplete-new).    
+It offers enhanced autocomplete functionality with improved address mapping capabilities and configurable field mappings per country through a dedicated configuration interface.
 
-This widget give you full control over how Google Places data is mapped to your Odoo model fields, allowing for a more tailored and accurate data entry experience.
+This widget gives you full control over how Google Places data is mapped to your Odoo model fields, allowing for a more tailored and accurate data entry experience.
 
+## Table of Contents
+
+- [Features](#features)
+- [Screenshots](#screenshots)
+- [Widget: gplace_autocomplete_el](#widget-gplace_autocomplete_el)
+  - [Usage](#usage)
+  - [Configuration Options](#configuration-options)
+  - [Street Formatting](#street-formatting)
+- [Installation & Configuration](#installation--configuration)
+- [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
+- [Authors](#authors)
+
+## Features
+
+- **Google Places API (New)**: Leverages the latest Google Places API for improved accuracy and performance
+- **Flexible Field Mapping**: Configure custom mappings between Google Places data and Odoo fields
+- **Multiple Mapping Modes**: Support for both "places" and "address" autocomplete modes
+- **Interactive Mapping Test**: Built-in testing tool to verify your field mappings
+- **Quick Access**: Shortcut button in form views to access mapping configuration
+- **Street Format Control**: Configure street formatting per country (route + number or number + route)
+
+## Screenshots
 
 <div style="display: flex; gap: 4px; justify-content: center; margin-bottom: 50px;">
   <img src="static/img/google_fields_mapping.png" alt="Google Fields Mapping" style="width: 40%; max-width: 300px; height: auto;">
@@ -11,16 +35,222 @@ This widget give you full control over how Google Places data is mapped to your 
 </div>
 
 You can also access the mapping configuration quickly via the shortcut button next to the autocomplete input field in the form view.
+
 <div style="display: flex; gap: 4px; justify-content: center;">
-  <img src="static/img/shortcut_to_access_the_mapping.png" alt="Quick access to mapping configurationn" style="width: 40%; max-width: 300px; height: auto;">
+  <img src="static/img/shortcut_to_access_the_mapping.png" alt="Quick access to mapping configuration" style="width: 40%; max-width: 300px; height: auto;">
 </div>
 
-### Installation & Configuration
+## Widget: gplace_autocomplete_el
 
-1. Configure your Google Maps API key with the NEW Places API enabled in `Settings > General Settings > Google Maps`
-2. Configure your mappings in `Settings > Technical > Google Places Mapping`
-3. Use the widget in your custom forms by specifying the appropriate widget in XML views
-4. Places API (New) must be enabled in your Google Cloud Console 
+This module introduces a new widget named `gplace_autocomplete_el` that leverages the latest Google Places API for enhanced autocomplete functionality.
+
+### Prerequisites
+
+Before using the widget, ensure you have:
+
+1. Google Maps API key with Places API (New) enabled
+2. At least one mapping configuration created in `Settings > Technical > Google Places Mapping`
+
+**Reference Examples**: Check the `contacts_google_autocomplete` or `crm_google_autocomplete` modules for pre-configured mapping examples.
+
+### Usage
+
+To use the widget in your form views, you can configure it in two ways:
+
+#### Option 1: Using Mapping Code (Recommended)
+
+The `mapping_code` is the unique identifier of your mapping configuration. This option takes priority over `mapping_mode`.
+
+```xml
+<record id="view_form_your_model" model="ir.ui.view">
+  <field name="name">your.model.form</field>
+  <field name="model">your.model</field>
+  <field name="arch" type="xml">
+    <form>
+      ...
+      <field name="your_field_name" widget="gplace_autocomplete_el"
+             options="{'mapping_code': 'your_mapping_code'}"/>
+      ...
+    </form>
+    </field>
+</record>
+```
+
+#### Option 2: Using Mapping Mode
+
+There are two available mapping modes:
+
+- **`places`**: General places autocomplete (businesses, landmarks, addresses)
+- **`address`**: Restricted to street addresses only
+
+```xml
+<record id="view_form_your_model" model="ir.ui.view">
+  <field name="name">your.model.form</field>
+  <field name="model">your.model</field>
+  <field name="arch" type="xml">
+    <form>
+      ...
+      <field name="your_field_name" widget="gplace_autocomplete_el"
+             options="{'mapping_mode': 'address'}"/>
+      ...
+    </form>
+    </field>
+</record>
+```
+
+### Configuration Options
+
+1. Autocomplete Options (optional)   
+The widget behavior can be customized using Google Places Autocomplete options. These options are configured in the mapping configuration and control the autocomplete element initialization.    
+Please check this document [Google Places Autocomplete documentation](https://developers.google.com/maps/documentation/places/web-service/place-autocomplete#supported-parameters) for more details.
+
+**Example**: For address-only results, configure your mapping with:
+```python
+{'includedPrimaryTypes': ['route', 'street_address']}
+```
+
+2. Fields Property (mandatory).   
+It's recommended to define the `fields` property in your mapping configuration to specify which Google Places fields to retrieve. This optimizes performance by limiting data retrieval to only necessary fields.     
+Use the fields property wisely as it affects the cost of API usage.    
+Please check this document [Place Fields documentation](https://developers.google.com/maps/documentation/javascript/place-class-data-fields) for more details.    
+
+
+**Example**: To retrieve only location(geolocation) and address, configure your mapping with:
+```python
+['location', 'addressComponents']
+```
+### Street Formatting
+
+Countries now include a "Street Format" field (`street_format`) to control how street addresses are formatted:
+
+- **`route_street_number`** (default): Route name followed by street number (e.g., "Main Street 123")
+- **`street_number_route`**: Street number followed by route name (e.g., "123 Main Street")
+
+Configure this in `Contacts > Configuration > Countries` for each country.
+
+
+## Installation & Configuration
+
+### Step 1: Google Cloud Platform Setup
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
+2. Enable the following APIs:
+   - **Places API (New)** - Required for the new widget
+   - **Maps JavaScript API** - Required for map display
+   - **Geocoding API** - Optional, for additional geocoding features
+3. Create or use an existing API key with the above APIs enabled
+
+### Step 2: Odoo Configuration
+
+1. Install the `web_widget_google_place_autocomplete` module
+2. Go to `Settings > General Settings > Google Maps`
+3. Configure your Google Maps API key
+4. Save the configuration
+
+### Step 3: Create Mapping Configuration
+
+1. Go to `Settings > Technical > Google Places Mapping`
+2. Create a new mapping configuration:
+   - **Name**: Descriptive name for your mapping
+   - **Model**: Target Odoo model (e.g., `res.partner`, `crm.lead`)
+   - **Mapping Mode**: Choose `address` or `places`
+   - **Field Mappings**: Map Google Places fields to Odoo model fields.    
+      There are two sections: 
+      - **Address Mapping**: For general address fields
+      - **Other**: For any fields outside of the address scope
+3. Use the Section test to test your mapping configuration
+
+### Step 4: Apply Widget to Forms
+
+Add the widget to your form views using one of the methods described in the [Usage](#usage) section.
+
+## Examples
+
+### Example 1: Using Mapping Code on inherited form view
+
+```xml
+<record id="view_partner_form_custom" model="ir.ui.view">
+  <field name="name">res.partner.form.custom</field>
+  <field name="model">res.partner</field>
+  <field name="inherit_id" ref="base.view_partner_form"/>
+  <field name="arch" type="xml">
+    <field name="street" position="attributes">
+      <attribute name="widget">gplace_autocomplete_el</attribute>
+      <attribute name="options">{'mapping_code': 'ibSbbpMF'}</attribute>
+    </field>
+  </field>
+</record>
+```
+
+### Example 2: Using Mapping Mode on inherited form view
+
+```xml
+<record id="view_crm_lead_form_custom" model="ir.ui.view">
+  <field name="name">crm.lead.form.custom</field>
+  <field name="model">crm.lead</field>
+  <field name="inherit_id" ref="crm.crm_lead_view_form"/>
+  <field name="arch" type="xml">
+    <field name="street" position="attributes">
+      <attribute name="widget">gplace_autocomplete_el</attribute>
+      <attribute name="options">{'mapping_mode': 'address'}</attribute>
+    </field>
+  </field>
+</record>
+```
+
+## Troubleshooting
+
+### Widget Not Showing Autocomplete Suggestions
+
+**Possible causes:**
+- Google API key not configured or invalid
+- Places API (New) not enabled in Google Cloud Console
+- API key restrictions blocking requests
+- Network/firewall blocking Google APIs
+
+**Solution:**
+1. Check API key configuration in `Settings > General Settings`
+2. Verify Places API (New) is enabled in Google Cloud Console
+3. Check browser console for API errors
+4. Verify API key has no IP/domain restrictions preventing access
+
+### Fields Not Populating After Selection
+
+**Possible causes:**
+- Mapping configuration not properly set up
+- Field names in mapping don't match model fields
+- Country-specific mapping missing
+
+**Solution:**
+1. Go to `Settings > Technical > Google Places Mapping`
+2. Verify your mapping configuration exists and is active
+3. Use the "Test Mapping" feature to verify field mappings
+4. Check that mapped field names exactly match your model's field names
+5. Ensure country-specific mappings are configured for target countries
+
+### Incorrect Street Formatting
+
+**Possible causes:**
+- Country street format not configured
+- Using default formatting when country-specific format is needed
+
+**Solution:**
+1. Go to `Contacts > Configuration > Countries`
+2. Find the target country
+3. Set the "Street Format" field to the appropriate value:
+   - `route_street_number` for "Street Name Number"
+   - `street_number_route` for "Number Street Name"
+
+### Quick Access Button Not Visible
+
+**Possible causes:**
+- User doesn't have technical features enabled
+- Widget options not properly configured
+
+**Solution:**
+1. Enable "Technical Features" for your user in `Settings > Users & Companies > Users`
+2. Verify the widget is properly configured with a valid `mapping_code` or `mapping_mode`
 
 ## Authors
+
 - [Yopi Angi](https://www.github.com/gityopie)

--- a/web_widget_google_place_autocomplete/README.md
+++ b/web_widget_google_place_autocomplete/README.md
@@ -109,7 +109,7 @@ Please check this document [Google Places Autocomplete documentation](https://de
 {'includedPrimaryTypes': ['route', 'street_address']}
 ```
 
-2. Fields Property (mandatory).   
+2. Fields Property (mandatory)   
 It's recommended to define the `fields` property in your mapping configuration to specify which Google Places fields to retrieve. This optimizes performance by limiting data retrieval to only necessary fields.     
 Use the fields property wisely as it affects the cost of API usage.    
 Please check this document [Place Fields documentation](https://developers.google.com/maps/documentation/javascript/place-class-data-fields) for more details.    

--- a/web_widget_google_place_autocomplete/__manifest__.py
+++ b/web_widget_google_place_autocomplete/__manifest__.py
@@ -5,15 +5,14 @@
         New widget of Google Place Autcomplete using the NEW Place API
     ''',
     'description': '''
-        Implementation of Google Autocomplete Address form and
-        Google Places autocomplete through widget
+        Implementation of Google Places Autocomplete Element through widget
     ''',
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.0',
+    'version': '1.0.1',
     'depends': ['base_google_map'],
     'assets': {
         'web.assets_backend': [

--- a/web_widget_google_place_autocomplete/static/src/component/google_place_autocomplete.js
+++ b/web_widget_google_place_autocomplete/static/src/component/google_place_autocomplete.js
@@ -320,6 +320,7 @@ export class GooglePlaceAutocompleteElement extends Component {
                 ),
                 { type: 'warning' }
             );
+            this.displayGooglePlaceError();
         }
     }
 
@@ -403,6 +404,15 @@ export class GooglePlaceAutocompleteElement extends Component {
             errorMessage = sprintf(_t('Something went wrong with the Google Autocomplete widget.\n%s'), error);
         }
         this.notificationService.add(errorMessage, { type: 'warning' });
+    }
+
+    /**
+     * Displays a generic error message in the Google Autocomplete widget area.
+     */
+    displayGooglePlaceError() {
+        const errorMessage = _t('Failed to initialize Google Autocomplete');
+        this.gAutocompleteRef.el.innerHTML = '<p class="text-center mb-0">⚠️ ' + errorMessage + '</p>';
+        this.gAutocompleteRef.el.classList.add('smaller', 'text-muted');
     }
 
     /**

--- a/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceMappingTest/google_place_mapping_test.js
+++ b/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceMappingTest/google_place_mapping_test.js
@@ -67,6 +67,7 @@ export class GooglePlaceMappingTestField extends Component {
     setup() {
         this.notificationService = useService('notification');
         this.dialogService = useService('dialog');
+        this.actionService = useService('action');
         this.widgetId = this.getWidgetId();
         this.config = this.getConfig();
     }
@@ -122,6 +123,10 @@ export class GooglePlaceMappingTestField extends Component {
 
         config.resModel = record.resModel || '';
         return config;
+    }
+
+    reloadTestPlaceAutocomplete() {
+        return this.actionService.doAction({type: 'ir.actions.client', tag: 'reload'});
     }
 }
 

--- a/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceMappingTest/google_place_mapping_test.xml
+++ b/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceMappingTest/google_place_mapping_test.xml
@@ -13,6 +13,11 @@
                 elementId="widgetId + '_google_places'"
                 callback.bind="showValues"
             />
+            <div class="mt-2">
+                <button type="button" class="btn btn-sm btn-secondary w-50" t-on-click="reloadTestPlaceAutocomplete">
+                    Reload
+                </button>
+            </div>
         </div>
     </t>
     <t t-name="web_widget_google_place_autocomplete.ViewMappingResult">

--- a/web_widget_google_place_autocomplete/views/google_places_mapping_views.xml
+++ b/web_widget_google_place_autocomplete/views/google_places_mapping_views.xml
@@ -21,7 +21,7 @@
                         <p class="mb-0 fst-italic text-600" style="font-size:12px;">
                             <small>Please make sure to test before using the mapping</small>
                             <br/>
-                            <small>When testing the mapping, please reload the page whenever a value is changed.</small>
+                            <small>When testing the mapping, please reload the page whenever the mapping is changed.</small>
                         </p>
                     </div>
                     <div class="oe_title mb-2">
@@ -49,7 +49,7 @@
                                 <field name="gplace_options" widget="code" options="{'mode': 'python'}"/>
                                 <small class="text-muted">
                                     <span>Before configure the value please check this document first </span>
-                                    <a class="text-decoration-underline" href="https://developers.google.com/maps/documentation/javascript/reference/places-widget#PlaceAutocompleteElementOptions" target="_blank">PlaceAutocompleteElementOptions interface</a>
+                                    <a class="text-decoration-underline" href="https://developers.google.com/maps/documentation/places/web-service/place-autocomplete#supported-parameters" target="_blank">PlaceAutocompleteElementOptions interface</a>
                                 </small>
                             </div>
                         </group>


### PR DESCRIPTION
[IMP] web_widget_google_place_autocomplete: Enhanced documentation and usability

Improvements to the Google Place Autocomplete widget module:

Documentation:
- Comprehensive README rewrite with table of contents and structured sections
- Added Features, Prerequisites, and Troubleshooting sections
- Improved code examples with practical use cases
- Fixed grammar and typos
- Added links to official Google Places API documentation

Widget functionality:
- Added visual error display when Google Autocomplete fails to initialize
- Implemented reload button in mapping test interface for easier testing
- Updated help text to clarify when page reload is needed

Configuration:
- Set default gplace_options for contacts and CRM modules to filter address-only results
- Updated documentation links to point to current Google API references

Version: 19.0.1.0.0 -> 19.0.1.0.1