### PR TITLE
[19.0] sale_google_map: Scope CSS styles and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.2 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.1 | Base module for sub view of "google_map" for drawing capability |
-| [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.1 | Implementation of view "Google Maps" on Sale Order |
+| [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.2 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps widget |
 | [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete Element |

--- a/sale_google_map/CHANGELOG.md
+++ b/sale_google_map/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 19.0.1.0.2
+Small UI improvements on the map sidebar.
+
 ## 19.0.1.0.1
 - Clean up code, no functional changes.
 - Visual improvements when showing individual marker in the map.

--- a/sale_google_map/__manifest__.py
+++ b/sale_google_map/__manifest__.py
@@ -8,7 +8,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/Sales',
-    'version': '1.0.1',
+    'version': '1.0.2',
     'depends': ['sale_management', 'web_view_google_map'],
     'data': ['views/sale_order.xml', 'views/res_partner.xml'],
     'assets': {

--- a/sale_google_map/static/src/views/google_map/google_map_sidebar.scss
+++ b/sale_google_map/static/src/views/google_map/google_map_sidebar.scss
@@ -2,15 +2,17 @@
     .o_google_map_renderer, .o_dialog {
         .o_map_right_sidebar {
             .content {
-                table tr td .o_map_sidebar_group {
-                    display: block;
-                    white-space: nowrap;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    max-width: 300px;
+                .sale_google_map {
+                    table tr td .o_map_sidebar_group {
+                        display: block;
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        max-width: 300px;
 
-                    @media (max-width: 1920px) {
-                        max-width: 250px;
+                        @media (max-width: 1920px) {
+                            max-width: 250px;
+                        }
                     }
                 }
             }

--- a/sale_google_map/static/src/views/google_map/google_map_sidebar.xml
+++ b/sale_google_map/static/src/views/google_map/google_map_sidebar.xml
@@ -16,5 +16,8 @@
     </t>
     <t t-name="sale_google_map.GoogleMapSidebar" t-inherit="web_view_google_map.GoogleMapSidebar" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='props.allowSelectors']" position="replace"/>
+        <xpath expr="//div[@t-ref='root']" position="attributes">
+            <attribute name="class" add="sale_google_map" separator=" "/>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Improved CSS specificity for the sale_google_map sidebar to prevent style conflicts with other Google Map view implementations