### PR TITLE
[19.0] web_view_google_map: Improve grouped data visibility on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [crm_google_autocomplete](/crm_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete on CRM Leads/Opportunities |
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.2 | Implementation of view "Google Maps" on CRM |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
-| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.2 | Base module for a new view "google_map" |
-| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.1 | Base module for sub view of "google_map" for drawing capability |
+| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.3 | Base module for a new view "google_map" |
+| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.2 | Base module for sub view of "google_map" for drawing capability |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.1 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps widget |

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 19.0.1.0.3
+Improve the visibility of data displayed on the map when grouping the data.
+
 ## 19.0.1.0.2
 Fix bug where updating (clicking the "edit" button below Google Maps view in form view) a record's geolocation in form view opened in a pop-up window caused an error.
 

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.2',
+    'version': '1.0.3',
     'depends': ['base_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -16,7 +16,6 @@ import {
     invertColorDarken,
     AdvancedMarkerBoxSelector,
     getRecordDataView,
-    generateUUID,
 } from './utils';
 
 /**
@@ -100,9 +99,8 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
             sidebarIsFolded: false,
             // flag to Google Maps API loader status
             loaderStatus: LOADER_STATUS.NOT_LOADED,
-            // flag to control when to update markers
-            groupDatalistId: null,
         });
+
         this.markerInfoWindow = null;
         this.cache = new Map();
         this.cacheRecordDataView = new Map();
@@ -118,27 +116,12 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         this.debounceRenderGeolocationData = debounce(this.renderGeolocationData.bind(this), 500);
         this.debounceSelectedMarkers = debounce(this.onSelectedMarkers.bind(this), 500);
 
-        useEffect(
-            () => {
-                if (this.state.groupDatalistId && this.isMapLoaded() && !this._isSidebarAction) {
-                    this.debounceRenderGeolocationData();
-                }
-                this._isSidebarAction = false;
-            },
-            () => [this.state.groupDatalistId]
-        );
-
         useEffect(() => {
-            if (this.isMapLoaded() && !this.state.groupDatalistId && !this._isSidebarAction) {
-                const isGrouped = this.props.list.isGrouped;
-                if (isGrouped) {
-                    this.state.groupDatalistId = generateUUID();
-                } else {
-                    this.debounceRenderGeolocationData();
-                }
+            if (this.isMapLoaded() && !this._isSidebarAction) {
+                this.debounceRenderGeolocationData();
                 this._isSidebarAction = false;
             }
-        });
+        }, () => [this.state.isMapReady]);
 
         useSubEnv({
             mapState: this.state,
@@ -149,21 +132,30 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         });
 
         onWillUpdateProps((nextProps) => {
-            this._invalidateMarkerPositionIndex();
-            this.state.groupDatalistId = generateUUID();
+            this.onWillUpdatePropsRenderMarkers(nextProps);
         });
 
         onPatched(() => {
             if (this._isSidebarAction) {
                 this._isSidebarAction = false;
             }
-            if (this.state.groupDatalistId && !this.props.list.isGrouped) {
-                this.state.groupDatalistId = null;
-            }
         });
 
         if (this.props.allowSelectors) {
             useBus(this.uiService.bus, 'google-map-center-map', this.centerMap);
+        }
+    }
+
+    onWillUpdatePropsRenderMarkers(nextProps) {
+        this._invalidateMarkerPositionIndex();
+
+        const nextIsGrouped = !!nextProps.list.isGrouped;
+        const currentIsGrouped = !!this.props.list.isGrouped;
+
+        if (nextIsGrouped !== currentIsGrouped && this.isMapLoaded() && nextIsGrouped) {
+            this.clearMarkers();
+        } else if (((currentIsGrouped && !nextIsGrouped) || (!currentIsGrouped && !nextIsGrouped)) && this.isMapLoaded()) {
+            this.debounceRenderGeolocationData();
         }
     }
 
@@ -304,6 +296,11 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         return result;
     }
 
+    async toggleGroup(group) {
+        this._isSidebarAction = true;
+        await group.toggle();
+    }
+
     /**
      * Create or update a marker for a record
      * @param {Object} record The record to create a marker for
@@ -359,13 +356,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
 
         // Remove all markers from the map and clear event listeners
         for (const [id, marker] of this.cache) {
-            // Remove connection line if exists
-            if (marker._connectionLine) {
-                marker._connectionLine.setMap(null);
-                delete marker._connectionLine;
-            }
-            marker.map = null;
-            this._removeMarkerEventListeners(id);
+            this._cleanUpMarker(id, marker);
         }
 
         this.cacheRecordDataView.clear();
@@ -432,16 +423,36 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      */
     async centerMapByGroup(groupRecords) {
         if (!this.isMapLoaded() || !Array.isArray(groupRecords)) return;
+
         this.markerInfoWindow?.close();
         const { LatLngBounds } = await this.apiLoader.importLibrary('core');
         const bounds = new LatLngBounds();
         groupRecords.forEach((record) => {
             const marker = this.cache.get(record.id);
-            if (marker && marker.map) {
+            if (marker) {
+                if (marker.map === null) {
+                    marker.map = this.googleMap;
+                    if (this.markerClusterer) {
+                        this.markerClusterer.addMarker(marker);
+                    }
+                }
                 bounds.extend(marker.position);
             }
         });
         this._fitMapBoundsWithLimit(bounds);
+    }
+
+    async deleteGroupRecords(groupRecords) {
+        if (!this.isMapLoaded() || !Array.isArray(groupRecords)) return;
+        this.markerInfoWindow?.close();
+        groupRecords.forEach((record) => {
+            const marker = this.cache.get(record.id);
+            if (marker) {
+                this._cleanUpMarker(record.id, marker);
+                this.cache.delete(record.id);
+            }
+        });
+        this._fitBoundsWhenReady();
     }
 
     /**
@@ -685,6 +696,10 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
     // Getters
     //--------------------------------------------------------------------------
 
+    get isGrouped() {
+        return !!this.props.list.isGrouped;
+    }
+
     /**
      * Get sidebar props for the sidebar component
      */
@@ -695,11 +710,12 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
             title: this.props.archInfo.sidebarTitleField,
             subTitle: this.props.archInfo.sidebarSubtitleField,
             getGroupsOrRecords: this.getGroupsOrRecords.bind(this),
-            createMarker: this.createMarker.bind(this),
+            toggleGroup: this.toggleGroup.bind(this),
+            renderGroupedRecordsFitBounds: this._renderGroupedRecordsFitBounds.bind(this),
             openRecord: this.props.openRecord.bind(this),
             showRecordsByDomain: this.props.showRecordsByDomain.bind(this),
             pointInMap: this.pointInMap.bind(this),
-            centerMapByGroup: this.centerMapByGroup.bind(this),
+            deleteGroupRecords: this.deleteGroupRecords.bind(this),
             handleToggleRecordSelection: this.toggleRecordSelection.bind(this),
             handleToggleSelection: this.toggleSelectionAll.bind(this),
             handleCanSelectRecord: this.canSelectRecord,
@@ -1007,6 +1023,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      * @returns {Promise} Promise that resolves when all markers are rendered
      */
     async _renderGroupedMarkers(datas) {
+        console.log(' *** Render grouped markers *** ');
         const groupPromises = datas.map(async ({ group }) => {
             try {
                 // Create all markers for this group and wait for them to complete
@@ -1023,6 +1040,11 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
 
         // Wait for all groups to finish creating their markers
         await Promise.all(groupPromises);
+    }
+
+    async _renderGroupedRecordsFitBounds(datas) {
+        await this._renderGroupedMarkers(datas);
+        this._fitBoundsWhenReady();
     }
 
     /**
@@ -1480,6 +1502,8 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      */
     _removeElementEventListeners(element) {
         const listeners = this._elementEventListeners.get(element);
+        console.log('Removing event listeners for element:', { element, listeners });
+
 
         if (listeners) {
             listeners.forEach((listener, eventType) => {
@@ -1616,6 +1640,9 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
 
     _cleanUpMarker(id, marker) {
         if (marker) {
+            if (this.markerClusterer) {
+                this.markerClusterer.removeMarker(marker);
+            }
             // Remove connection line if exists
             if (marker._connectionLine) {
                 marker._connectionLine.setMap(null);

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -1056,7 +1056,6 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      * @returns {Promise} Promise that resolves when all markers are rendered
      */
     async _renderGroupedMarkers(datas) {
-        console.log(' *** Render grouped markers *** ');
         const groupPromises = datas.map(async ({ group }) => {
             try {
                 // Create all markers for this group and wait for them to complete

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -146,15 +146,34 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         }
     }
 
-    onWillUpdatePropsRenderMarkers(nextProps) {
+    /**
+     * Handles marker rendering logic before props are updated.
+     * Invalidates the marker position index and manages marker lifecycle based on grouping state changes.
+     * When switching to grouped view, clears all markers. Otherwise, triggers a debounced render.
+     *
+     * @param {Object} nextProps - The incoming props object containing the updated state
+     * @param {Object} nextProps.list - The list data object
+     * @param {boolean} nextProps.list.isGrouped - Whether the next state is grouped
+    */
+   onWillUpdatePropsRenderMarkers(nextProps) {
+        if (!this.isMapLoaded()) {
+           return;
+        }
+
         this._invalidateMarkerPositionIndex();
 
         const nextIsGrouped = !!nextProps.list.isGrouped;
         const currentIsGrouped = !!this.props.list.isGrouped;
+        const isGroupingChanged = nextIsGrouped !== currentIsGrouped;
 
-        if (nextIsGrouped !== currentIsGrouped && this.isMapLoaded() && nextIsGrouped) {
+        // Clear all markers when switching to grouped view
+        if (isGroupingChanged && nextIsGrouped) {
             this.clearMarkers();
-        } else if (((currentIsGrouped && !nextIsGrouped) || (!currentIsGrouped && !nextIsGrouped)) && this.isMapLoaded()) {
+            return;
+        }
+
+        // Re-render when not in grouped view (staying ungrouped or switching from grouped)
+        if (!nextIsGrouped) {
             this.debounceRenderGeolocationData();
         }
     }
@@ -296,6 +315,13 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         return result;
     }
 
+    /**
+     * Toggles the expansion/collapse state of a group in the sidebar.
+     * Sets a flag to indicate this is a sidebar-initiated action.
+     *
+     * @param {Object} group - The group object to toggle
+     * @returns {Promise<void>}
+     */
     async toggleGroup(group) {
         this._isSidebarAction = true;
         await group.toggle();
@@ -442,6 +468,13 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         this._fitMapBoundsWithLimit(bounds);
     }
 
+    /**
+     * Deletes all markers associated with the given group records.
+     * Cleans up markers from the cache and map, then adjusts the map bounds.
+     *
+     * @param {Array<Object>} groupRecords - Array of record objects to delete from the map
+     * @returns {Promise<void>}
+     */
     async deleteGroupRecords(groupRecords) {
         if (!this.isMapLoaded() || !Array.isArray(groupRecords)) return;
         this.markerInfoWindow?.close();

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -1502,9 +1502,6 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      */
     _removeElementEventListeners(element) {
         const listeners = this._elementEventListeners.get(element);
-        console.log('Removing event listeners for element:', { element, listeners });
-
-
         if (listeners) {
             listeners.forEach((listener, eventType) => {
                 element.removeEventListener(eventType, listener);

--- a/web_view_google_map/static/src/views/google_map/google_map_sidebar.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_sidebar.js
@@ -14,11 +14,12 @@ export class GoogleMapSidebar extends Component {
         title: { type: String, optional: true },
         subTitle: String,
         getGroupsOrRecords: Function,
-        createMarker: Function,
+        toggleGroup: Function,
+        renderGroupedRecordsFitBounds: Function,
         openRecord: Function,
         showRecordsByDomain: Function,
         pointInMap: Function,
-        centerMapByGroup: Function,
+        deleteGroupRecords: Function,
         handleToggleSelection: Function,
         handleCanSelectRecord: Boolean,
         handleSelectAll: Boolean,
@@ -40,11 +41,14 @@ export class GoogleMapSidebar extends Component {
         const { group } = this.datas.find((data) => data.key === groupKey);
         if (!group) return;
 
-        await group.toggle();
-        const records = group.list.records;
-
         if (!ev.currentTarget?.classList.contains('collapsed')) {
-            this.props.centerMapByGroup(records);
+            await this.props.toggleGroup(group);
+            const datas = this.props.getGroupsOrRecords();
+            const groupDatas = datas.filter((data) => data.key === groupKey);
+            this.props.renderGroupedRecordsFitBounds(groupDatas);
+        } else {
+            const records = group.list.records;
+            this.props.deleteGroupRecords(records);
         }
     }
 

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 19.0.1.0.2
+Improve the visibility of data displayed on the map when grouping the data.
+
 ## 19.0.1.0.1
 Small improvements on the SCSS.
 

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.1',
+    'version': '1.0.2',
     'depends': ['web_view_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
@@ -286,13 +286,32 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
 
     }
 
+    /**
+     * Handles feature rendering logic before props are updated.
+     * Manages feature lifecycle based on grouping state changes.
+     * When switching to grouped view, clears all rendering data. Otherwise, triggers a debounced render.
+     *
+     * @param {Object} nextProps - The incoming props object containing the updated state
+     * @param {Object} nextProps.list - The list data object
+     * @param {boolean} nextProps.list.isGrouped - Whether the next state is grouped
+     */
     onWillUpdatePropsRenderMarkers(nextProps) {
+        if (!this.isMapLoaded()) {
+            return;
+        }
+
         const nextIsGrouped = !!nextProps.list.isGrouped;
         const currentIsGrouped = !!this.props.list.isGrouped;
+        const isGroupingChanged = nextIsGrouped !== currentIsGrouped;
 
-        if (nextIsGrouped !== currentIsGrouped && this.isMapLoaded() && nextIsGrouped) {
+        // Clear all data when switching to grouped view
+        if (isGroupingChanged && nextIsGrouped) {
             this._clearRenderingData();
-        } else if (((currentIsGrouped && !nextIsGrouped) || (!currentIsGrouped && !nextIsGrouped)) && this.isMapLoaded()) {
+            return;
+        }
+
+        // Re-render when not in grouped view (staying ungrouped or switching from grouped)
+        if (!nextIsGrouped) {
             this.debounceRenderGeolocationData();
         }
     }
@@ -1094,6 +1113,13 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
         return result;
     }
 
+    /**
+     * Toggles the expansion/collapse state of a group in the sidebar.
+     * Sets a flag to indicate this is a sidebar-initiated action.
+     *
+     * @param {Object} group - The group object to toggle
+     * @returns {Promise<void>}
+     */
     async toggleGroup(group) {
         this._isSidebarAction = true;
         await group.toggle();
@@ -1531,6 +1557,13 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
     }
 
 
+    /**
+     * Deletes all map features associated with the given group records.
+     * Removes features from all data structures and updates the map visualization.
+     *
+     * @param {Array<Object>} groupRecords - Array of record objects to delete from the map
+     * @returns {Promise<void>}
+     */
     async deleteGroupRecords(groupRecords) {
         if (!this.isMapLoaded() || !Array.isArray(groupRecords)) return;
         this.markerInfoWindow?.close();

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
@@ -211,8 +211,6 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
             ...this.state,
             // Sidebar state
             sidebarIsFolded: false,
-            // Data management
-            groupDatalistId: null,
         });
 
         this.controlPanelHeight = null;
@@ -261,38 +259,20 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
             }
         });
 
-        // Performance-optimized effects
-        useEffect(
-            () => {
-                if (this.state.groupDatalistId && !this._isSidebarAction && this.deckglOverlay && this.isMapLoaded()) {
-                    this.debounceRenderGeolocationData();
-                }
-                this._isSidebarAction = false;
-            },
-            () => [this.state.groupDatalistId]
-        );
-
         useEffect(() => {
-            if (!this.state.groupDatalistId && !this._isSidebarAction && this.deckglOverlay && this.isMapLoaded()) {
-                if (this.isListGrouped) {
-                    this.state.groupDatalistId = generateUUID();
-                } else {
-                    this.debounceRenderGeolocationData();
-                }
+            if (this.isMapLoaded() && !this._isSidebarAction && this.deckglOverlay) {
+                this.debounceRenderGeolocationData();
                 this._isSidebarAction = false;
             }
-        });
+        }, () => [this.state.isMapReady]);
 
-        onWillUpdateProps(() => {
-            this.state.groupDatalistId = generateUUID();
+        onWillUpdateProps((nextProps) => {
+            this.onWillUpdatePropsRenderMarkers(nextProps);
         });
 
         onPatched(() => {
             if (this._isSidebarAction) {
                 this._isSidebarAction = false;
-            }
-            if (this.state.groupDatalistId && !this.isListGrouped) {
-                this.state.groupDatalistId = null;
             }
         });
 
@@ -304,6 +284,17 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
             useBus(this.uiService.bus, 'google-map-center-map', this.centerMap);
         }
 
+    }
+
+    onWillUpdatePropsRenderMarkers(nextProps) {
+        const nextIsGrouped = !!nextProps.list.isGrouped;
+        const currentIsGrouped = !!this.props.list.isGrouped;
+
+        if (nextIsGrouped !== currentIsGrouped && this.isMapLoaded() && nextIsGrouped) {
+            this._clearRenderingData();
+        } else if (((currentIsGrouped && !nextIsGrouped) || (!currentIsGrouped && !nextIsGrouped)) && this.isMapLoaded()) {
+            this.debounceRenderGeolocationData();
+        }
     }
 
     /**
@@ -420,11 +411,11 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
      * Process a batch of features asynchronously
      * @private
      */
-    _processBatchAsync(batch) {
+    _processBatchAsync(batch, color) {
         return new Promise((resolve) => {
             const processBatch = () => {
                 batch.forEach(({ record }) => {
-                    this._processRecordGeoJSON(record);
+                    this._processRecordGeoJSON(record, color);
                 });
                 resolve();
             };
@@ -444,9 +435,8 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
     async _renderGroupedShapesOptimized(datas) {
         const promises = datas.map(async ({ group }) => {
             try {
-                const records = await group.groupRecords();
-                const batch = records.map(record => ({ record }));
-                await this._processBatchAsync(batch);
+                const batch = group.records.map(record => ({ record }));
+                await this._processBatchAsync(batch, group.groupColor);
             } catch (error) {
                 console.error('Failed to load group records:', error);
             }
@@ -456,10 +446,23 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
     }
 
     /**
+     * Render grouped records and fit bounds
+     * @param {Array} datas 
+     */
+    async _renderGroupedRecordsFitBounds(datas) {
+        // Render grouped shapes
+        await this._renderGroupedShapesOptimized(datas);
+        // Update Deck.gl layers
+        this._updateDeckGLLayers();
+        // Fit bounds when ready
+        this._fitBoundsWhenReady();
+    }
+
+    /**
      * Process individual record GeoJSON with optimizations
      * @private
      */
-    _processRecordGeoJSON(record) {
+    _processRecordGeoJSON(record, color) {
         try {
             const geoJson = record.data[this.props.viewAttrs.geoJsonField];
             if (!geoJson?.features?.length) return;
@@ -476,7 +479,8 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
                     feature,
                     recordValues,
                     dataView,
-                    featureId
+                    featureId,
+                    color
                 );
                 this.geoJsonData.set(processedFeature.id, processedFeature);
                 this._indexFeature(processedFeature);
@@ -495,11 +499,11 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
      * Create optimized feature object
      * @private
      */
-    _createOptimizedFeature(feature, recordData, dataView, featureId) {
+    _createOptimizedFeature(feature, recordData, dataView, featureId, featureColor) {
         // Get object from pool or create new one
         const optimizedFeature = this._createEmptyFeatureObject();
 
-        const color = dataView?.other?.__geoColor || generateColor();
+        const color = featureColor || dataView?.other?.__geoColor || generateColor();
 
         optimizedFeature.id = featureId;
         optimizedFeature.type = feature.type;
@@ -1090,6 +1094,11 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
         return result;
     }
 
+    async toggleGroup(group) {
+        this._isSidebarAction = true;
+        await group.toggle();
+    }
+
     /**
      * @override
      * Initialize map with Deck.gl overlay
@@ -1272,11 +1281,12 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
             title: this.props.archInfo.sidebarTitleField,
             subTitle: this.props.archInfo.sidebarSubtitleField,
             getGroupsOrRecords: this.getGroupsOrRecords.bind(this),
+            toggleGroup: this.toggleGroup.bind(this),
+            renderGroupedRecordsFitBounds: this._renderGroupedRecordsFitBounds.bind(this),
             openRecord: this.props.openRecord.bind(this),
-            createShape: this._processRecordGeoJSON.bind(this),
             showRecordsByDomain: this.props.showRecordsByDomain.bind(this),
             pointInMap: this.pointInMap.bind(this),
-            centerMapByGroup: this.centerMapByGroup.bind(this),
+            deleteGroupRecords: this.deleteGroupRecords.bind(this),
             handleToggleRecordSelection: this.toggleRecordSelection.bind(this),
             handleToggleSelection: this.toggleSelectionAll.bind(this),
             handleCanSelectRecord: this.canSelectRecord,
@@ -1384,7 +1394,7 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
     }
 
     get isListGrouped() {
-        return this.props.list?.isGrouped || this.props.groups?.length > 0;
+        return !!this.props.list.isGrouped;
     }
 
     /**
@@ -1519,6 +1529,43 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
             this.googleMap.fitBounds(this.latLngBounds);
         }
     }
+
+
+    async deleteGroupRecords(groupRecords) {
+        if (!this.isMapLoaded() || !Array.isArray(groupRecords)) return;
+        this.markerInfoWindow?.close();
+
+        const deletedFeatureIds = new Set();
+
+        groupRecords.forEach((record) => {
+            const _id = record.id.toString() + '-';
+            this.geoJsonData.forEach((feature) => {
+                if (feature.id.startsWith(_id)) {
+                    deletedFeatureIds.add(feature.id);
+                }
+            });
+        });
+
+        // Delete features from all data structures
+        deletedFeatureIds.forEach(featureId => {
+            this.geoJsonData.delete(featureId);
+            this.selectedFeatureIds.delete(featureId);
+            this.visibleFeatures.delete(featureId);
+        });
+
+        // Clean up feature index
+        this.featureIndex.forEach((featureSet) => {
+            deletedFeatureIds.forEach(featureId => {
+                featureSet.delete(featureId);
+            });
+        });
+
+        // Update the visual layers to reflect the deletion
+        this._updateDeckGLLayers();
+
+        this._fitBoundsWhenReady();
+    }
+
 
     /**
      * Cleanup resources

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.js
@@ -1,41 +1,7 @@
 import { _t } from '@web/core/l10n/translation';
 import { GoogleMapSidebar } from '@web_view_google_map/views/google_map/google_map_sidebar';
 
-const sidebarProps = { ...GoogleMapSidebar.props };
-delete sidebarProps.createMarker;
-
 export class GoogleMapsDrawingSidebar extends GoogleMapSidebar {
-    static props = {
-        ...sidebarProps,
-        createShape: Function,
-    };
     static recordItemTemplate = 'web_view_google_map_drawing.RecordItem';
     static groupItemTemplate = 'web_view_google_map_drawing.GroupItem';
-
-    async handleGroupCollapse(ev, groupKey) {
-        const group = this.datas.find((data) => data.key === groupKey);
-        if (!group) return;
-
-        const currentGroupRecords = group.group.records.length;
-        let records = [];
-
-        if (!currentGroupRecords) {
-            records = await group.group.groupRecords();
-        } else {
-            records = group.group.records;
-        }
-        if (currentGroupRecords === 0) {
-            records.forEach((record) => {
-                this.props.createShape(record, group.group.markerColor);
-            });
-            this.props.centerMapByGroup(records);
-        } else {
-            if (!ev.currentTarget.classList.contains('collapsed')) {
-                records.forEach((record) => {
-                    this.props.createShape(record, group.group.markerColor);
-                });
-                this.props.centerMapByGroup(records);
-            }
-        }
-    }
 }


### PR DESCRIPTION
Major improvements to how grouped data is displayed and managed in Google Maps views:

Core improvements (web_view_google_map):
- Refactored group data rendering to show/hide markers when groups are collapsed/expanded
- Removed redundant groupDatalistId state management and simplified useEffect hooks
- Added toggleGroup() and deleteGroupRecords() methods for better group control
- Improved marker cleanup when toggling groups to prevent memory leaks
- Enhanced onWillUpdatePropsRenderMarkers() to handle group state changes efficiently
- Markers now properly added/removed from map when expanding/collapsing groups

Drawing view improvements (web_view_google_map_drawing):
- Applied same rendering optimizations for GeoJSON shapes
- Improved color handling - now passes group colors to features
- Enhanced deleteGroupRecords() to properly clean up feature index and data structures
- Simplified sidebar component by consolidating group handling logic
- Better memory management when processing grouped shapes

Performance enhancements:
- Reduced unnecessary re-renders when toggling groups
- Improved bounds fitting when rendering grouped data
- Optimized marker/shape visibility updates

Versions:
- web_view_google_map: 19.0.1.0.2 -> 19.0.1.0.3
- web_view_google_map_drawing: 19.0.1.0.1 -> 19.0.1.0.2