### PR TITLE
[IMP] web_view_google_map_drawing: Add GeoJSON export and improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.4 | Implementation of view "Google Maps" on CRM |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.8 | Base module for a new view "google_map" |
-| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.7 | Base module for sub view of "google_map" for drawing capability |
+| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.8 | Base module for sub view of "google_map" for drawing capability |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps widget |

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Change Log
 
+## 19.0.1.0.8
+### Added
+- **GeoJSON Export**: Added export functionality to both Terra Draw and Deck.gl editors
+  - Download current features as a `.geojson` file with timestamp-based filename
+  - Automatic removal of internal properties (mode, midPoint, selectionPoint, _metadata) from export
+  - Filter out system features (midpoints, selection points) from Terra Draw exports
+- **Deck.gl Import/Export Toolbar**: Added import and export buttons to DeckGlEditor component
+  - Upload button for importing GeoJSON files
+  - Download button (disabled when no data available)
+  - Styled toolbar matching Terra Draw UI
+- **3D Coordinate Detection**: Automatic detection and handling of 3D coordinates (with altitude)
+  - Features with altitude values are automatically rendered using Deck.gl
+  - Added `_hasAltitude()` helper method for recursive coordinate checking
+
+### Improved
+- **Area Calculation**: Simplified `calculateArea()` function
+  - Now passes GeoJSON Feature directly to `turf.area()` instead of creating intermediate geometry
+  - Proper support for both Polygon and MultiPolygon geometry types
+  - Added robust validation for `calculateFeaturesTotalArea()`
+- **GeoJSON Change Detection**: Replaced expensive `JSON.stringify` comparison with lightweight fingerprinting
+  - New `_hasGeoJsonChanged()` method using reference equality and fingerprint comparison
+  - New `_getGeoJsonFingerprint()` method capturing geometry type, ID, and coordinate count
+  - New `_countCoordinates()` helper for recursive coordinate counting
+  - Significantly faster for large GeoJSON datasets
+- **Point Layer Rendering**: Simplified `_createPointLayer()` in DeckGlEditor
+  - Removed custom icon atlas implementation
+  - Now uses ScatterplotLayer exclusively for point features
+
+### Removed
+- Removed 17 unused functions from `utils.js` (reduced from ~1067 to ~537 lines):
+  - `generateUUID`, `formatNumber`, `hasPolygonsWithHoles`, `hexToRgba`
+  - `stripAltitude`, `stripAltitudeFromFeature`, `stripAltitudeFromGeometry`
+  - `debounce`, `AREA_THRESHOLDS`, `LENGTH_THRESHOLDS`
+  - `formatDistance`, `formatDistanceMeasurement`, `generateTooltipHtml`
+  - `GEOMETRY_COLORS`, `createFeatureCollection`, `extractPointsFromGeometry`
+  - `getMeasurementForGeometry`
+- Removed `createIconAtlas()` function and `ICON_MAPPING` constant from DeckGlEditor
+- Removed `window.DEBUG_DECKGL` debugging flag
+
+### Technical Details
+- Added `_cleanPropertiesForExport()` method to both TerraDrawToolsUI and DeckGlEditor
+- DeckGlEditor now imports `UploadGeoJsonFileDialog` component
+- Added `hasDataToExport` computed property to DeckGlEditor
+- Updated README.md with new Import/Export, Rendering Modes, and Performance Optimizations sections
+
 ## 19.0.1.0.7
 ### Added
 - **GeoJSON File Import**: New upload dialog for importing GeoJSON files directly into Terra Draw

