### PR TITLE
[IMP] web_view_google_map_drawing: Add dataset-level performance analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.4 | Implementation of view "Google Maps" on CRM |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.0 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.8 | Base module for a new view "google_map" |
-| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.8 | Base module for sub view of "google_map" for drawing capability |
+| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.9 | Base module for sub view of "google_map" for drawing capability |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps widget |

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change Log
 
+## 19.0.1.0.9
+### Added
+- **Dataset-Level Performance Analysis**: Automatic detection and routing of large datasets to DeckGL
+  - New `analyzeDatasetPerformance()` function in `geometry_performance_utils.js`
+  - Analyzes total feature count, total vertices, and point-specific counts
+  - Returns recommendation on whether to use DeckGL with detailed reason
+- **New Performance Thresholds**: Added dataset-level limits to `GEOMETRY_PERFORMANCE_CONFIG`
+  - `MAX_FEATURES_FOR_TERRA_DRAW`: 3000 (total feature count limit)
+  - `MAX_TOTAL_VERTICES_FOR_TERRA_DRAW`: 5000 (sum of all vertices across features)
+  - `MAX_POINTS_FOR_TERRA_DRAW`: 5000 (specifically for Point geometries)
+
+### Improved
+- **Automatic Renderer Selection**: Updated `determineRenderingMode()` in `terra_draw.js`
+  - Now checks dataset size limits before checking for polygon holes or 3D coordinates
+  - Logs warning to console when switching to DeckGL due to large dataset
+  - Prevents browser hang when loading 100k+ points or large feature sets
+
+### Fixed
+- **Feature Simplification ID Conflict**: Fixed "Feature could not be found by Google Maps API" error
+  - `simplifySelectedFeature()` now generates a new UUID for simplified features
+  - Prevents Terra Draw adapter conflicts when removing and adding features with same ID
+
+### Technical Details
+- Import `analyzeDatasetPerformance` in `terra_draw.js` from `geometry_performance_utils.js`
+- Dataset analysis runs before polygon hole and 3D coordinate checks (most common performance issue)
+- Point geometries are counted separately as they are lightweight compared to polygons
+
 ## 19.0.1.0.8
 ### Added
 - **GeoJSON Export**: Added export functionality to both Terra Draw and Deck.gl editors

--- a/web_view_google_map_drawing/README.md
+++ b/web_view_google_map_drawing/README.md
@@ -153,7 +153,21 @@ The module uses Turf.js for accurate area calculations:
 
 ## Import/Export GeoJSON
 
-Both Terra Draw and Deck.gl editors support importing and exporting GeoJSON files:
+Both Terra Draw and Deck.gl editors support importing and exporting GeoJSON files.
+
+### Why This Feature Exists
+
+Terra Draw has limitations that may require users to work with external tools:
+- **No support for polygons with holes** (interior rings)
+- **No support for 3D coordinates** (altitude/elevation data)
+- **Performance limits** with large datasets (3000+ features or 5000+ vertices)
+- **Limited advanced editing** capabilities compared to dedicated GIS software
+
+The Import/Export feature allows you to:
+- Create complex geometries in professional GIS tools (QGIS, ArcGIS, geojson.io) and import them
+- Export data for use in other mapping platforms or GIS applications
+- Back up your geospatial data in a standard, interoperable format
+- Share GeoJSON data with team members or external systems
 
 ### Import
 - Click the **Upload** button (↑) to import a GeoJSON file
@@ -166,7 +180,7 @@ Both Terra Draw and Deck.gl editors support importing and exporting GeoJSON file
 - The exported file is named `geojson_export_YYYY-MM-DD.geojson`
 - Internal properties (mode, midPoint, selectionPoint, _metadata) are automatically removed from the export
 
-This functionality allows easy data exchange with other GIS tools and platforms.
+This functionality enables seamless data exchange with other GIS tools and platforms, overcoming Terra Draw's inherent limitations.
 
 ## Rendering Modes
 
@@ -177,12 +191,12 @@ The module automatically selects the appropriate rendering engine based on geome
 | Simple polygons without holes | Terra Draw | Full editing capabilities |
 | Polygons with holes (interior rings) | Deck.gl | Terra Draw doesn't support holes |
 | 3D coordinates (with altitude) | Deck.gl | Terra Draw doesn't support 3D |
-| Very complex features | Deck.gl | Better performance for large datasets |
+| Large datasets (3000+ features, 5000+ vertices, or 5000+ points) | Deck.gl | Prevents browser freezing |
 
 ## Known issues and limitations
 - Terra Draw doesn't support GeoJSON with holes or interior rings. Such GeoJSON will be rendered in read-only mode using Deck.gl.
 - Terra Draw doesn't support 3D coordinates (coordinates with altitude values). Such GeoJSON will be rendered using Deck.gl.
