### PR TITLE
[IMP] base_google_map: Export constants and fix loader state initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 
 | Module | Version | Description |
 |--------|---------|-------------|
-| [base_google_map](/base_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps contains settings to setup Google API Key |
+| [base_google_map](/base_google_map/README.md) | 19.0.1.0.3 | Base module of Google Maps contains settings to setup Google API Key |
 | [contacts_google_autocomplete](/contacts_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete on Contacts |
 | [contacts_google_map](/contacts_google_map/README.md) | 19.0.1.0.3 | Implementation of view "Google Maps" on Contacts |
 | [crm_google_autocomplete](/crm_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete on CRM Leads/Opportunities |

--- a/base_google_map/CHANGELOG.md
+++ b/base_google_map/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 19.0.1.0.3
+### Improved
+- **Exported Constants**: Made validation and configuration constants available for import in other modules (MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL, VALID_LAT_RANGE, VALID_LNG_RANGE, RESIZE_DEBOUNCE_DELAY, MAP_LOAD_TIMEOUT)
+- **Exported Accessibility Labels**: Made A11Y_LABELS constant exportable for consistency across components
+
+### Fixed
+- **Loader State Initialization**: Changed initial loader status from `INITIALIZING` to `NOT_LOADED` for more accurate state representation
+- **State Update Bug**: Added missing `loaderStatus` parameter to `updateLoaderState()` method call
+
+### Technical Details
+- Removed commented-out API loader code for cleaner codebase
+- Constants can now be imported and reused across different map components
+
 ## 19.0.1.0.2
 ### Improved
 - **Map Initialization State**: Enhanced `isMapLoaded()` to include `isMapReady` state check for more reliable map readiness detection

--- a/base_google_map/__manifest__.py
+++ b/base_google_map/__manifest__.py
@@ -13,7 +13,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.2',
+    'version': '1.0.3',
     'depends': ['web', 'base_geolocalize'],
     'data': [
         'data/google_map.xml',

--- a/base_google_map/static/src/utils/base_google_map.js
+++ b/base_google_map/static/src/utils/base_google_map.js
@@ -4,15 +4,15 @@ import { useService } from '@web/core/utils/hooks';
 import { LOADER_STATUS, LOADER_ERROR_TYPES, useGoogleMapsAPILoader } from './loader_google_map';
 
 // Constants for validation and configuration
-const MAX_ZOOM_LEVEL = 23;
-const MIN_ZOOM_LEVEL = 1;
-const VALID_LAT_RANGE = [-90, 90];
-const VALID_LNG_RANGE = [-180, 180];
-const RESIZE_DEBOUNCE_DELAY = 250;
-const MAP_LOAD_TIMEOUT = 30000;
+export const MAX_ZOOM_LEVEL = 23;
+export const MIN_ZOOM_LEVEL = 1;
+export const VALID_LAT_RANGE = [-90, 90];
+export const VALID_LNG_RANGE = [-180, 180];
+export const RESIZE_DEBOUNCE_DELAY = 250;
+export const MAP_LOAD_TIMEOUT = 30000;
 
 // Accessibility constants
-const A11Y_LABELS = {
+export const A11Y_LABELS = {
     MAP_CONTAINER: 'Interactive map',
     LOADING: 'Map is loading',
     ERROR: 'Map failed to load',
@@ -33,11 +33,7 @@ export class BaseGoogleMapComponent extends Component {
         this.notificationService = useService('notification');
         this.uiService = useService('ui');
 
-        // API Loader
-        // this.apiLoader = useGoogleMapsAPILoader(
-        //     (...args) => this.onGoogleMapsApiLoad(...args),
-        //     (...args) => this.onGoogleMapsApiError(...args)
-        // );
+        // Google Maps API Loader
         this.apiLoader = useGoogleMapsAPILoader(
             (...args) => this.handleOnApiLoaderSuccess(...args),
             (...args) => this.handleOnApiLoaderError(...args),
@@ -57,7 +53,7 @@ export class BaseGoogleMapComponent extends Component {
         // Map State
         this.state = useState({
             isMapReady: null,
-            loaderStatus: LOADER_STATUS.INITIALIZING,
+            loaderStatus: LOADER_STATUS.NOT_LOADED,
             isLoading: null,
             isOffline: null,
         });
@@ -193,7 +189,7 @@ export class BaseGoogleMapComponent extends Component {
             // Trigger map ready callback
             await this.onMapReady(googleMap);
             // Update loader state
-            this.updateLoaderState();
+            this.updateLoaderState(this.state.loaderStatus);
         } catch (error) {
             this.onGoogleMapsApiError(error);
         }


### PR DESCRIPTION
- Export validation and configuration constants for reuse in other modules
- Export accessibility labels for consistency across components
- Initialize loader status as NOT_LOADED instead of INITIALIZING
- Pass loader status parameter to updateLoaderState method
- Clean up commented code and improve code clarity