### PR TITLE
[IMP] web_view_google_map_drawing: Update Terra Draw dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.4 | Implementation of view "Google Maps" on CRM |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.7 | Base module for a new view "google_map" |
-| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.5 | Base module for sub view of "google_map" for drawing capability |
+| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.6 | Base module for sub view of "google_map" for drawing capability |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps widget |

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 19.0.1.0.6
+### Updated Dependencies
+- **Terra Draw**: Updated from 1.19.0 to 1.21.4
+- **Terra Draw Google Maps Adapter**: Updated from 1.1.0 to 1.2.1
+
 ## 19.0.1.0.5
 ### Improved
 - **Domain Filtering**: Fixed empty GeoJSON filtering to use 'json_ne' with AND logic, properly excluding null and empty FeatureCollections

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.5',
+    'version': '1.0.6',
     'depends': ['web_view_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map_drawing/static/src/utils/utils.js
+++ b/web_view_google_map_drawing/static/src/utils/utils.js
@@ -98,8 +98,8 @@ export async function loadTerraDrawAssets() {
         return;
     }
     try {
-        await loadJS('https://unpkg.com/terra-draw@1.19.0/dist/terra-draw.umd.js');
-        await loadJS('https://unpkg.com/terra-draw-google-maps-adapter@1.1.0/dist/terra-draw-google-maps-adapter.umd.js');
+        await loadJS('https://unpkg.com/terra-draw@1.21.4/dist/terra-draw.umd.js');
+        await loadJS('https://unpkg.com/terra-draw-google-maps-adapter@1.2.1/dist/terra-draw-google-maps-adapter.umd.js');
         if (!window.terraDraw || !window.terraDrawGoogleMapsAdapter) {
             throw new Error('Terra Draw or its Google Maps adapter failed to load correctly.');
         }


### PR DESCRIPTION
Update Terra Draw library from 1.19.0 to 1.21.4 and Terra Draw Google Maps adapter from 1.1.0 to 1.2.1 to benefit from latest bug fixes and improvements.