-- Editing very large GeoJSON data may lead to performance issues. Use the "Simplify Selected Feature" button in the drawing toolbar to reduce complexity, but be aware that this may result in a loss of detail.
+- Large datasets are automatically routed to Deck.gl for display. For individual complex features within Terra Draw, use the "Simplify Selected Feature" button to reduce complexity, but be aware that this may result in a loss of detail.
 - Resize the browser window may cause the map to not render properly. To fix this issue, you can refresh the browser page.
 - GeoJSON file import is limited to 5MB file size.
 
@@ -190,6 +204,7 @@ The module automatically selects the appropriate rendering engine based on geome
 
 The module includes several performance optimizations for handling large GeoJSON datasets:
 
+- **Automatic Renderer Selection**: Datasets exceeding performance thresholds (3000+ features, 5000+ vertices, or 5000+ points) are automatically routed to Deck.gl
 - **Chunked Processing**: Large feature sets are processed in chunks of 50 features to prevent UI blocking
 - **Lightweight Change Detection**: Uses fingerprinting (geometry type + coordinate count) instead of full JSON comparison
 - **Debounced Rendering**: Rendering operations are debounced to prevent excessive re-renders

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.8',
+    'version': '1.0.9',
     'depends': ['web_view_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map_drawing/static/src/utils/geometry_performance_utils.js
+++ b/web_view_google_map_drawing/static/src/utils/geometry_performance_utils.js
@@ -13,6 +13,8 @@ import { sprintf } from '@web/core/utils/strings';
 
 /**
  * Performance configuration constants
+ * Note: These values are tuned for Terra Draw performance
+ * and may need adjustment based on real-world usage.
  */
 export const GEOMETRY_PERFORMANCE_CONFIG = {
     MAX_VERTICES_FOR_EDITING: 150,      // Safe editing threshold for Terra Draw
@@ -26,6 +28,11 @@ export const GEOMETRY_PERFORMANCE_CONFIG = {
     // Special handling for geographic boundary data
     GEOGRAPHIC_BOUNDARY_THRESHOLD: 150, // Specific threshold for province/country boundaries
     GEOGRAPHIC_SIMPLIFICATION_TOLERANCE: 0.008, // Optimized for coastlines and borders
+
+    // Dataset-level limits for automatic DeckGL routing
+    MAX_FEATURES_FOR_TERRA_DRAW: 3000,          // Total feature count limit
+    MAX_TOTAL_VERTICES_FOR_TERRA_DRAW: 5000,    // Sum of all vertices across features
+    MAX_POINTS_FOR_TERRA_DRAW: 5000,            // Specifically for Point geometries (lightweight)
 };
 
 /**
@@ -132,6 +139,75 @@ export function analyzeFeaturePerformance(feature) {
         isVeryComplex,
         recommendedAction,
         estimatedProcessingTime: Math.ceil(vertexCount / 1000) * 100, // Rough estimate in ms
+    };
+}
+
+/**
+ * Analyze an entire dataset to determine if it should use DeckGL instead of Terra Draw
+ * This checks total feature count, total vertices, and point-specific limits
+ * @param {Array} features - Array of GeoJSON features
+ * @returns {Object} Dataset analysis with recommendation
+ */
+export function analyzeDatasetPerformance(features) {
+    if (!features || !Array.isArray(features)) {
+        return {
+            totalFeatures: 0,
+            totalVertices: 0,
+            pointCount: 0,
+            shouldUseDeckGL: false,
+            reason: null,
+        };
+    }
+
+    let totalVertices = 0;
+    let pointCount = 0;
+
+    for (const feature of features) {
+        if (!feature?.geometry) continue;
+
+        const vertexCount = getVertexCount(feature.geometry);
+        totalVertices += vertexCount;
+
+        if (feature.geometry.type === 'Point') {
+            pointCount += 1;
+        } else if (feature.geometry.type === 'MultiPoint') {
+            pointCount += feature.geometry.coordinates.length;
+        }
+    }
+
+    const totalFeatures = features.length;
+    let shouldUseDeckGL = false;
+    let reason = null;
+
+    if (totalFeatures > GEOMETRY_PERFORMANCE_CONFIG.MAX_FEATURES_FOR_TERRA_DRAW) {
+        shouldUseDeckGL = true;
+        reason = sprintf(
+            _t('%s features exceeds limit of %s'),
+            totalFeatures,
+            GEOMETRY_PERFORMANCE_CONFIG.MAX_FEATURES_FOR_TERRA_DRAW
+        );
+    } else if (totalVertices > GEOMETRY_PERFORMANCE_CONFIG.MAX_TOTAL_VERTICES_FOR_TERRA_DRAW) {
+        shouldUseDeckGL = true;
+        reason = sprintf(
+            _t('%s total vertices exceeds limit of %s'),
+            totalVertices,
+            GEOMETRY_PERFORMANCE_CONFIG.MAX_TOTAL_VERTICES_FOR_TERRA_DRAW
+        );
+    } else if (pointCount > GEOMETRY_PERFORMANCE_CONFIG.MAX_POINTS_FOR_TERRA_DRAW) {
+        shouldUseDeckGL = true;
+        reason = sprintf(
+            _t('%s points exceeds limit of %s'),
+            pointCount,
+            GEOMETRY_PERFORMANCE_CONFIG.MAX_POINTS_FOR_TERRA_DRAW
+        );
+    }
+
+    return {
+        totalFeatures,
+        totalVertices,
+        pointCount,
+        shouldUseDeckGL,
+        reason,
     };
 }
 

--- a/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
+++ b/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js
@@ -1164,16 +1164,20 @@ export class TerraDrawToolsUI extends Component {
             if (editableResult && editableResult.isSimplified) {
                 const simplifiedFeature = editableResult.feature;
 
+                // Generate a new ID for the simplified feature to avoid conflicts
+                // Terra Draw's Google Maps adapter may have issues when removing and
+                // adding a feature with the same ID in quick succession
+                const newFeatureId = generateUUID();
+                simplifiedFeature.id = newFeatureId;
+
                 // Replace the original feature with the simplified version
                 this.terraDrawInstance.removeFeatures([this.state.selectedFeatureId]);
                 this.terraDrawInstance.addFeatures([simplifiedFeature]);
 
                 // Update selection to the new feature
                 setTimeout(() => {
-                    if (simplifiedFeature.id) {
-                        this.terraDrawInstance.selectFeature(simplifiedFeature.id);
-                        this.setSelectedFeatureId(simplifiedFeature.id);
-                    }
+                    this.terraDrawInstance.selectFeature(newFeatureId);
+                    this.setSelectedFeatureId(newFeatureId);
                 }, 100);
 
                 const iterationsInfo = editableResult.iterations ? ` in ${editableResult.iterations} iteration(s)` : '';

--- a/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js
+++ b/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js
@@ -16,6 +16,7 @@ import { GoogleMapSearchPlaces } from '@web_view_google_map/views/google_map/com
 import { TerraDrawToolsUI } from '../../views/components/terra-tools-ui/terra-tools-ui';
 import { DeckGlEditor } from '../../views/components/deck-gl-editor/deck-gl-editor';
 import { MAP_OPTIONS } from '../../utils/map_config';
+import { analyzeDatasetPerformance } from '../../utils/geometry_performance_utils';
 
 
 export class GoogleMapTerraDrawField extends BaseGoogleMapComponent {
@@ -151,17 +152,27 @@ export class GoogleMapTerraDrawField extends BaseGoogleMapComponent {
     }
 
     /**
-     * Determine rendering mode based on feature support
+     * Determine rendering mode based on feature support and performance
      * Terra Draw doesn't support:
      * - Polygons with holes (interior rings)
      * - 3D coordinates (coordinates with altitude)
+     * - Large datasets (3000+ features, 5000+ vertices, 5000+ points)
      * Use DeckGL for those cases
+     * @param {Object} [geojson] - Optional GeoJSON object to analyze. If not provided, uses this.geoJson
      */
     determineRenderingMode(geojson) {
         const geoJson = typeof geojson === 'undefined' ? this.geoJson : geojson;
 
         if (!geoJson?.features?.length) {
             this.state.renderingMode = 'terra-draw';
+            return;
+        }
+
+        // Check dataset size limits first (most common performance issue)
+        const datasetAnalysis = analyzeDatasetPerformance(geoJson.features);
+        if (datasetAnalysis.shouldUseDeckGL) {
+            console.warn(`Large dataset detected, switching to DeckGL: ${datasetAnalysis.reason}`);
+            this.state.renderingMode = 'deckgl';
             return;
         }
 


### PR DESCRIPTION
Add automatic detection and routing of large datasets to DeckGL to prevent browser freezing when loading 100k+ points or large feature sets.

Changes:
- Add analyzeDatasetPerformance() function to analyze total features, vertices, and point counts
- Add new thresholds: MAX_FEATURES (3000), MAX_TOTAL_VERTICES (5000), MAX_POINTS (5000)
- Update determineRenderingMode() to check dataset limits first
- Fix simplifySelectedFeature() ID conflict causing "Feature could not be found by Google Maps API" error
- Update README with "Why This Feature Exists" section for Import/Export
- Update documentation with specific performance thresholds