--- a/web_view_google_map_drawing/README.md
+++ b/web_view_google_map_drawing/README.md
@@ -12,10 +12,12 @@ The Google Maps Drawing has been deprecated ([source](https://developers.google.
 - **Drawing Tools**: Point, LineString, Polygon, Rectangle, Circle, and Freehand drawing modes
 - **GPU-Accelerated Rendering**: Deck.gl provides smooth 60fps rendering for 10k+ features
 - **Real-time Measurements**: Area, perimeter, length calculations using Turf.js
-- **GeoJSON Import**: Upload GeoJSON files directly into the drawing canvas
+- **GeoJSON Import/Export**: Upload and download GeoJSON files directly from the drawing canvas
 - **Undo/Redo**: Full history management for drawing operations
 - **Feature Simplification**: Reduce complex geometry for better editing performance
 - **Keyboard Shortcuts**: Efficient operation with keyboard controls
+- **3D Coordinate Support**: Automatic detection and rendering of 3D coordinates (with altitude)
+- **Smart Rendering Mode**: Automatically switches between Terra Draw and Deck.gl based on geometry complexity
 
 ## Keyboard Shortcuts
 
@@ -140,11 +142,56 @@ All libraries are bundled locally for reliability and offline capability:
 | [Deck.gl](https://deck.gl/) | GPU-accelerated rendering for large datasets |
 | [Turf.js](https://turfjs.org/) | Geospatial measurements and calculations |
 
+## Area Calculation
+
+The module uses Turf.js for accurate area calculations:
+
+- Supports both **Polygon** and **MultiPolygon** geometry types
+- Area is calculated in square meters
+- Total area is automatically computed when importing GeoJSON or saving features
+- Area values can be stored in a designated field using the `field_area` widget option
+
+## Import/Export GeoJSON
+
+Both Terra Draw and Deck.gl editors support importing and exporting GeoJSON files:
+
+### Import
+- Click the **Upload** button (↑) to import a GeoJSON file
+- Supported formats: `.geojson` and `.json` files
+- Maximum file size: 5MB
+- The imported GeoJSON is validated before being loaded
+
+### Export
+- Click the **Download** button (↓) to export current features as a GeoJSON file
+- The exported file is named `geojson_export_YYYY-MM-DD.geojson`
+- Internal properties (mode, midPoint, selectionPoint, _metadata) are automatically removed from the export
+
+## Rendering Modes
+
+The module automatically selects the appropriate rendering engine based on geometry complexity:
+
+| Condition | Rendering Engine | Reason |
+|-----------|------------------|--------|
+| Simple polygons without holes | Terra Draw | Full editing capabilities |
+| Polygons with holes (interior rings) | Deck.gl | Terra Draw doesn't support holes |
+| 3D coordinates (with altitude) | Deck.gl | Terra Draw doesn't support 3D |
+| Very complex features | Deck.gl | Better performance for large datasets |
+
 ## Known issues and limitations
 - Terra Draw doesn't support GeoJSON with holes or interior rings. Such GeoJSON will be rendered in read-only mode using Deck.gl.
+- Terra Draw doesn't support 3D coordinates (coordinates with altitude values). Such GeoJSON will be rendered using Deck.gl.
 - Editing very large GeoJSON data may lead to performance issues. Use the "Simplify Selected Feature" button in the drawing toolbar to reduce complexity, but be aware that this may result in a loss of detail.
 - Resize the browser window may cause the map to not render properly. To fix this issue, you can refresh the browser page.
 - GeoJSON file import is limited to 5MB file size.
+
+## Performance Optimizations
+
+The module includes several performance optimizations for handling large GeoJSON datasets:
+
+- **Chunked Processing**: Large feature sets are processed in chunks of 50 features to prevent UI blocking
+- **Lightweight Change Detection**: Uses fingerprinting (geometry type + coordinate count) instead of full JSON comparison
+- **Debounced Rendering**: Rendering operations are debounced to prevent excessive re-renders
+- **GPU Acceleration**: Deck.gl leverages WebGL for smooth rendering of 10,000+ features
 
 ## Authors
 - [Yopi Angi](https://www.github.com/gityopie)

--- a/web_view_google_map_drawing/README.md
+++ b/web_view_google_map_drawing/README.md
@@ -166,6 +166,8 @@ Both Terra Draw and Deck.gl editors support importing and exporting GeoJSON file
 - The exported file is named `geojson_export_YYYY-MM-DD.geojson`
 - Internal properties (mode, midPoint, selectionPoint, _metadata) are automatically removed from the export
 
+This functionality allows easy data exchange with other GIS tools and platforms.
+
 ## Rendering Modes
 
 The module automatically selects the appropriate rendering engine based on geometry complexity:

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.7',
+    'version': '1.0.8',
     'depends': ['web_view_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map_drawing/static/src/utils/map_config.js
+++ b/web_view_google_map_drawing/static/src/utils/map_config.js
@@ -1,61 +1,38 @@
 
-const COLORS = {
-    DISPLAY: '#006ee5',
-    EDIT: '#ffa187',
-    STROKE: '#fc6c44',
+
+/**
+ * Deck.gl configuration constants
+ */
+export const DECKGL_CONFIG = {
+    // Visual styling
+    DEFAULT_COLORS: {
+        FILL: [70, 130, 180, 80], // Steel blue with 80% opacity
+        STROKE: [25, 25, 112, 255], // Midnight blue
+        SELECTED_FILL: [0, 123, 255, 120], // Bright blue with transparency
+        SELECTED_STROKE: [0, 86, 179, 255], // Deep blue
+        HOVERED_FILL: [255, 165, 0, 120], // Gold with transparency
+        HOVERED_STROKE: [255, 140, 0, 255], // Dark orange
+    },
 };
 
-export const MapConfig = {
-    DRAWING_MODES: [
-        'circle',
-        'polygon',
-        'rectangle',
-    ],
+/** 
+ * Stroke configuration constants
+ */
+export const STROKE_CONFIG = { 
+    DEFAULT_WIDTH: 2, // Default stroke width in pixels
+    HOVER_WIDTH: 4,   // Stroke width on hover in pixels
+};
 
-    COLORS: COLORS,
-
-    DEFAULT_SHAPE_OPTIONS: {
-        polygonOptions: {
-            strokeWeight: 2.0,
-            fillOpacity: 0.35,
-            editable: false,
-            strokeColor: COLORS.DISPLAY,
-            fillColor: COLORS.DISPLAY,
-        },
-        circleOptions: {
-            strokeWeight: 2.0,
-            fillOpacity: 0.35,
-            editable: false,
-            strokeColor: COLORS.DISPLAY,
-            fillColor: COLORS.DISPLAY,
-        },
-        rectangleOptions: {
-            strokeWeight: 2.0,
-            fillOpacity: 0.35,
-            editable: false,
-            strokeColor: COLORS.DISPLAY,
-            fillColor: COLORS.DISPLAY,
-        },
-    },
-
-    SHAPE_EDITING_OPTIONS: {
-        strokeColor: '#ffa187',
-        fillColor: '#ffa187',
-        strokeWeight: 2.0,
-        fillOpacity: 0.45,
-        editable: true
-    },
-
-    DEBOUNCE_DELAY: 500,
-
-    MAP_OPTIONS: {
-        mapTypeId: 'satellite',
-        center: { lat: 0, lng: 0 },
-        zoom: 4,
-        minZoom: 2,
-        maxZoom: 22,
-        fullscreenControl: true,
-        mapTypeControl: true,
-        gestureHandling: 'cooperative',
-    },
+/**
+ * Google Maps configuration constants
+ */
+export const MAP_OPTIONS = {
+    mapTypeId: 'satellite',
+    center: { lat: 0, lng: 0 },
+    zoom: 4,
+    minZoom: 2,
+    maxZoom: 22,
+    fullscreenControl: true,
+    mapTypeControl: true,
+    gestureHandling: 'cooperative',
 };

--- a/web_view_google_map_drawing/static/src/utils/utils.js
+++ b/web_view_google_map_drawing/static/src/utils/utils.js
@@ -67,7 +67,9 @@ export async function loadTerraDrawAssets() {
     }
     try {
         await loadJS('/web_view_google_map_drawing/static/lib/terra-draw/terra-draw.umd.js');
-        await loadJS('/web_view_google_map_drawing/static/lib/terra-draw/terra-draw-google-maps-adapter.umd.js');
+        await loadJS(
+            '/web_view_google_map_drawing/static/lib/terra-draw/terra-draw-google-maps-adapter.umd.js'
+        );
         if (!window.terraDraw || !window.terraDrawGoogleMapsAdapter) {
             throw new Error('Terra Draw or its Google Maps adapter failed to load correctly.');
         }
@@ -156,10 +158,7 @@ export function formatAreaMeasurement(
     unitSystem = MEASUREMENT_CONFIG.UNITS.METRIC
 ) {
     if (isNaN(parseFloat(areaInSquareMeter)) || !isFinite(areaInSquareMeter)) {
-        console.warn(
-            'Invalid area provided for formatting:',
-            areaInSquareMeter
-        );
+        console.warn('Invalid area provided for formatting:', areaInSquareMeter);
         return areaInSquareMeter;
     }
 
@@ -218,14 +217,8 @@ export function formatLengthMeasurement(
     decimals = 2,
     unitSystem = MEASUREMENT_CONFIG.UNITS.METRIC
 ) {
-    if (
-        isNaN(parseFloat(lengthInKilometers)) ||
-        !isFinite(lengthInKilometers)
-    ) {
-        console.warn(
-            'Invalid length provided for formatting:',
-            lengthInKilometers
-        );
+    if (isNaN(parseFloat(lengthInKilometers)) || !isFinite(lengthInKilometers)) {
+        console.warn('Invalid length provided for formatting:', lengthInKilometers);
         return lengthInKilometers;
     }
 
@@ -279,7 +272,6 @@ export function formatLengthMeasurement(
     return `${value} ${unit}`;
 }
 
-
 /**
  * Validate geometry coordinates based on geometry type
  * @param {string} type - Geometry type
@@ -295,31 +287,38 @@ function validateGeometryCoordinates(type, coordinates) {
     switch (type) {
         case 'Point':
             // Point: [lon, lat] or [lon, lat, elevation]
-            return coordinates.length >= 2 &&
-                   coordinates.length <= 3 &&
-                   coordinates.every(n => typeof n === 'number' && isFinite(n));
+            return (
+                coordinates.length >= 2 &&
+                coordinates.length <= 3 &&
+                coordinates.every((n) => typeof n === 'number' && isFinite(n))
+            );
 
         case 'LineString':
         case 'MultiPoint':
             // LineString/MultiPoint: array of positions (at least 2 for LineString)
             const minLength = type === 'LineString' ? 2 : 1;
-            return coordinates.length >= minLength &&
-                   coordinates.every(pos =>
-                       Array.isArray(pos) &&
-                       pos.length >= 2 &&
-                       pos.every(n => typeof n === 'number' && isFinite(n))
-                   );
+            return (
+                coordinates.length >= minLength &&
+                coordinates.every(
+                    (pos) =>
+                        Array.isArray(pos) &&
+                        pos.length >= 2 &&
+                        pos.every((n) => typeof n === 'number' && isFinite(n))
+                )
+            );
 
         case 'Polygon':
         case 'MultiLineString':
             // Polygon/MultiLineString: array of LineString coordinates
-            return coordinates.every(ring => {
-                const isValid = Array.isArray(ring) &&
+            return coordinates.every((ring) => {
+                const isValid =
+                    Array.isArray(ring) &&
                     ring.length >= (type === 'Polygon' ? 4 : 2) &&
-                    ring.every(pos =>
-                        Array.isArray(pos) &&
-                        pos.length >= 2 &&
-                        pos.every(n => typeof n === 'number' && isFinite(n))
+                    ring.every(
+                        (pos) =>
+                            Array.isArray(pos) &&
+                            pos.length >= 2 &&
+                            pos.every((n) => typeof n === 'number' && isFinite(n))
                     );
 
                 // For Polygon, verify ring closure (first point === last point)
@@ -334,17 +333,20 @@ function validateGeometryCoordinates(type, coordinates) {
 
         case 'MultiPolygon':
             // MultiPolygon: array of Polygon coordinates
-            return coordinates.every(polygon =>
-                Array.isArray(polygon) &&
-                polygon.every(ring =>
-                    Array.isArray(ring) &&
-                    ring.length >= 4 &&
-                    ring.every(pos =>
-                        Array.isArray(pos) &&
-                        pos.length >= 2 &&
-                        pos.every(n => typeof n === 'number' && isFinite(n))
+            return coordinates.every(
+                (polygon) =>
+                    Array.isArray(polygon) &&
+                    polygon.every(
+                        (ring) =>
+                            Array.isArray(ring) &&
+                            ring.length >= 4 &&
+                            ring.every(
+                                (pos) =>
+                                    Array.isArray(pos) &&
+                                    pos.length >= 2 &&
+                                    pos.every((n) => typeof n === 'number' && isFinite(n))
+                            )
                     )
-                )
             );
 
         default:
@@ -363,11 +365,7 @@ function validateGeometryCoordinates(type, coordinates) {
  * @returns {boolean} True if valid GeoJSON structure
  */
 export function validateGeoJson(geoJson, options = {}) {
-    const {
-        requireFeatures = false,
-        validateGeometry = false,
-        strict = false
-    } = options;
+    const { requireFeatures = false, validateGeometry = false, strict = false } = options;
 
     // Null/undefined check
     if (!geoJson || typeof geoJson !== 'object') {
@@ -384,7 +382,7 @@ export function validateGeoJson(geoJson, options = {}) {
         'MultiPoint',
         'MultiLineString',
         'MultiPolygon',
-        'GeometryCollection'
+        'GeometryCollection',
     ];
 
     // Check if type is valid
@@ -405,7 +403,7 @@ export function validateGeoJson(geoJson, options = {}) {
 
         // Optional: validate each feature
         if (validateGeometry && geoJson.features.length > 0) {
-            return geoJson.features.every(feature =>
+            return geoJson.features.every((feature) =>
                 validateGeoJson(feature, { validateGeometry: true, strict })
             );
         }
@@ -442,7 +440,7 @@ export function validateGeoJson(geoJson, options = {}) {
             }
 
             if (validateGeometry) {
-                return geoJson.geometries.every(geom =>
+                return geoJson.geometries.every((geom) =>
                     validateGeoJson(geom, { validateGeometry: true, strict })
                 );
             }
@@ -521,4 +519,85 @@ export function calculateFeaturesTotalArea(features) {
 
         return totalArea;
     }, 0); // in square meters
+}
+
+/**
+ * Generate a lightweight fingerprint for a features array
+ * Captures geometry types, IDs, and coordinate counts without full serialization
+ * @param {Array} features - Array of GeoJSON features
+ * @returns {string} Fingerprint string
+ */
+function getGeoJsonFingerprint(features) {
+    let fingerprint = '';
+    for (let i = 0; i < features.length; i++) {
+        const feature = features[i];
+        const id = feature.id || feature.properties?.id || i;
+        const geomType = feature.geometry?.type || 'null';
+        const coordCount = countCoordinates(feature.geometry?.coordinates);
+        fingerprint += `${id}:${geomType}:${coordCount};`;
+    }
+    return fingerprint;
+}
+
+/**
+ * Count total coordinates in a geometry
+ * @param {Array} coordinates - GeoJSON coordinates array
+ * @returns {number} Total coordinate count
+ */
+function countCoordinates(coordinates) {
+    if (!coordinates) return 0;
+    if (typeof coordinates[0] === 'number') {
+        // Single coordinate [lng, lat] or [lng, lat, alt]
+        return 1;
+    }
+    let count = 0;
+    for (const coord of coordinates) {
+        count += countCoordinates(coord);
+    }
+    return count;
+}
+
+/**
+ * Check if GeoJSON data has changed using lightweight comparison
+ * Avoids expensive JSON.stringify for large datasets
+ * @param {Object} current - Current GeoJSON data
+ * @param {Object} next - Next GeoJSON data
+ * @returns {boolean} True if data has changed
+ */
+export function hasGeoJsonChanged(current, next) {
+    // Reference equality - fastest check
+    if (current === next) {
+        return false;
+    }
+
+    // Handle null/undefined cases
+    if (!current || !next) {
+        return current !== next;
+    }
+
+    // Check features array reference
+    if (current.features === next.features) {
+        return false;
+    }
+
+    // Handle missing features
+    if (!current.features || !next.features) {
+        return true;
+    }
+
+    // Quick count check
+    if (current.features.length !== next.features.length) {
+        return true;
+    }
+
+    // Empty arrays are equal
+    if (current.features.length === 0) {
+        return false;
+    }
+
+    // Compare feature fingerprints (geometry type + coordinate structure)
+    const currentFingerprint = getGeoJsonFingerprint(current.features);
+    const nextFingerprint = getGeoJsonFingerprint(next.features);
+
+    return currentFingerprint !== nextFingerprint;
 }

--- a/web_view_google_map_drawing/static/src/utils/utils.js
+++ b/web_view_google_map_drawing/static/src/utils/utils.js
@@ -6,50 +6,18 @@
  * and the readonly Terra Draw renderer.
  *
  * Key Features:
- * - Feature validation and proces        default:
-            return {
-                fillColor: color,
-                fillOpacity: TERRA_DRAW_DEFAULT_CONFIG.defaultFillOpacity,
-                outlineColor: color,
-                outlineWidth: TERRA_DRAW_DEFAULT_CONFIG.defaultOutlineWidth,
-            }; - UUID generation compatible with Terra Draw
+ * - Asset loading for Terra Draw, Deck.gl, and Turf.js
+ * - GeoJSON validation
  * - Coordinate normalization
- * - MultiPolygon processing and splitting
- * - Feature structure creation and validation
- * - Terra Draw compatibility utilities
+ * - Area calculation using Turf.js
+ * - Measurement formatting
  *
  * @author Yan - https://github.com/yan
  * @version 1.0.0
- * @requires Terra Draw Library
  */
 
 import { loadJS } from '@web/core/assets';
-import { formatNumber, generateUUID } from '@web_view_google_map/views/google_map/utils';
-
-/**
- * Terra Draw mode mapping
- */
-export const TERRA_DRAW_MODE_MAP = {
-    Point: 'point',
-    LineString: 'linestring',
-    Polygon: 'polygon',
-    Circle: 'circle',
-    Rectangle: 'rectangle',
-    MultiPoint: 'point',
-    MultiLineString: 'linestring',
-    MultiPolygon: 'polygon',
-};
-
-/**
- * Default Terra Draw configuration
- */
-export const TERRA_DRAW_DEFAULT_CONFIG = {
-    coordinatePrecision: 10,
-    defaultFillOpacity: 0.3,
-    // Default outline width
-    defaultOutlineWidth: 0.2,
-    uuidVersion: 4,
-};
+import { formatNumber } from '@web_view_google_map/views/google_map/utils';
 
 export const TERRA_DRAW_CONFIG = {
     COORDINATE_PRECISION: 9,
@@ -140,70 +108,9 @@ export async function loadTurfJSAssets() {
 }
 
 /**
- * Validate if a feature meets Terra Draw requirements
- * @param {Object} feature - Feature to validate
- * @returns {boolean} - True if valid
- */
-export function validateTerraDrawFeature(feature) {
-    if (!feature) return false;
-
-    // Check required GeoJSON structure
-    if (!feature.type || feature.type !== 'Feature') {
-        console.error('Missing or invalid type:', feature.type);
-        return false;
-    }
-
-    if (!feature.id || typeof feature.id !== 'string') {
-        console.error('Missing or invalid id:', feature.id);
-        return false;
-    }
-
-    if (!feature.geometry || !feature.geometry.type || !feature.geometry.coordinates) {
-        console.error('Missing or invalid geometry:', feature.geometry);
-        return false;
-    }
-
-    if (!feature.properties || typeof feature.properties !== 'object') {
-        console.error('Missing or invalid properties:', feature.properties);
-        return false;
-    }
-
-    // Check Terra Draw specific requirements
-    if (!feature.properties.mode || typeof feature.properties.mode !== 'string') {
-        console.error('Missing mode property:', feature.properties.mode);
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * Strip altitude (3rd coordinate) from coordinates to convert 3D to 2D
- * Terra Draw only supports 2D coordinates [longitude, latitude]
- * @param {Array} coordinates - Coordinate array (may be nested for polygons/lines)
- * @param {string} geometryType - GeoJSON geometry type
- * @returns {Array} - 2D coordinates
- */
-export function stripAltitude(coordinates, geometryType) {
-    if (!Array.isArray(coordinates)) return coordinates;
-
-    if (geometryType === 'Point') {
-        // Point: [lng, lat, alt?] -> [lng, lat]
-        return coordinates.slice(0, 2);
-    } else if (geometryType === 'LineString') {
-        // LineString: [[lng, lat, alt?], ...] -> [[lng, lat], ...]
-        return coordinates.map((coord) => coord.slice(0, 2));
-    } else if (geometryType === 'Polygon') {
-        // Polygon: [[[lng, lat, alt?], ...], ...] -> [[[lng, lat], ...], ...]
-        return coordinates.map((ring) => ring.map((coord) => coord.slice(0, 2)));
-    }
-    return coordinates;
-}
-
-/**
  * Normalize coordinates to remove excessive precision
  * @param {Array} coordinates - Coordinate array to normalize
- * @param {number} precision - Number of decimal places (default: 10)
+ * @param {number} precision - Number of decimal places (default: 9)
  * @returns {Array} - Normalized coordinates
  */
 export function normalizeCoordinates(coordinates, precision = 9) {
@@ -219,377 +126,9 @@ export function normalizeCoordinates(coordinates, precision = 9) {
     });
 }
 
-/**
- * Process complex MultiPolygon by splitting into individual polygons
- * @param {Object} multiPolygonFeature - Original MultiPolygon feature
- * @param {string} color - Color for the features
- * @param {boolean} isReadonly - Whether features should be readonly
- * @returns {Array} - Array of individual polygon features
- */
-export function processComplexMultiPolygon(multiPolygonFeature, color, isReadonly = false) {
-    const polygonFeatures = [];
-    const coordinates = multiPolygonFeature.geometry.coordinates;
-
-    coordinates.forEach((polygonCoords, index) => {
-        // Create individual polygon feature
-        const polygonFeature = {
-            type: 'Feature',
-            id: generateUUID(), // Generate Terra Draw compatible UUID
-            geometry: {
-                type: 'Polygon',
-                coordinates: normalizeCoordinates(polygonCoords),
-            },
-            properties: {
-                ...multiPolygonFeature.properties,
-                mode: 'polygon',
-                originalFeatureId: multiPolygonFeature.id,
-                partIndex: index,
-                totalParts: coordinates.length,
-            },
-        };
-
-        polygonFeatures.push(polygonFeature);
-    });
-
-    return polygonFeatures;
-}
-
-/**
- * Create Terra Draw compatible feature from GeoJSON feature
- * @param {Object} feature - Original GeoJSON feature
- * @param {string} color - Color for the feature
- * @param {boolean} isReadonly - Whether feature should be readonly
- * @returns {Object} - Terra Draw compatible feature
- */
-export function createTerraDrawFeature(feature, color, isReadonly = false) {
-    const geometry = feature.geometry;
-
-    // Normalize coordinates
-    const normalizedGeometry = {
-        ...geometry,
-        coordinates: normalizeCoordinates(geometry.coordinates),
-    };
-
-    // Generate Terra Draw compatible UUID if no ID exists
-    const featureId = feature.id || generateUUID();
-
-    // Determine Terra Draw mode based on geometry type
-    const modeMap = {
-        Point: 'point',
-        LineString: 'linestring',
-        Polygon: 'polygon',
-        Circle: 'circle',
-        Rectangle: 'rectangle',
-    };
-
-    const mode = modeMap[geometry.type] || 'polygon';
-
-    // Create Terra Draw feature
-    const terraDrawFeature = {
-        type: 'Feature',
-        id: featureId,
-        geometry: normalizedGeometry,
-        properties: {
-            ...feature.properties,
-            mode: mode,
-            // Permissions (readonly or editable)
-            // ...getFeaturePermissions(isReadonly),
-            // Styling based on geometry type
-            // ...getStylePropertiesForGeometry(geometry.type, color),
-        },
-    };
-
-    return terraDrawFeature;
-}
-
-/**
- * Get feature permissions based on readonly status
- * @param {boolean} isReadonly - Whether feature should be readonly
- * @returns {Object} - Permission properties
- */
-export function getFeaturePermissions(isReadonly) {
-    if (isReadonly) {
-        return {
-            editable: false,
-            draggable: false,
-            rotateable: false,
-            scaleable: false,
-            deletable: false,
-            coordinatesDraggable: false,
-            coordinatesDeletable: false,
-            coordinatesAddable: false,
-            midpoints: false,
-        };
-    } else {
-        return {
-            editable: true,
-            draggable: true,
-            rotateable: true,
-            scaleable: true,
-            deletable: true,
-            coordinatesDraggable: true,
-            coordinatesDeletable: true,
-            coordinatesAddable: true,
-            midpoints: true,
-        };
-    }
-}
-
-/**
- * Get style properties for different geometry types
- * @param {string} geometryType - Type of geometry
- * @param {string} color - Color for the feature
- * @returns {Object} - Style properties
- */
-export function getStylePropertiesForGeometry(geometryType, color) {
-    switch (geometryType) {
-        case 'Point':
-            return {
-                pointColor: color,
-                pointOutlineColor: color,
-            };
-
-        case 'LineString':
-        case 'MultiLineString':
-            return {
-                lineColor: color,
-                pointColor: color,
-            };
-
-        case 'Polygon':
-        case 'MultiPolygon':
-        case 'Rectangle':
-        case 'Circle':
-            return {
-                fillColor: color,
-                fillOpacity: TERRA_DRAW_DEFAULT_CONFIG.defaultFillOpacity,
-                outlineColor: color,
-                outlineWidth: TERRA_DRAW_DEFAULT_CONFIG.defaultOutlineWidth,
-            };
-
-        default:
-            return {
-                fillColor: color,
-                fillOpacity: 0.3,
-                outlineColor: color,
-                outlineWidth: TERRA_DRAW_DEFAULT_CONFIG.defaultOutlineWidth,
-            };
-    }
-}
-
-/**
- * Process GeoJSON features with enhanced MultiPolygon handling
- * @param {Object} geoJsonData - GeoJSON data
- * @param {string} color - Color for the features
- * @param {boolean} isReadonly - Whether features should be readonly
- * @returns {Array} - Processed Terra Draw features
- */
-export function processGeoJsonFeatures(geoJsonData, recordId, color, isReadonly = false) {
-    const processedFeatures = [];
-
-    geoJsonData.features.forEach((feature, featureIndex) => {
-        const geometry = feature.geometry;
-        feature.properties = Object.assign(feature.properties || {}, { odoo: recordId });;
-
-        if (geometry.type === 'MultiPolygon') {
-            // Split MultiPolygon into individual polygons
-            const splitPolygons = processComplexMultiPolygon(feature, color, isReadonly);
-            processedFeatures.push(...splitPolygons);
-        } else {
-            // Process single geometry features
-            const processedFeature = createTerraDrawFeature(feature, color, isReadonly);
-            if (processedFeature) {
-                processedFeatures.push(processedFeature);
-            }
-        }
-    });
-
-    return processedFeatures;
-}
-
-/**
- * Add features to Terra Draw with comprehensive debugging
- * @param {Object} terraDrawInstance - Terra Draw instance
- * @param {Array} features - Features to add
- * @param {string} context - Context for debugging (e.g., 'readonly', 'editable')
- * @returns {Promise<boolean>} - Success status
- */
-export async function addFeaturesToTerraDrawWithDebugging(
-    terraDrawInstance,
-    features,
-    context = ''
-) {
-    try {
-        // Validate first feature
-        if (features.length > 0) {
-            const isValid = validateTerraDrawFeature(features[0]);
-            if (!isValid) {
-                console.error(`Invalid feature in context ${context}:`, features[0]);
-                return false;
-            }
-        }
-
-        // Ensure Terra Draw is in select mode for viewing features
-        if (terraDrawInstance.getMode() !== 'select') {
-            terraDrawInstance.setMode('select');
-        }
-        
-        // Add features to Terra Draw
-        terraDrawInstance.addFeatures(features);
-        
-        // Wait for Terra Draw to process the features
-        await new Promise(resolve => setTimeout(resolve, 100));
-        
-        // Verify features were added successfully
-        try {
-            terraDrawInstance.getSnapshot();
-            return true;
-        } catch (error) {
-            console.warn('Failed to get Terra Draw snapshot after adding features:', error);
-            return false;
-        }
-        
-    } catch (error) {
-        console.error(`Error adding features to Terra Draw (${context}):`, error);
-        return false;
-    }
-}
-
 export function getRandomColor() {
     const randomIndex = Math.floor(Math.random() * COLOR_PALETTE.length);
     return COLOR_PALETTE[randomIndex];
-}
-
-/**
- * Calculate the distance between two geographic coordinates using Haversine formula
- * @param {number} lat1 - Latitude of first point
- * @param {number} lon1 - Longitude of first point
- * @param {number} lat2 - Latitude of second point
- * @param {number} lon2 - Longitude of second point
- * @param {string} unit - Unit of measurement ('metric' or 'imperial')
- * @returns {number} Distance in kilometers or miles
- */
-export function calculateDistance(lat1, lon1, lat2, lon2, unit = MEASUREMENT_CONFIG.UNITS.METRIC) {
-    const R =
-        unit === MEASUREMENT_CONFIG.UNITS.IMPERIAL
-            ? MEASUREMENT_CONFIG.EARTH_RADIUS_MILES
-            : MEASUREMENT_CONFIG.EARTH_RADIUS_KM;
-
-    const dLat = ((lat2 - lat1) * Math.PI) / 180;
-    const dLon = ((lon2 - lon1) * Math.PI) / 180;
-    const a =
-        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-        Math.cos((lat1 * Math.PI) / 180) *
-            Math.cos((lat2 * Math.PI) / 180) *
-            Math.sin(dLon / 2) *
-            Math.sin(dLon / 2);
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-    return R * c;
-}
-
-/**
- * Calculate the area of a polygon using the spherical excess formula
- * @param {Array} coordinates - Array of [lng, lat] coordinates forming the polygon
- * @param {string} unit - Unit of measurement ('metric' or 'imperial')
- * @returns {number} Area in square kilometers or square miles
- */
-export function calculatePolygonArea(coordinates, unit = MEASUREMENT_CONFIG.UNITS.METRIC) {
-    if (coordinates.length < 3) return 0;
-
-    const R =
-        unit === MEASUREMENT_CONFIG.UNITS.IMPERIAL
-            ? MEASUREMENT_CONFIG.EARTH_RADIUS_MILES
-            : MEASUREMENT_CONFIG.EARTH_RADIUS_KM;
-
-    let area = 0;
-    const coords = coordinates.slice(); // Copy array
-
-    // Ensure polygon is closed
-    if (
-        coords[0][0] !== coords[coords.length - 1][0] ||
-        coords[0][1] !== coords[coords.length - 1][1]
-    ) {
-        coords.push(coords[0]);
-    }
-
-    for (let i = 0; i < coords.length - 1; i++) {
-        const [lon1, lat1] = coords[i];
-        const [lon2, lat2] = coords[i + 1];
-
-        area +=
-            (lon2 - lon1) *
-            (2 + Math.sin((lat1 * Math.PI) / 180) + Math.sin((lat2 * Math.PI) / 180));
-    }
-
-    area = Math.abs((area * R * R * Math.PI) / 360);
-    return area;
-}
-
-/**
- * Calculate the total length of a linestring
- * @param {Array} coordinates - Array of [lng, lat] coordinates
- * @param {string} unit - Unit of measurement ('metric' or 'imperial')
- * @returns {number} Total length in kilometers or miles
- */
-export function calculateLineStringLength(coordinates, unit = MEASUREMENT_CONFIG.UNITS.METRIC) {
-    if (coordinates.length < 2) return 0;
-
-    let totalLength = 0;
-    for (let i = 0; i < coordinates.length - 1; i++) {
-        const [lon1, lat1] = coordinates[i];
-        const [lon2, lat2] = coordinates[i + 1];
-        totalLength += calculateDistance(lat1, lon1, lat2, lon2, unit);
-    }
-
-    return totalLength;
-}
-
-/**
- * Calculate the area of a circle given its radius
- * @param {number} radius - Radius in kilometers or miles
- * @returns {number} Area in square kilometers or square miles
- */
-export function calculateCircleArea(radius) {
-    return Math.PI * Math.pow(radius, 2);
-}
-
-/**
- * Calculate the radius of a circle from polygon coordinates
- * @param {Array} polygonCoords 
- * @param {string} unit 
- * @returns {number} radius in kilometers or miles
- */
-export function calculateCircleRadius(polygonCoords, unit = MEASUREMENT_CONFIG.UNITS.METRIC) {
-    // Assuming polygonCoords is an array of linear rings, take the first ring
-    const firstRing = polygonCoords[0];
-    if (firstRing.length < 2) return 0;
-
-    // Calculate the centroid of the polygon
-    let sumLat = 0;
-    let sumLng = 0;
-    firstRing.forEach(([lng, lat]) => {
-        sumLat += lat;
-        sumLng += lng;
-    });
-    const centroidLat = sumLat / firstRing.length;
-    const centroidLng = sumLng / firstRing.length;
-
-    // Calculate the distance from the centroid to the first point as radius
-    const [firstLng, firstLat] = firstRing[0];
-    const radius = calculateDistance(centroidLat, centroidLng, firstLat, firstLng, unit);
-
-    return radius;
-}
-
-/**
- * Calculate circle measurements: area and diameter
- * @param {Number} radius
- * @returns {Object} area and diameter
- */
-export function calculateCircleMeasurements(radius) {
-    const area = calculateCircleArea(radius);
-    const diameter = radius * 2;
-    return { area, diameter };
 }
 
 /**
@@ -602,80 +141,11 @@ export function formatPointCount(count) {
 }
 
 /**
- * Format measurement value with appropriate units and precision
- * @param {number} value - The measurement value
- * @param {string} type - Type of measurement ('distance', 'area')
- * @param {string} unit - Unit system ('metric' or 'imperial')
- * @returns {string} Formatted measurement string
- */
-export function formatMeasurement(value, type, unit = MEASUREMENT_CONFIG.UNITS.METRIC, locale = 'en-US') {
-    if (type === 'distance') {
-        if (unit === MEASUREMENT_CONFIG.UNITS.IMPERIAL) {
-            if (value < 0.1) {
-                // Very short distances in feet with no decimals for readability
-                const feet = value * 5280;
-                return `${formatNumber(feet, 0, locale)} ft`;
-            } else if (value < 1) {
-                // Short distances in feet with 1 decimal
-                const feet = value * 5280;
-                return `${formatNumber(feet, 1, locale)} ft`;
-            } else {
-                // Longer distances in miles
-                return `${formatNumber(value, 2, locale)} mi`;
-            }
-        } else {
-            if (value < 0.001) {
-                // Very short distances in centimeters
-                const cm = value * 100000;
-                return `${formatNumber(cm, 0, locale)} cm`;
-            } else if (value < 1) {
-                // Short distances in meters
-                const meters = value * 1000;
-                return `${formatNumber(meters, meters < 10 ? 1 : 0, locale)} m`;
-            } else {
-                // Longer distances in kilometers
-                return `${formatNumber(value, 2, locale)} km`;
-            }
-        }
-    } else if (type === 'area') {
-        if (unit === MEASUREMENT_CONFIG.UNITS.IMPERIAL) {
-            if (value < 0.0015625) {
-                // Very small areas in square feet
-                const sqFeet = value * 27878400; // 1 sq mile = 27,878,400 sq ft
-                return `${formatNumber(sqFeet, 0, locale)} ft²)`;
-            } else if (value < 1) {
-                // Small to medium areas in acres
-                const acres = value * 640;
-                return `${formatNumber(acres, acres < 1 ? 2 : 1, locale)} acres`;
-            } else {
-                // Large areas in square miles
-                return `${formatNumber(value, 2, locale)} m²`;
-            }
-        } else {
-            if (value < 0.01) {
-                // Small areas in square meters
-                const sqMeters = value * 1000000;
-                return `${formatNumber(sqMeters, sqMeters < 100 ? 1 : 0, locale)} m²`;
-            } else if (value < 1) {
-                // Medium areas in hectares
-                const hectares = value * 100;
-                return `${formatNumber(hectares, 2, locale)} ha`;
-            } else {
-                // Large areas in square kilometers
-                return `${formatNumber(value, 2, locale)} km²`;
-            }
-        }
-    }
-    return formatNumber(value, 2, locale);
-}
-
-
-/**
  * Format area measurement with appropriate unit based on size and unit system
  * Supports both metric (m², ha, km²) and imperial (sq ft, ac, sq mi) units
  * @param {number} areaInSquareMeter - Area value in square meters
- * @param {number} decimals - Number of decimal places (default: 2)
  * @param {string} locale - Locale for number formatting (default: 'en-US')
+ * @param {number} decimals - Number of decimal places (default: 2)
  * @param {string} unitSystem - Unit system to use: 'metric' or 'imperial' (default: 'metric')
  * @returns {string} Formatted area string with appropriate unit
  */
@@ -998,4 +468,57 @@ export function validateGeoJson(geoJson, options = {}) {
     }
 
     return false;
+}
+
+/**
+ * Calculate area of a polygon or multipolygon feature using Turf.js
+ * Supports both Polygon and MultiPolygon geometry types
+ * @param {Object} feature - GeoJSON Feature with Polygon or MultiPolygon geometry
+ * @returns {number} Area in square meters, or 0 if calculation fails
+ */
+export function calculateArea(feature) {
+    if (!feature || !feature.geometry || !window.turf) {
+        return 0;
+    }
+
+    const { type } = feature.geometry;
+
+    // Only calculate area for polygon types
+    if (!['Polygon', 'MultiPolygon'].includes(type)) {
+        return 0;
+    }
+
+    try {
+        // turf.area() accepts GeoJSON Feature directly
+        return window.turf.area(feature);
+    } catch (error) {
+        console.error('turf.area calculation failed:', error);
+        return 0;
+    }
+}
+
+/**
+ * Calculate total area of multiple polygon features using Turf.js
+ * Filters and sums areas of all Polygon and MultiPolygon features
+ * @param {Array<Object>} features - Array of GeoJSON Features
+ * @returns {number} Total area in square meters
+ */
+export function calculateFeaturesTotalArea(features) {
+    if (!features || !Array.isArray(features) || features.length === 0) {
+        return 0;
+    }
+
+    return features.reduce((totalArea, feature) => {
+        // Skip features without valid geometry
+        if (!feature?.geometry?.type) {
+            return totalArea;
+        }
+
+        const area = calculateArea(feature);
+        if (typeof area === 'number' && !isNaN(area) && isFinite(area)) {
+            return totalArea + area;
+        }
+
+        return totalArea;
+    }, 0); // in square meters
 }

--- a/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js
+++ b/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js
@@ -11,118 +11,27 @@ import {
     onWillUpdateProps,
 } from '@odoo/owl';
 import { hexToRgba, generateColor } from '@web_view_google_map/views/google_map/utils';
-import { loadDeckGlAssets } from '../../../utils/utils';
-
-
-/**
- * Deck.gl configuration constants
- */
-const DECKGL_CONFIG = {
-    // Rendering performance
-    MAX_FEATURES_PER_BATCH: 50000, // Maximum features to process per batch
-    VIEWPORT_PADDING: 0.1, // Padding around viewport for culling (10%)
-
-    // Memory management
-    FEATURE_POOL_SIZE: 100000, // Pre-allocated feature object pool
-    GC_INTERVAL: 30000, // Garbage collection interval (30s)
-    MEMORY_THRESHOLD: 0.8, // Memory usage threshold for cleanup
-
-    // Visual styling
-    DEFAULT_COLORS: {
-        FILL: [70, 130, 180, 80], // Steel blue with 80% opacity
-        STROKE: [25, 25, 112, 255], // Midnight blue
-        SELECTED_FILL: [255, 215, 0, 120], // Gold with transparency
-        SELECTED_STROKE: [255, 140, 0, 255], // Dark orange
-    },
-
-    // Interactive features
-    HOVER_RADIUS: 10, // Pixels for hover detection
-    SELECT_RADIUS: 15, // Pixels for selection detection
-    ANIMATION_DURATION: 300, // Milliseconds for smooth transitions
-};
-
-/**
- * Enable debug mode to see the flag canvas
- * @type {boolean}
- */
-window.DEBUG_DECKGL = true;
-
-/**
- * Create icon atlas and mapping for Deck.gl IconLayer
- */
-const createIconAtlas = () => {
-    const canvas = document.createElement('canvas');
-    const size = 64;
-    canvas.width = size;
-    canvas.height = size;
-    const ctx = canvas.getContext('2d');
-    
-    // Clear canvas with transparent background
-    ctx.clearRect(0, 0, size, size);
-    
-    // Create a simple flag icon on canvas
-    ctx.fillStyle = '#dc3545'; // Red flag
-    ctx.strokeStyle = '#2d3748'; // Dark pole
-    ctx.lineWidth = 3;
-
-    // Draw flag pole
-    ctx.beginPath();
-    ctx.moveTo(12, 8);
-    ctx.lineTo(12, 56);
-    ctx.stroke();
-    
-    // Draw flag
-    ctx.fillStyle = '#dc3545';
-    ctx.beginPath();
-    ctx.moveTo(12, 8);
-    ctx.lineTo(48, 16);
-    ctx.lineTo(40, 28);
-    ctx.lineTo(48, 40);
-    ctx.lineTo(12, 32);
-    ctx.closePath();
-    ctx.fill();
-    
-    // Add border to flag
-    ctx.strokeStyle = '#721c24';
-    ctx.lineWidth = 1;
-    ctx.stroke();
-    
-    // Draw pole base
-    ctx.fillStyle = '#2d3748';
-    ctx.beginPath();
-    ctx.arc(12, 56, 4, 0, 2 * Math.PI);
-    ctx.fill();
-
-    return canvas;
-};
-
-/**
- * Icon mapping for Deck.gl IconLayer
- */
-const ICON_MAPPING = {
-    flag: {
-        x: 0,
-        y: 0,
-        width: 64,
-        height: 64,
-        anchorY: 56, // Anchor at the bottom of the pole
-        anchorX: 12, // Anchor at the pole center
-        mask: false
-    }
-};
+import { loadDeckGlAssets, validateGeoJson, calculateFeaturesTotalArea } from '../../../utils/utils';
+import { DECKGL_CONFIG, STROKE_CONFIG } from '../../../utils/map_config';
+import { UploadGeoJsonFileDialog } from '../upload_geojson_dialog/upload_geojson_dialog';
 
 
 export class DeckGlEditor extends Component {
     static template = 'web_view_google_map_drawing.DeckGlEditor';
     static props = {
+        readonly: Boolean,
+        renderingMode: String,
         googleMap: Object,
         dataGeoJson: { type: Object, optional: true },
+        saveFeatures: Function,
         record: Object,
         onSelectionChange: { type: Function, optional: true }, // Callback for selection changes
     };
 
     setup() {
         this.notificationService = useService('notification');
+        this.dialogService = useService('dialog');
+        this.uiService = useService('ui');
         this.editorRef = useRef('editor');
         this.googleMapBounds = null;
         this.deckglOverlay = null;
@@ -137,15 +46,11 @@ export class DeckGlEditor extends Component {
         this.isDragging = false;
         this.dragStartPosition = null;
         this.dragFeatureIds = new Set();
-        
-        // Icon atlas for flag markers
-        this.iconAtlas = null;
-        
+
         this.debounceRenderGeoJsonData = debounce(this.renderGeoJsonData.bind(this), 500);
 
         onWillStart(async () => {
-            await this._loadDeckGLAssets();
-            this._createIconAtlas();
+            await loadDeckGlAssets();
         });
 
         useEffect(
@@ -159,35 +64,17 @@ export class DeckGlEditor extends Component {
 
         onWillDestroy(() => this._cleanUp());
 
-        onWillUpdateProps(() => {
+        onWillUpdateProps((nextProps) => {
             if (this.props.dataGeoJson && this.deckglOverlay) {
+                if (nextProps.renderingMode !== 'deckgl') {
+                    console.warn('Rendering mode changed, skipping Deck.gl data render');
+                    return;
+                }
                 this.debounceRenderGeoJsonData();
             }
         });
     }
 
-
-    /**
-     * Load Deck.gl and Nebula GL assets and dependencies
-     * @private
-     */
-    async _loadDeckGLAssets() {
-        loadDeckGlAssets();
-    }
-
-    /**
-     * Create icon atlas for flag markers
-     * @private
-     */
-    _createIconAtlas() {
-        try {
-            this.iconAtlas = createIconAtlas();
-        } catch (error) {
-            console.error('Failed to create icon atlas:', error);
-            this.iconAtlas = null;
-        }
-    }
-    
     async _initializeDeckGLOverlay() {
         if (!window.deck || !this.props.googleMap) {
             throw new Error('Deck.gl or Google Maps not available');
@@ -334,255 +221,104 @@ export class DeckGlEditor extends Component {
         });
     }
 
-    renderGeoJsonData() {
-        if (!this.deckglOverlay || !this.props.dataGeoJson || !this.props.dataGeoJson.features) {
-            console.log('Deck.gl overlay or GeoJSON data not available');
+    renderGeoJsonData(geojson) {
+        if (this.props.renderingMode !== 'deckgl') {
+            console.warn('Rendering mode is not deckgl, skipping renderGeoJsonData');
             return;
         }
-        
-        // Ensure all features have unique IDs
-        this.props.dataGeoJson.features.forEach((feature, index) => {
-            if (!feature.properties) feature.properties = {};
-            if (!feature.properties.id) {
-                feature.properties.id = `feature_${index}`;
+        this.uiService.block();
+        try {
+            const dataGeoJson = geojson || this.props.dataGeoJson;
+            if (!this.deckglOverlay || !dataGeoJson || !dataGeoJson.features) {
+                console.log('Deck.gl overlay or GeoJSON data not available');
+                this.uiService.unblock();
+                return;
             }
-        });
 
-        const polygons = this.props.dataGeoJson.features.filter(f => ['Polygon', 'MultiPolygon'].includes(f.geometry.type));
-        const points = this.props.dataGeoJson.features.filter(f => ['Point', 'MultiPoint'].includes(f.geometry.type));
-        const lines = this.props.dataGeoJson.features.filter(f => ['LineString', 'MultiLineString'].includes(f.geometry.type));
-
-        const color = generateColor();
-        const normalFillColor = hexToRgba(color, 0.4, DECKGL_CONFIG.DEFAULT_COLORS.FILL);
-        const normalStrokeColor = hexToRgba(color, 1.0, DECKGL_CONFIG.DEFAULT_COLORS.FILL);
-
-        const layers = [
-            // Polygon layer for filled shapes
-            new window.deck.GeoJsonLayer({
-                id: 'polygonsLayer',
-                data: polygons,
-                stroked: true,
-                filled: true,
-                lineWidthMinPixels: 2,
-                opacity: 0.8,
-                pickable: true,
-                autoHighlight: false, // We handle highlighting manually
-                
-                // Dynamic styling based on selection/hover state
-                getFillColor: d => this._getFeatureFillColor(d, normalFillColor),
-                getLineColor: d => this._getFeatureStrokeColor(d, normalStrokeColor),
-                getLineWidth: d => this._getFeatureLineWidth(d, 2),
-                
-                // Update triggers for re-rendering when selection changes
-                updateTriggers: {
-                    getFillColor: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                    getLineColor: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                    getLineWidth: [this.state.selectedFeatures, this.state.hoveredFeatureId],
+            // Ensure all features have unique IDs
+            dataGeoJson.features.forEach((feature, index) => {
+                if (!feature.properties) feature.properties = {};
+                if (!feature.properties.id) {
+                    feature.properties.id = `feature_${index}`;
                 }
-            }),
+            });
 
-            // Line layer for LineString geometries
-            new window.deck.GeoJsonLayer({
-                id: 'linesLayer',
-                data: lines,
-                filled: false,
-                stroked: true,
-                pickable: true,
-                autoHighlight: false, // We handle highlighting manually
-                lineWidthMinPixels: 2,
-                
-                // Dynamic styling
-                getLineColor: d => this._getFeatureStrokeColor(d, normalStrokeColor),
-                getLineWidth: d => this._getFeatureLineWidth(d, 3),
-                
-                // Update triggers
-                updateTriggers: {
-                    getLineColor: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                    getLineWidth: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                }
-            }),
+            const polygons = dataGeoJson.features.filter(f => ['Polygon', 'MultiPolygon'].includes(f.geometry.type));
+            const points = dataGeoJson.features.filter(f => ['Point', 'MultiPoint'].includes(f.geometry.type));
+            const lines = dataGeoJson.features.filter(f => ['LineString', 'MultiLineString'].includes(f.geometry.type));
 
-            // Try IconLayer for flags, fallback to ScatterplotLayer if it fails
-            this._createPointLayer(points, normalFillColor, normalStrokeColor)
-        ];
+            const color = generateColor();
+            const normalFillColor = hexToRgba(color, 0.4, DECKGL_CONFIG.DEFAULT_COLORS.FILL);
+            const normalStrokeColor = hexToRgba(color, 1.0, DECKGL_CONFIG.DEFAULT_COLORS.FILL);
 
-        this.deckglOverlay.setProps({ layers });
-        this.centerMapToFeatures(this.props.dataGeoJson.features);
-    }
+            const layers = [
+                // Polygon layer for filled shapes
+                new window.deck.GeoJsonLayer({
+                    id: 'polygonsLayer',
+                    data: polygons,
+                    filled: true,
+                    stroked: true,
+                    wrapLongitude: true,
+                    getFillColor: () => DECKGL_CONFIG.DEFAULT_COLORS.SELECTED_FILL,
+                    getLineColor: () => DECKGL_CONFIG.DEFAULT_COLORS.SELECTED_STROKE,
+                    getLineWidth: () => STROKE_CONFIG.DEFAULT_WIDTH,
+                    lineWidthMinPixels: STROKE_CONFIG.DEFAULT_WIDTH,
+                    lineWidthMaxPixels: STROKE_CONFIG.HOVER_WIDTH,
+                    pickable: true,
+                    autoHighlight: true,
+                    highlightColor: DECKGL_CONFIG.DEFAULT_COLORS.HOVERED_FILL,
+                }),
 
-    /**
-     * Create point layer - try IconLayer first, fallback to ScatterplotLayer
-     * @private
-     */
-    _createPointLayer(points, normalFillColor, normalStrokeColor) {
-        // Check if IconLayer is available and atlas is ready
-        if (window.deck.IconLayer && this.iconAtlas) {
-            try {
-                return new window.deck.IconLayer({
+                // Line layer for LineString geometries
+                new window.deck.GeoJsonLayer({
+                    id: 'linesLayer',
+                    data: lines,
+                    filled: false,
+                    stroked: true,
+                    wrapLongitude: true,
+                    getLineColor: () => DECKGL_CONFIG.DEFAULT_COLORS.SELECTED_STROKE,
+                    getLineWidth: () => 3,
+                    lineWidthUnits: 'pixels',
+                    lineWidthMinPixels: 3,
+                    lineWidthMaxPixels: 8,
+                    pickable: true,
+                    autoHighlight: true,
+                    highlightColor: DECKGL_CONFIG.DEFAULT_COLORS.HOVERED_STROKE,
+                }),
+
+                // ScatterplotLayer for point features
+                new window.deck.ScatterplotLayer({
                     id: 'pointsLayer',
                     data: points.map(f => ({
                         ...f,
                         position: f.geometry.type === 'Point'
                             ? f.geometry.coordinates
-                            : f.geometry.coordinates[0],
-                        icon: 'flag'
+                            : f.geometry.coordinates[0]
                     })),
-                    iconAtlas: this.iconAtlas,
-                    iconMapping: ICON_MAPPING,
                     getPosition: d => d.position,
-                    getIcon: d => d.icon,
-                    sizeScale: 1,
-                    sizeMinPixels: 24,
-                    sizeMaxPixels: 80,
+                    getRadius: 6,
+                    radiusUnits: 'pixels',
+                    radiusMinPixels: 6,
+                    radiusMaxPixels: 20,
+                    stroked: true,
+                    filled: true,
+                    getFillColor: normalFillColor,
+                    getLineColor: normalStrokeColor,
+                    lineWidthMinPixels: 2,
+                    lineWidthMaxPixels: 4,
                     pickable: true,
-                    autoHighlight: false,
-                    billboard: true,
-                    alphaCutoff: 0.05,
-                    
-                    // Dynamic sizing based on state
-                    getSize: d => this._getFeatureIconSize(d, 48),
-                    getColor: d => this._getFeatureIconColor(d),
-                    
-                    // Update triggers
-                    updateTriggers: {
-                        getSize: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                        getColor: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                    }
-                });
-            } catch (error) {
-                console.error('Failed to create IconLayer, falling back to ScatterplotLayer:', error);
-            }
-        }
+                    autoHighlight: true,
+                    highlightColor: DECKGL_CONFIG.DEFAULT_COLORS.HOVERED_FILL,
+                })
+            ];
 
-        // Fallback to ScatterplotLayer
-        return new window.deck.ScatterplotLayer({
-            id: 'pointsLayer',
-            data: points.map(f => ({
-                ...f,
-                position: f.geometry.type === 'Point'
-                    ? f.geometry.coordinates
-                    : f.geometry.coordinates[0]
-            })),
-            getPosition: d => d.position,
-            radiusMinPixels: 8,
-            radiusMaxPixels: 50,
-            pickable: true,
-            autoHighlight: false,
-            
-            // Dynamic styling
-            getRadius: d => this._getFeatureIconSize(d, 15), // Reuse the same sizing logic
-            getFillColor: d => this._getFeatureIconColor(d), // Reuse the same coloring logic
-            getLineColor: d => this._getFeatureStrokeColor(d, normalStrokeColor),
-            getLineWidth: d => this._getFeatureLineWidth(d, 2),
-            
-            // Update triggers
-            updateTriggers: {
-                getRadius: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                getFillColor: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                getLineColor: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-                getLineWidth: [this.state.selectedFeatures, this.state.hoveredFeatureId],
-            }
-        });
-    }
-
-    /**
-     * Get dynamic fill color based on feature state
-     */
-    _getFeatureFillColor(feature, normalColor) {
-        const featureId = feature.properties?.id;
-        
-        if (featureId === this.state.hoveredFeatureId) {
-            // Hover state - bright yellow/gold
-            return [255, 255, 0, 100];
+            this.deckglOverlay.setProps({ layers });
+            this.centerMapToFeatures(dataGeoJson.features);
+        } catch (error) {
+            console.error('Error rendering GeoJSON data in Deck.gl overlay:', error);
+        } finally {
+            this.uiService.unblock();
         }
-        
-        if (this.state.selectedFeatures.has(featureId)) {
-            // Selected state - gold with higher opacity
-            return DECKGL_CONFIG.DEFAULT_COLORS.SELECTED_FILL;
-        }
-        
-        // Normal state
-        return normalColor;
-    }
-
-    /**
-     * Get dynamic stroke color based on feature state  
-     */
-    _getFeatureStrokeColor(feature, normalColor) {
-        const featureId = feature.properties?.id;
-        
-        if (featureId === this.state.hoveredFeatureId) {
-            // Hover state - bright orange
-            return [255, 165, 0, 255];
-        }
-        
-        if (this.state.selectedFeatures.has(featureId)) {
-            // Selected state - dark orange
-            return DECKGL_CONFIG.DEFAULT_COLORS.SELECTED_STROKE;
-        }
-        
-        // Normal state
-        return normalColor;
-    }
-
-    /**
-     * Get dynamic line width based on feature state
-     */
-    _getFeatureLineWidth(feature, normalWidth) {
-        const featureId = feature.properties?.id;
-        
-        if (featureId === this.state.hoveredFeatureId) {
-            // Hover state - thicker line
-            return normalWidth + 2;
-        }
-        
-        if (this.state.selectedFeatures.has(featureId)) {
-            // Selected state - slightly thicker
-            return normalWidth + 1;
-        }
-        
-        // Normal state
-        return normalWidth;
-    }
-
-    /**
-     * Get dynamic icon size based on feature state
-     */
-    _getFeatureIconSize(feature, normalSize) {
-        const featureId = feature.properties?.id;
-        
-        if (featureId === this.state.hoveredFeatureId) {
-            // Hover state - larger icon
-            return normalSize * 1.5;
-        }
-        
-        if (this.state.selectedFeatures.has(featureId)) {
-            // Selected state - slightly larger
-            return normalSize * 1.2;
-        }
-        
-        // Normal state
-        return normalSize;
-    }
-
-    /**
-     * Get dynamic icon color based on feature state
-     */
-    _getFeatureIconColor(feature) {
-        const featureId = feature.properties?.id;
-        
-        if (featureId === this.state.hoveredFeatureId) {
-            // Hover state - bright yellow/gold
-            return [255, 215, 0, 255];
-        }
-        
-        if (this.state.selectedFeatures.has(featureId)) {
-            // Selected state - orange
-            return [255, 140, 0, 255];
-        }
-        
-        // Normal state - red flag
-        return [220, 53, 69, 255];
     }
 
     async centerMapToFeatures(features) {
@@ -644,7 +380,141 @@ export class DeckGlEditor extends Component {
         this._notifySelectionChange();
     }
 
+    /**
+     * Computed property to check if there is data to export
+     * @returns {boolean}
+     */
+    get hasDataToExport() {
+        return this.props.dataGeoJson?.features?.length > 0;
+    }
+
+    /**
+     * Handle Import button click - opens file upload dialog
+     */
+    onClickImport() {
+        this.dialogService.add(UploadGeoJsonFileDialog, {
+            confirm: (file) => this._processImportedFile(file),
+            cancel: () => {},
+        });
+    }
+
+    /**
+     * Process the imported GeoJSON file
+     * @param {File} file - The uploaded file
+     * @returns {Promise<boolean>} - Success status
+     * @private
+     */
+    async _processImportedFile(file) {
+        if (!file) {
+            this.notificationService.add(_t('No file was uploaded.'), { type: 'danger' });
+            return false;
+        }
+
+        return new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onload = async (e) => {
+                try {
+                    const geojson = JSON.parse(e.target.result);
+                    const isValid = validateGeoJson(geojson, {
+                        requireFeatures: true,
+                        validateGeometry: true,
+                        strict: false,
+                    });
+                    if (!isValid) {
+                        this.notificationService.add(
+                            _t('The imported file is not a valid GeoJSON.'),
+                            { type: 'danger' }
+                        );
+                        resolve(false);
+                        return;
+                    }
+                    // Update the data and re-render
+                    this.notificationService.add(
+                        _t('GeoJSON file imported successfully.'),
+                        { type: 'success' }
+                    );
+                    const totalArea = calculateFeaturesTotalArea(geojson.features);
+                    await this.props.saveFeatures(geojson, totalArea);
+                    resolve(true);
+                } catch (error) {
+                    console.error('Error parsing imported GeoJSON file:', error);
+                    this.notificationService.add(
+                        _t('Failed to parse the imported GeoJSON file.'),
+                        { type: 'danger' }
+                    );
+                    resolve(false);
+                }
+            };
+            reader.onerror = () => {
+                this.notificationService.add(
+                    _t('Failed to read the imported GeoJSON file.'),
+                    { type: 'danger' }
+                );
+                resolve(false);
+            };
+            reader.readAsText(file);
+        });
+    }
+
+    /**
+     * Handle Export button click - downloads current GeoJSON data
+     */
+    onClickExport() {
+        if (!this.hasDataToExport) {
+            this.notificationService.add(_t('No data available to export.'), { type: 'warning' });
+            return;
+        }
+
+        try {
+            // Create clean GeoJSON export
+            const exportData = {
+                type: 'FeatureCollection',
+                features: this.props.dataGeoJson.features.map((feature) => ({
+                    type: 'Feature',
+                    geometry: feature.geometry,
+                    properties: this._cleanPropertiesForExport(feature.properties || {}),
+                })),
+            };
+
+            const jsonString = JSON.stringify(exportData, null, 2);
+            const blob = new Blob([jsonString], { type: 'application/geo+json' });
+            const url = URL.createObjectURL(blob);
+
+            const timestamp = new Date().toISOString().slice(0, 10);
+            const filename = `geojson_export_${timestamp}.geojson`;
+
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = filename;
+            document.body.appendChild(link);
+            link.click();
+
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+
+            this.notificationService.add(_t('GeoJSON exported successfully.'), { type: 'success' });
+        } catch (error) {
+            console.error('Error exporting GeoJSON:', error);
+            this.notificationService.add(_t('Failed to export GeoJSON file.'), { type: 'danger' });
+        }
+    }
+
+    /**
+     * Clean properties for export - remove internal/transient properties
+     * @param {Object} properties - Feature properties
+     * @returns {Object} Cleaned properties
+     * @private
+     */
+    _cleanPropertiesForExport(properties) {
+        const cleanProps = { ...properties };
+        // Remove internal properties that should not be exported
+        const internalProps = ['mode', 'midPoint', 'selectionPoint', '_metadata'];
+        internalProps.forEach((prop) => delete cleanProps[prop]);
+        return cleanProps;
+    }
+
     _cleanUp() {
+        console.log('Cleaning up Deck.gl overlay resources');
         // Clear drag state
         this.isDragging = false;
         this.dragStartPosition = null;

--- a/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js
+++ b/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js
@@ -11,7 +11,7 @@ import {
     onWillUpdateProps,
 } from '@odoo/owl';
 import { hexToRgba, generateColor } from '@web_view_google_map/views/google_map/utils';
-import { loadDeckGlAssets, validateGeoJson, calculateFeaturesTotalArea } from '../../../utils/utils';
+import { loadDeckGlAssets, validateGeoJson, calculateFeaturesTotalArea, hasGeoJsonChanged } from '../../../utils/utils';
 import { DECKGL_CONFIG, STROKE_CONFIG } from '../../../utils/map_config';
 import { UploadGeoJsonFileDialog } from '../upload_geojson_dialog/upload_geojson_dialog';
 
@@ -65,12 +65,15 @@ export class DeckGlEditor extends Component {
         onWillDestroy(() => this._cleanUp());
 
         onWillUpdateProps((nextProps) => {
-            if (this.props.dataGeoJson && this.deckglOverlay) {
+            if (nextProps.dataGeoJson && this.deckglOverlay) {
                 if (nextProps.renderingMode !== 'deckgl') {
-                    console.warn('Rendering mode changed, skipping Deck.gl data render');
+                    console.debug('Rendering mode changed, skipping Deck.gl data render');
                     return;
                 }
-                this.debounceRenderGeoJsonData();
+                const isGeoJsonChanged = hasGeoJsonChanged(this.props.dataGeoJson, nextProps.dataGeoJson);
+                if (isGeoJsonChanged) {
+                    this.debounceRenderGeoJsonData(nextProps.dataGeoJson);
+                }
             }
         });
     }
@@ -230,7 +233,7 @@ export class DeckGlEditor extends Component {
         try {
             const dataGeoJson = geojson || this.props.dataGeoJson;
             if (!this.deckglOverlay || !dataGeoJson || !dataGeoJson.features) {
-                console.log('Deck.gl overlay or GeoJSON data not available');
+                console.debug('Deck.gl overlay or GeoJSON data not available');
                 this.uiService.unblock();
                 return;
             }
@@ -514,7 +517,6 @@ export class DeckGlEditor extends Component {
     }
 
     _cleanUp() {
-        console.log('Cleaning up Deck.gl overlay resources');
         // Clear drag state
         this.isDragging = false;
         this.dragStartPosition = null;

--- a/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.scss
+++ b/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.scss
@@ -2,7 +2,6 @@
     position: relative;
 
     .o_deckgl_toolbar {
-        // position: absolute;
         top: 10px;
         left: 10px;
         display: flex;

--- a/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.scss
+++ b/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.scss
@@ -1,3 +1,49 @@
 .deck-gl-editor {
     position: relative;
+
+    .o_deckgl_toolbar {
+        // position: absolute;
+        top: 10px;
+        left: 10px;
+        display: flex;
+        flex-flow: column;
+        gap: 3px;
+        padding: 6px;
+        z-index: 1000;
+
+        .mode-button {
+            width: 32px;
+            height: 32px;
+            border: 1px solid #ccc;
+            background-color: #000000;
+            padding: 4px;
+            box-sizing: border-box;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            span {
+                color: white;
+            }
+
+            &:hover {
+                background-color: #333333;
+            }
+
+            &:active {
+                background-color: #71639e;
+            }
+
+            &:disabled,
+            &[disabled] {
+                background-color: #dcdcdc;
+                cursor: not-allowed;
+
+                span {
+                    color: #888888;
+                }
+            }
+        }
+    }
 }

--- a/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.xml
+++ b/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <div t-name="web_view_google_map_drawing.DeckGlEditor" class="deck-gl-editor">
-        <span t-ref="editor"></span>
+        <!-- DeckGL Import/Export Toolbar -->
+        <div class="o_deckgl_toolbar" t-ref="editor">
+            <t t-if="!props.readonly">
+                <button id="import-geojson-button"
+                        class="mode-button"
+                        data-tooltip="Import GeoJSON"
+                        t-on-click.prevent="onClickImport">
+                    <span class="fa fa-upload fa-lg"></span>
+                </button>
+                <button id="export-geojson-button"
+                        class="mode-button"
+                        data-tooltip="Export GeoJSON"
+                        t-on-click.prevent="onClickExport"
+                        t-att-disabled="!hasDataToExport">
+                    <span class="fa fa-download fa-lg"></span>
+                </button>
+            </t>
+        </div>
     </div>
 </templates>

--- a/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
+++ b/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
@@ -16,10 +16,10 @@ import {
     loadTerraDrawAssets,
     loadTurfJSAssets,
     normalizeCoordinates,
-    stripAltitude,
     TERRA_DRAW_CONFIG,
     getRandomColor,
     validateGeoJson,
+    calculateFeaturesTotalArea,
 } from '../../../utils/utils';
 import { analyzeFeaturePerformance, createEditableFeature } from '../../../utils/geometry_performance_utils';
 import { UploadGeoJsonFileDialog } from '../upload_geojson_dialog/upload_geojson_dialog';
@@ -62,6 +62,7 @@ export class TerraDrawToolsUI extends Component {
     static props = {
         googleMap: Object,
         saveFeatures: Function,
+        renderingMode: String,
         dataGeoJson: { type: Object, optional: true, default: null },
         record: Object,
     };
@@ -117,17 +118,26 @@ export class TerraDrawToolsUI extends Component {
         onWillUpdateProps((nextProps) => {
             if (!nextProps.googleMap || !this.terraDrawInstance) return;
 
-            if (JSON.stringify(nextProps.dataGeoJson) !== JSON.stringify(this.props.dataGeoJson)) {
+            const isGeoJsonChanged = this._hasGeoJsonChanged(this.props.dataGeoJson, nextProps.dataGeoJson);
+            console.log('GeoJSON changed:', isGeoJsonChanged);
+            if (isGeoJsonChanged) {
                 if (this.state.isRestoring || this.state.isSaving) return;
                 this.terraDrawInstance.clear();
                 this.latLngBounds = null; // reset latLngBounds to recalculate
+                if (nextProps.renderingMode !== 'terra-draw') {
+                    console.log('Rendering mode changed, skipping loadRecordData');
+                    return;
+                }
                 this.loadRecordData(nextProps.dataGeoJson);
+            } else {
+                console.log('No changes in GeoJSON data detected.');
+                console.log({ curr: this.props.dataGeoJson, next: nextProps.dataGeoJson });
             }
         });
 
         useEffect(
-            (googleMap, toolUiRef) => {
-                if (googleMap && toolUiRef.el && window.terraDraw) {
+            (googleMap, toolUiRef, renderingMode) => {
+                if (googleMap && toolUiRef.el && window.terraDraw && renderingMode === 'terra-draw') {
                     this.initTerraDraw().catch((error) => {
                         console.error('Failed to initialize Terra Draw:', error);
                         this.notificationService.add(
@@ -137,7 +147,7 @@ export class TerraDrawToolsUI extends Component {
                     });
                 }
             },
-            () => [this.props.googleMap, this.toolsUiRef]
+            () => [this.props.googleMap, this.toolsUiRef, this.props.renderingMode]
         );
     }
 
@@ -158,10 +168,17 @@ export class TerraDrawToolsUI extends Component {
             return; // nothing to load
         }
 
+        if (this.props.renderingMode !== 'terra-draw') {
+            console.warn('Current mode is not terra-draw, skipping loadRecordData');
+            return;
+        }
+
         if (!this.terraDrawInstance) {
             console.warn('TerraDraw instance not initialized yet');
             return;
         }
+
+        this.uiService.block();
 
         this._loadingData = true;
 
@@ -198,6 +215,7 @@ export class TerraDrawToolsUI extends Component {
         } finally {
             this.state.isRestoring = false;
             this._loadingData = false;
+            this.uiService.unblock();
         }
     }
 
@@ -232,9 +250,7 @@ export class TerraDrawToolsUI extends Component {
                     plainFeature.geometry.coordinates.forEach((_polygonCoords) => {
                         if (_polygonCoords.length > 1) return; // Skip parts with holes
 
-                        // Strip altitude and normalize coordinates
-                        const strippedCoords = stripAltitude(_polygonCoords, 'Polygon');
-                        const polygonCoords = normalizeCoordinates(strippedCoords, TERRA_DRAW_CONFIG.COORDINATE_PRECISION);
+                        const polygonCoords = normalizeCoordinates(_polygonCoords, TERRA_DRAW_CONFIG.COORDINATE_PRECISION);
                         multiPolygonFeatures.push({
                             type: 'Feature',
                             id: generateUUID(),
@@ -250,12 +266,6 @@ export class TerraDrawToolsUI extends Component {
                     if (!plainFeature.id || typeof plainFeature.id !== 'string') {
                         plainFeature.id = generateUUID();
                     }
-
-                    // Strip altitude for Terra Draw compatibility (only accepts 2D coordinates)
-                    plainFeature.geometry.coordinates = stripAltitude(
-                        plainFeature.geometry.coordinates,
-                        plainFeature.geometry.type
-                    );
 
                     plainFeature.geometry.coordinates = normalizeCoordinates(
                         plainFeature.geometry.coordinates,
@@ -283,12 +293,6 @@ export class TerraDrawToolsUI extends Component {
         return processedFeatures;
     }
 
-    /**
-     * Analyze a set of features for performance characteristics
-     * @param {Array} features - Array of GeoJSON features
-     * @returns {Object} Performance analysis report
-     * @private
-     */
     /**
      * Check if feature can be safely edited and show warning if complex
      * @param {Object} feature - Feature to check
@@ -588,9 +592,16 @@ export class TerraDrawToolsUI extends Component {
             this._actionSaveManually();
         } else if (action === 'upload-button') {
             this._actionUploadGeoJSON();
+        } else if (action === 'download-button') {
+            this._actionDownloadGeoJSON();
         }
     }
 
+    /**
+     * Import GeoJSON data from a file
+     * Opens a file dialog to select and upload a GeoJSON file
+     * @private
+     */
     _actionUploadGeoJSON() {
         this.dialogService.add(UploadGeoJsonFileDialog, {
             confirm: (file) => {
@@ -603,7 +614,7 @@ export class TerraDrawToolsUI extends Component {
                 }
                 return new Promise((resolve) => {
                     const reader = new FileReader();
-                    reader.onload = (e) => {
+                    reader.onload = async (e) => {
                         try {
                             const geojson = JSON.parse(e.target.result);
                             const isValid = validateGeoJson(geojson, { requireFeatures: true, validateGeometry: true, strict: false });
@@ -615,12 +626,12 @@ export class TerraDrawToolsUI extends Component {
                                 resolve(false);
                                 return;
                             }
-                            this._actionClearMode();
-                            this.loadRecordData(geojson);
                             this.notificationService.add(
                                 _t('GeoJSON file imported successfully.'),
                                 { type: 'success' }
                             );
+                            const totalArea = calculateFeaturesTotalArea(geojson.features);
+                            await this.props.saveFeatures(geojson, totalArea);
                             resolve(true);
                         } catch (error) {
                             console.error('Error parsing imported GeoJSON file:', error);
@@ -647,6 +658,89 @@ export class TerraDrawToolsUI extends Component {
     }
 
     /**
+     * Download GeoJSON data as a file
+     * Exports current Terra Draw features to a downloadable GeoJSON file
+     * @private
+     */
+    _actionDownloadGeoJSON() {
+        if (!this.terraDrawInstance) {
+            this.notificationService.add(
+                _t('Terra Draw is not initialized properly'),
+                { type: 'danger' }
+            );
+            return;
+        }
+
+        const features = this.terraDrawInstance.getSnapshot();
+
+        // Filter out system features (midpoints, selection points)
+        const exportFeatures = features.filter(
+            (f) => !f.properties?.midPoint && !f.properties?.selectionPoint
+        );
+
+        if (exportFeatures.length === 0) {
+            this.notificationService.add(
+                _t('No data available to export.'),
+                { type: 'warning' }
+            );
+            return;
+        }
+
+        try {
+            // Create clean GeoJSON export
+            const exportData = {
+                type: 'FeatureCollection',
+                features: exportFeatures.map((feature) => ({
+                    type: 'Feature',
+                    geometry: feature.geometry,
+                    properties: this._cleanPropertiesForExport(feature.properties || {}),
+                })),
+            };
+
+            const jsonString = JSON.stringify(exportData, null, 2);
+            const blob = new Blob([jsonString], { type: 'application/geo+json' });
+            const url = URL.createObjectURL(blob);
+
+            const timestamp = new Date().toISOString().slice(0, 10);
+            const filename = `geojson_export_${timestamp}.geojson`;
+
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = filename;
+            document.body.appendChild(link);
+            link.click();
+
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+
+            this.notificationService.add(
+                _t('GeoJSON exported successfully.'),
+                { type: 'success' }
+            );
+        } catch (error) {
+            console.error('Error exporting GeoJSON:', error);
+            this.notificationService.add(
+                _t('Failed to export GeoJSON file.'),
+                { type: 'danger' }
+            );
+        }
+    }
+
+    /**
+     * Clean properties for export - remove internal/transient properties
+     * @param {Object} properties - Feature properties
+     * @returns {Object} Cleaned properties
+     * @private
+     */
+    _cleanPropertiesForExport(properties) {
+        const cleanProps = { ...properties };
+        // Remove internal properties that should not be exported
+        const internalProps = ['mode', 'midPoint', 'selectionPoint', '_metadata'];
+        internalProps.forEach((prop) => delete cleanProps[prop]);
+        return cleanProps;
+    }
+
+    /**
      * Manually save changes to features
      * Triggers immediate save without debounce
      * @private
@@ -661,34 +755,6 @@ export class TerraDrawToolsUI extends Component {
                 { type: 'danger' }
             );
         }
-    }
-
-    calculateArea(feature) {
-        if (!feature || !feature.geometry || !window.turf) return 0;
-
-        const { coordinates } = feature.geometry;
-        try {
-            const polygon = turf.polygon(coordinates);
-            return turf.area(polygon); // in square meters
-        } catch (error) {
-            console.error('turf.area failed', error);
-        }
-    }
-
-    calculateFeaturesTotalArea(features) {
-        let totalArea = 0;
-        if (!features || !Array.isArray(features) || features.length === 0) {
-            return totalArea;
-        }
-        features.forEach(feature => {
-            if (['Polygon', 'MultiPolygon'].includes(feature.geometry.type)) {
-                const area = this.calculateArea(feature);
-                if (!isNaN(area)) {
-                    totalArea += area;
-                }
-            }
-        });
-        return totalArea; // in square meters
     }
 
     /**
@@ -980,7 +1046,7 @@ export class TerraDrawToolsUI extends Component {
      * @private
      */
     _initializeTerraDrawInstance() {
-        if (this.terraDrawInstance || !this.props.googleMap) {
+        if (this.terraDrawInstance || !this.props.googleMap || this.props.renderingMode !== 'terra-draw') {
             return;
         }
 
@@ -999,7 +1065,8 @@ export class TerraDrawToolsUI extends Component {
 
             this.terraDrawInstance.start();
             this.terraDrawInstance.on('ready', () => {
-                if (this.props.dataGeoJson && this.props.dataGeoJson.features && this.props.dataGeoJson.features.length > 0) {
+                const isGeoJsonValid = validateGeoJson(this.props.dataGeoJson, { requireFeatures: true, validateGeometry: true, strict: true });
+                if (isGeoJsonValid) {
                     this.loadRecordData(this.props.dataGeoJson);
                 } else {
                     console.warn('⚠️ No dataGeoJson available on Terra Draw ready event');
@@ -1147,8 +1214,8 @@ export class TerraDrawToolsUI extends Component {
      * @private
      */
     async onDrawSelect(id) {
+        this.uiService.block();
         try {
-            this.uiService.block();
             // STEP 1: Get feature data BEFORE selection
             const features = this.terraDrawInstance.getSnapshot();
             const targetFeature = features.find(f => f.id === id);
@@ -1288,16 +1355,14 @@ export class TerraDrawToolsUI extends Component {
             this.uiService.block();
             this.setActiveMode('select-mode'); // Switch to select mode before saving
 
-            const snapshot = this.terraDrawInstance.getSnapshot();
-
+            const features = this.terraDrawInstance.getSnapshot();
             const geoJson = {
                 type: 'FeatureCollection',
-                features: snapshot,
+                features,
             };
-
-            const totalArea = this.calculateFeaturesTotalArea(snapshot);
+            const totalArea = calculateFeaturesTotalArea(features);
             await this.props.saveFeatures(geoJson, totalArea);
-            this._fitMapToBounds(snapshot);
+            this._fitMapToBounds(features);
         } catch (error) {
             console.error('Save failed:', error);
             this.notificationService.add(
@@ -1352,7 +1417,7 @@ export class TerraDrawToolsUI extends Component {
             } catch (error) {
                 console.error(`Failed to create ${name} mode:`, error);
                 this.notificationService.add(
-                    _t('Failed to initialize %s drawing mode', name),
+                    sprintf(_t('Failed to initialize %s drawing mode %s', name)),
                     { type: 'warning' }
                 );
             }
@@ -1545,6 +1610,7 @@ export class TerraDrawToolsUI extends Component {
      * @private
      */
     _cleanUp() {
+        console.log('Cleaning up Terra Tools UI component resources...');
         // Clear any pending timeouts first
         if (this.debounceTimeout) {
             clearTimeout(this.debounceTimeout);
@@ -1601,5 +1667,89 @@ export class TerraDrawToolsUI extends Component {
         
         // Clear bounds
         this.latLngBounds = null;
+    }
+
+    /**
+     * Check if GeoJSON data has changed using lightweight comparison
+     * Avoids expensive JSON.stringify for large datasets
+     * @param {Object} current - Current GeoJSON data
+     * @param {Object} next - Next GeoJSON data
+     * @returns {boolean} True if data has changed
+     * @private
+     */
+    _hasGeoJsonChanged(current, next) {
+        // Reference equality - fastest check
+        if (current === next) {
+            return false;
+        }
+
+        // Handle null/undefined cases
+        if (!current || !next) {
+            return current !== next;
+        }
+
+        // Check features array reference
+        if (current.features === next.features) {
+            return false;
+        }
+
+        // Handle missing features
+        if (!current.features || !next.features) {
+            return true;
+        }
+
+        // Quick count check
+        if (current.features.length !== next.features.length) {
+            return true;
+        }
+
+        // Empty arrays are equal
+        if (current.features.length === 0) {
+            return false;
+        }
+
+        // Compare feature fingerprints (geometry type + coordinate structure)
+        const currentFingerprint = this._getGeoJsonFingerprint(current.features);
+        const nextFingerprint = this._getGeoJsonFingerprint(next.features);
+
+        return currentFingerprint !== nextFingerprint;
+    }
+
+    /**
+     * Generate a lightweight fingerprint for a features array
+     * Captures geometry types, IDs, and coordinate counts without full serialization
+     * @param {Array} features - Array of GeoJSON features
+     * @returns {string} Fingerprint string
+     * @private
+     */
+    _getGeoJsonFingerprint(features) {
+        let fingerprint = '';
+        for (let i = 0; i < features.length; i++) {
+            const feature = features[i];
+            const id = feature.id || feature.properties?.id || i;
+            const geomType = feature.geometry?.type || 'null';
+            const coordCount = this._countCoordinates(feature.geometry?.coordinates);
+            fingerprint += `${id}:${geomType}:${coordCount};`;
+        }
+        return fingerprint;
+    }
+
+    /**
+     * Count total coordinates in a geometry
+     * @param {Array} coordinates - GeoJSON coordinates array
+     * @returns {number} Total coordinate count
+     * @private
+     */
+    _countCoordinates(coordinates) {
+        if (!coordinates) return 0;
+        if (typeof coordinates[0] === 'number') {
+            // Single coordinate [lng, lat] or [lng, lat, alt]
+            return 1;
+        }
+        let count = 0;
+        for (const coord of coordinates) {
+            count += this._countCoordinates(coord);
+        }
+        return count;
     }
 }

--- a/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
+++ b/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
@@ -20,6 +20,7 @@ import {
     getRandomColor,
     validateGeoJson,
     calculateFeaturesTotalArea,
+    hasGeoJsonChanged,
 } from '../../../utils/utils';
 import { analyzeFeaturePerformance, createEditableFeature } from '../../../utils/geometry_performance_utils';
 import { UploadGeoJsonFileDialog } from '../upload_geojson_dialog/upload_geojson_dialog';
@@ -116,22 +117,15 @@ export class TerraDrawToolsUI extends Component {
         onWillDestroy(() => this._cleanUp());
 
         onWillUpdateProps((nextProps) => {
-            if (!nextProps.googleMap || !this.terraDrawInstance) return;
+            if (!nextProps.googleMap || !this.terraDrawInstance || nextProps.renderingMode !== 'terra-draw') return;
 
-            const isGeoJsonChanged = this._hasGeoJsonChanged(this.props.dataGeoJson, nextProps.dataGeoJson);
-            console.log('GeoJSON changed:', isGeoJsonChanged);
+            if (this.state.isRestoring || this.state.isSaving) return;
+
+            const isGeoJsonChanged = hasGeoJsonChanged(this.props.dataGeoJson, nextProps.dataGeoJson);
             if (isGeoJsonChanged) {
-                if (this.state.isRestoring || this.state.isSaving) return;
                 this.terraDrawInstance.clear();
                 this.latLngBounds = null; // reset latLngBounds to recalculate
-                if (nextProps.renderingMode !== 'terra-draw') {
-                    console.log('Rendering mode changed, skipping loadRecordData');
-                    return;
-                }
                 this.loadRecordData(nextProps.dataGeoJson);
-            } else {
-                console.log('No changes in GeoJSON data detected.');
-                console.log({ curr: this.props.dataGeoJson, next: nextProps.dataGeoJson });
             }
         });
 
@@ -1417,7 +1411,7 @@ export class TerraDrawToolsUI extends Component {
             } catch (error) {
                 console.error(`Failed to create ${name} mode:`, error);
                 this.notificationService.add(
-                    sprintf(_t('Failed to initialize %s drawing mode %s', name)),
+                    sprintf(_t('Failed to initialize drawing mode %s', name)),
                     { type: 'warning' }
                 );
             }
@@ -1610,7 +1604,6 @@ export class TerraDrawToolsUI extends Component {
      * @private
      */
     _cleanUp() {
-        console.log('Cleaning up Terra Tools UI component resources...');
         // Clear any pending timeouts first
         if (this.debounceTimeout) {
             clearTimeout(this.debounceTimeout);
@@ -1669,87 +1662,4 @@ export class TerraDrawToolsUI extends Component {
         this.latLngBounds = null;
     }
 
-    /**
-     * Check if GeoJSON data has changed using lightweight comparison
-     * Avoids expensive JSON.stringify for large datasets
-     * @param {Object} current - Current GeoJSON data
-     * @param {Object} next - Next GeoJSON data
-     * @returns {boolean} True if data has changed
-     * @private
-     */
-    _hasGeoJsonChanged(current, next) {
-        // Reference equality - fastest check
-        if (current === next) {
-            return false;
-        }
-
-        // Handle null/undefined cases
-        if (!current || !next) {
-            return current !== next;
-        }
-
-        // Check features array reference
-        if (current.features === next.features) {
-            return false;
-        }
-
-        // Handle missing features
-        if (!current.features || !next.features) {
-            return true;
-        }
-
-        // Quick count check
-        if (current.features.length !== next.features.length) {
-            return true;
-        }
-
-        // Empty arrays are equal
-        if (current.features.length === 0) {
-            return false;
-        }
-
-        // Compare feature fingerprints (geometry type + coordinate structure)
-        const currentFingerprint = this._getGeoJsonFingerprint(current.features);
-        const nextFingerprint = this._getGeoJsonFingerprint(next.features);
-
-        return currentFingerprint !== nextFingerprint;
-    }
-
-    /**
-     * Generate a lightweight fingerprint for a features array
-     * Captures geometry types, IDs, and coordinate counts without full serialization
-     * @param {Array} features - Array of GeoJSON features
-     * @returns {string} Fingerprint string
-     * @private
-     */
-    _getGeoJsonFingerprint(features) {
-        let fingerprint = '';
-        for (let i = 0; i < features.length; i++) {
-            const feature = features[i];
-            const id = feature.id || feature.properties?.id || i;
-            const geomType = feature.geometry?.type || 'null';
-            const coordCount = this._countCoordinates(feature.geometry?.coordinates);
-            fingerprint += `${id}:${geomType}:${coordCount};`;
-        }
-        return fingerprint;
-    }
-
-    /**
-     * Count total coordinates in a geometry
-     * @param {Array} coordinates - GeoJSON coordinates array
-     * @returns {number} Total coordinate count
-     * @private
-     */
-    _countCoordinates(coordinates) {
-        if (!coordinates) return 0;
-        if (typeof coordinates[0] === 'number') {
-            // Single coordinate [lng, lat] or [lng, lat, alt]
-            return 1;
-        }
-        let count = 0;
-        for (const coord of coordinates) {
-            count += this._countCoordinates(coord);
-        }
-        return count;
-    }
 }

--- a/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
+++ b/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
@@ -1411,7 +1411,7 @@ export class TerraDrawToolsUI extends Component {
             } catch (error) {
                 console.error(`Failed to create ${name} mode:`, error);
                 this.notificationService.add(
-                    sprintf(_t('Failed to initialize drawing mode %s', name)),
+                    sprintf(_t('Failed to initialize drawing mode %s'), name),
                     { type: 'warning' }
                 );
             }

--- a/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.scss
+++ b/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.scss
@@ -4,18 +4,18 @@
 
 .o_terra_tools_ui {
     // background: white;
-    padding: 8px;
+    padding: 6px;
     display: flex;
     flex-flow: column;
 
     .o_terra_toolbar {
         display: flex;
         flex-flow: column;
-        gap: 3px;
+        gap: 1px;
     }
 
     button {
-        margin: 5px 0;
+        margin: 4px 0;
         cursor: pointer;
         // background-color: white;
     }

--- a/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml
+++ b/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml
@@ -46,6 +46,9 @@
                 <button id="upload-button" class="mode-button" data-tooltip="Upload GeoJSON" t-on-click.prevent="onClickActionButton">
                     <span class="fa fa-upload fa-lg"></span>
                 </button>
+                <button id="download-button" class="mode-button" data-tooltip="Download GeoJSON" t-on-click.prevent="onClickActionButton">
+                    <span class="fa fa-download fa-lg"></span>
+                </button>
                 <button id="save-button" class="mode-button" data-tooltip="Save Changes (Ctrl+S)" t-on-click.prevent="onClickActionButton">
                     <span class="fa fa-save fa-lg"></span>
                 </button>

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
@@ -26,26 +26,8 @@ import {
     loadDeckGlAssets,
     loadTurfJSAssets,
 } from '../../utils/utils';
+import { DECKGL_CONFIG, STROKE_CONFIG } from '../../utils/map_config';
 
-/**
- * Deck.gl configuration constants
- */
-const DECKGL_CONFIG = {
-    // Visual styling
-    DEFAULT_COLORS: {
-        FILL: [70, 130, 180, 80], // Steel blue with 80% opacity
-        STROKE: [25, 25, 112, 255], // Midnight blue
-        SELECTED_FILL: [0, 123, 255, 120], // Bright blue with transparency
-        SELECTED_STROKE: [0, 86, 179, 255], // Deep blue
-        HOVERED_FILL: [255, 165, 0, 120], // Gold with transparency
-        HOVERED_STROKE: [255, 140, 0, 255], // Dark orange
-    },
-};
-
-const STROKE_CONFIG = { 
-    DEFAULT_WIDTH: 2, // Default stroke width in pixels
-    HOVER_WIDTH: 4,   // Stroke width on hover in pixels
-};
 
 /**
  * Deck.gl High-Performance Renderer Component

--- a/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js
+++ b/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js
@@ -15,7 +15,7 @@ import { GoogleMapSearchPlaces } from '@web_view_google_map/views/google_map/com
 
 import { TerraDrawToolsUI } from '../../views/components/terra-tools-ui/terra-tools-ui';
 import { DeckGlEditor } from '../../views/components/deck-gl-editor/deck-gl-editor';
-import { MapConfig } from '../../utils/map_config';
+import { MAP_OPTIONS } from '../../utils/map_config';
 
 
 export class GoogleMapTerraDrawField extends BaseGoogleMapComponent {
@@ -147,12 +147,15 @@ export class GoogleMapTerraDrawField extends BaseGoogleMapComponent {
      * @returns {google.maps.MapOptions} Map options for Google Maps instance
      */
     getMapOptions() {
-        return MapConfig.MAP_OPTIONS;
-    }
+        return MAP_OPTIONS;
+    };
 
     /**
      * Determine rendering mode based on feature support
-     * Terra Draw doesn't support polygons with holes (interior rings), use DeckGL for those
+     * Terra Draw doesn't support:
+     * - Polygons with holes (interior rings)
+     * - 3D coordinates (coordinates with altitude)
+     * Use DeckGL for those cases
      */
     determineRenderingMode(geojson) {
         const geoJson = typeof geojson === 'undefined' ? this.geoJson : geojson;
@@ -172,7 +175,38 @@ export class GoogleMapTerraDrawField extends BaseGoogleMapComponent {
             return false;
         });
 
-        this.state.renderingMode = hasPolygonsWithHoles ? 'deckgl' : 'terra-draw';
+        // Check if any feature has 3D coordinates (altitude/elevation)
+        const has3DCoordinates = geoJson.features.some((feature) => {
+            return this._hasAltitude(feature.geometry);
+        });
+
+        this.state.renderingMode = (hasPolygonsWithHoles || has3DCoordinates) ? 'deckgl' : 'terra-draw';
+    }
+
+    /**
+     * Check if geometry contains 3D coordinates (with altitude)
+     * @param {Object} geometry - GeoJSON geometry object
+     * @returns {boolean} - True if any coordinate has altitude
+     * @private
+     */
+    _hasAltitude(geometry) {
+        if (!geometry || !geometry.coordinates) {
+            return false;
+        }
+
+        const checkCoordinate = (coord) => {
+            // A coordinate with altitude has 3 or more values [lng, lat, alt, ...]
+            if (Array.isArray(coord) && typeof coord[0] === 'number') {
+                return coord.length > 2;
+            }
+            // Recursively check nested arrays
+            if (Array.isArray(coord)) {
+                return coord.some(checkCoordinate);
+            }
+            return false;
+        };
+
+        return checkCoordinate(geometry.coordinates);
     }
 
     validateProps() {

--- a/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js
+++ b/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js
@@ -148,7 +148,7 @@ export class GoogleMapTerraDrawField extends BaseGoogleMapComponent {
      */
     getMapOptions() {
         return MAP_OPTIONS;
-    };
+    }
 
     /**
      * Determine rendering mode based on feature support

--- a/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml
+++ b/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml
@@ -5,37 +5,52 @@
             <InMapSearchPlaces googleMap="googleMap"/>
             <div class="o_google_map_view" id="o_google_map_view" t-ref="map"></div>
             <Geolocate googleMap="googleMap" t-if="state.isMapReady"/>
-            <!-- Readonly Mode Banner for features with holes -->
-            <div class="o_complexity_banner" t-if="state.isMapReady and state.renderingMode === 'deckgl'">
-                <div class="alert alert-warning">
-                    <strong>Readonly Mode:</strong> Features contain polygons with holes (interior rings) which are not supported for editing.
-                </div>
-            </div>
 
-            <t t-if="props.readonly">
-                <!-- Conditional Rendering: DeckGL for complex features -->
-                <DeckGlEditor 
-                    dataGeoJson="geoJson" 
-                    googleMap="googleMap" 
-                    record="props.record" 
-                    t-if="state.isMapReady"/>
+            <t t-if="state.isMapReady">
+                <t t-if="props.readonly">
+                    <!-- Conditional Rendering: DeckGL for complex features -->
+                    <DeckGlEditor 
+                        dataGeoJson="geoJson" 
+                        googleMap="googleMap" 
+                        record="props.record"
+                        saveFeatures.bind="handleSave" 
+                        readonly="props.readonly"/>
+                </t>
+                <t t-elif="!props.readonly &amp;&amp; state.renderingMode === 'terra-draw'">
+                    <!-- Conditional Rendering: Terra Draw for simple features -->
+                    <TerraDrawToolsUI 
+                        dataGeoJson="geoJson" 
+                        googleMap="googleMap" 
+                        saveFeatures.bind="handleSave" 
+                        record="props.record"
+                        renderingMode="state.renderingMode"/>
+                </t>
+                <t t-elif="!props.readonly &amp;&amp; state.renderingMode === 'deckgl'">
+                    <!-- Conditional Rendering: DeckGL for complex features -->
+                    <DeckGlEditor 
+                        dataGeoJson="geoJson" 
+                        googleMap="googleMap" 
+                        record="props.record" 
+                        saveFeatures.bind="handleSave"
+                        renderingMode="state.renderingMode"
+                        readonly="props.readonly"/>
+                </t>
+                <t t-else="">
+                    <DeckGlEditor 
+                        dataGeoJson="geoJson" 
+                        googleMap="googleMap" 
+                        record="props.record" 
+                        saveFeatures.bind="handleSave"
+                        renderingMode="state.renderingMode"
+                        readonly="props.readonly"/>
+                </t>
             </t>
-            <t t-else="">
-                <!-- Conditional Rendering: Terra Draw for simple features -->
-                <TerraDrawToolsUI 
-                    dataGeoJson="geoJson" 
-                    googleMap="googleMap" 
-                    saveFeatures.bind="handleSave" 
-                    record="props.record" 
-                    t-if="state.isMapReady and state.renderingMode === 'terra-draw'"/>
-                
-                <!-- Conditional Rendering: DeckGL for complex features -->
-                <DeckGlEditor 
-                    dataGeoJson="geoJson" 
-                    googleMap="googleMap" 
-                    record="props.record" 
-                    t-if="state.isMapReady and state.renderingMode === 'deckgl'"/>
-            </t>
+        </div>
+        <!-- Readonly Mode Banner for features with holes -->
+        <div class="o_complexity_banner" t-if="state.isMapReady and state.renderingMode === 'deckgl'">
+            <p class="p-0 m-0 text-warning small">
+                *Features contain polygons with holes (interior rings) which are not supported for editing.
+            </p>
         </div>
     </div>
 </templates>

--- a/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml
+++ b/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml
@@ -14,7 +14,8 @@
                         googleMap="googleMap" 
                         record="props.record"
                         saveFeatures.bind="handleSave" 
-                        readonly="props.readonly"/>
+                        readonly="props.readonly"
+                        renderingMode="state.renderingMode"/>
                 </t>
                 <t t-elif="!props.readonly &amp;&amp; state.renderingMode === 'terra-draw'">
                     <!-- Conditional Rendering: Terra Draw for simple features -->
@@ -49,7 +50,7 @@
         <!-- Readonly Mode Banner for features with holes -->
         <div class="o_complexity_banner" t-if="state.isMapReady and state.renderingMode === 'deckgl'">
             <p class="p-0 m-0 text-warning small">
-                *Features contain polygons with holes (interior rings) which are not supported for editing.
+                *Features contain complex geometry (polygon with holes or 3D coordinates) are not supported for editing.
             </p>
         </div>
     </div>

--- a/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml
+++ b/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml
@@ -50,7 +50,7 @@
         <!-- Readonly Mode Banner for features with holes -->
         <div class="o_complexity_banner" t-if="state.isMapReady and state.renderingMode === 'deckgl'">
             <p class="p-0 m-0 text-warning small">
-                *Features contain complex geometry (polygon with holes or 3D coordinates) are not supported for editing.
+                *Features containing complex geometry (polygon with holes or 3D coordinates) are not supported for editing.
             </p>
         </div>
     </div>


### PR DESCRIPTION
Add GeoJSON export functionality to both Terra Draw and Deck.gl editors:
- Download current features as .geojson file with timestamp-based filename
- Automatic removal of internal properties from export
- Filter out system features (midpoints, selection points) from Terra Draw

Add Import/Export toolbar to DeckGlEditor component:
- Upload button for importing GeoJSON files
- Download button (disabled when no data available)
- Styled toolbar matching Terra Draw UI

Add 3D coordinate detection and handling:
- Features with altitude values automatically rendered using Deck.gl
- Added _hasAltitude() helper method for recursive coordinate checking

Improve performance:
- Simplify calculateArea() to pass GeoJSON Feature directly to turf.area()
- Replace expensive JSON.stringify comparison with lightweight fingerprinting
- Add _hasGeoJsonChanged(), _getGeoJsonFingerprint(), _countCoordinates() methods

Remove unused code:
- Remove 17 unused functions from utils.js (~530 lines removed)
- Remove createIconAtlas() and ICON_MAPPING from DeckGlEditor
- Remove window.DEBUG_DECKGL debugging flag

Update documentation:
- Add Import/Export, Rendering Modes, Performance Optimizations sections
- Document area calculation and 3D coordinate support