### PR TITLE
Enhance Google Maps view and Google Place Autocomplete widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.3 | Base module of Google Maps widget |
-| [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.5 | Implementation of Google Places Autocomplete Element |
+| [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.6 | Implementation of Google Places Autocomplete Element |
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.10 | Base module for sub view of "google_map" for drawing capability |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
-| [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.2 | Base module of Google Maps widget |
+| [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.3 | Base module of Google Maps widget |
 | [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.5 | Implementation of Google Places Autocomplete Element |
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [contacts_google_map](/contacts_google_map/README.md) | 19.0.1.0.3 | Implementation of view "Google Maps" on Contacts |
 | [crm_google_autocomplete](/crm_google_autocomplete/README.md) | 19.0.1.0.1 | Implementation of Google Places Autocomplete on CRM Leads/Opportunities |
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.4 | Implementation of view "Google Maps" on CRM |
-| [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.2 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
+| [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.3 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.9 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.10 | Base module for sub view of "google_map" for drawing capability |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [crm_google_autocomplete](/crm_google_autocomplete/README.md) | 19.0.1.0.1 | Implementation of Google Places Autocomplete on CRM Leads/Opportunities |
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.4 | Implementation of view "Google Maps" on CRM |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.3 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
-| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.9 | Base module for a new view "google_map" |
+| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.10 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.10 | Base module for sub view of "google_map" for drawing capability |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |

--- a/partner_autocomplete_with_google_autocomplete/README.md
+++ b/partner_autocomplete_with_google_autocomplete/README.md
@@ -2,6 +2,8 @@
 
 The `partner_autocomplete_with_google_autocomplete` module integrates [Google Places Autocomplete Element](https://developers.google.com/maps/documentation/javascript/place-autocomplete-new) with Odoo's partner autocomplete feature. It enhances the partner creation experience by combining Odoo's standard partner autocomplete with Google Places data.
 
+This module extends `web_widget_google_place_autocomplete`. The widget `partner_autocomplete_with_gplace` is a drop-in replacement for the `gplace_autocomplete_el` widget, inheriting all of its functionality and options.
+
 ## Features
 - Enhanced partner autocomplete using Google Places API
 - Automatic population of address fields (street, city, state, zip, country) based on selected place
@@ -13,6 +15,3 @@ The `partner_autocomplete_with_google_autocomplete` module integrates [Google Pl
 2. Use the partner autocomplete feature in forms - it will now be enhanced with Google Places data
 3. Create new partners more easily with accurate address information from Google Places
 4. Places API (New) must be enabled in your Google Cloud Console for the autocomplete functionality to work properly.
-
-## Authors
-- [Yopi Angi](https://www.github.com/gityopie)

--- a/partner_autocomplete_with_google_autocomplete/__manifest__.py
+++ b/partner_autocomplete_with_google_autocomplete/__manifest__.py
@@ -12,7 +12,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.2',
+    'version': '1.0.3',
     'depends': ['partner_autocomplete', 'contacts_google_autocomplete'],
     'assets': {
         'web.assets_backend': [

--- a/partner_autocomplete_with_google_autocomplete/i18n/partner_autocomplete_with_google_autocomplete.pot
+++ b/partner_autocomplete_with_google_autocomplete/i18n/partner_autocomplete_with_google_autocomplete.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-27 10:48+0000\n"
-"PO-Revision-Date: 2025-10-27 10:48+0000\n"
+"POT-Creation-Date: 2026-03-04 09:24+0000\n"
+"PO-Revision-Date: 2026-03-04 09:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,6 +18,11 @@ msgstr ""
 #. module: partner_autocomplete_with_google_autocomplete
 #: model:ir.model,name:partner_autocomplete_with_google_autocomplete.model_res_partner
 msgid "Contact"
+msgstr ""
+
+#. module: partner_autocomplete_with_google_autocomplete
+#: model:ir.model,website_form_label:partner_autocomplete_with_google_autocomplete.model_res_partner
+msgid "Create a Customer"
 msgstr ""
 
 #. module: partner_autocomplete_with_google_autocomplete
@@ -38,8 +43,24 @@ msgid "Google Autocomplete"
 msgstr ""
 
 #. module: partner_autocomplete_with_google_autocomplete
+#. odoo-javascript
+#: code:addons/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js:0
+msgid ""
+"Google Place Autocomplete widget requires a mapping code or mapping mode to "
+"function properly. Please check the configuration."
+msgstr ""
+
+#. module: partner_autocomplete_with_google_autocomplete
 #: model:ir.model.fields,field_description:partner_autocomplete_with_google_autocomplete.field_res_partner__id
 msgid "ID"
+msgstr ""
+
+#. module: partner_autocomplete_with_google_autocomplete
+#. odoo-javascript
+#: code:addons/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js:0
+msgid ""
+"Invalid mapping mode: \"${this.props.mappingMode}\" for Google Place "
+"Autocomplete widget"
 msgstr ""
 
 #. module: partner_autocomplete_with_google_autocomplete
@@ -51,5 +72,27 @@ msgstr ""
 #. module: partner_autocomplete_with_google_autocomplete
 #. odoo-javascript
 #: code:addons/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js:0
+msgid ""
+"No valid mapping configuration found for Google Place Autocomplete. Please "
+"check the settings."
+msgstr ""
+
+#. module: partner_autocomplete_with_google_autocomplete
+#. odoo-javascript
+#: code:addons/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.xml:0
+msgid "No valid mapping configuration found."
+msgstr ""
+
+#. module: partner_autocomplete_with_google_autocomplete
+#. odoo-javascript
+#: code:addons/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js:0
 msgid "Partner Autocomplete with Google Place"
+msgstr ""
+
+#. module: partner_autocomplete_with_google_autocomplete
+#. odoo-javascript
+#: code:addons/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js:0
+msgid ""
+"This field is read-only because manual edits are disabled. Please use the "
+"Google Place Autocomplete to update the value."
 msgstr ""

--- a/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js
+++ b/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js
@@ -59,16 +59,22 @@ export class PartnerAutoCompleteCharFieldWithGooglePlace extends PartnerAutoComp
         this.mappingConfig = {};
 
         useEffect(
-            (inputRef, noManualEdit, readonly) => {
-                if (inputRef.el && !readonly) {
-                    if (noManualEdit) {
-                        inputRef.el.setAttribute('readonly', 'readonly');
-                    } else {
-                        inputRef.el.removeAttribute('readonly');
-                    }
+            () => {
+                if (this.inputRef.el && !this.props.readonly && this.props.noManualEdit) {
+                    this.inputRef.el.setAttribute('readonly', 'readonly');
+                    this.inputRef.el.setAttribute(
+                        'data-tooltip',
+                        _t('This field is read-only because manual edits are disabled. Please use the Google Place Autocomplete to update the value.')
+                    );
                 }
+                return () => {
+                    if (this.inputRef.el) {
+                        this.inputRef.el.removeAttribute('readonly');
+                        this.inputRef.el.removeAttribute('data-tooltip');
+                    }
+                };
             },
-            () => [this.inputRef, this.props.noManualEdit, this.props.readonly]
+            () => [this.inputRef.el, this.props.noManualEdit, this.props.readonly]
         );
 
         onWillUnmount(() => {

--- a/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js
+++ b/partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js
@@ -1,7 +1,8 @@
 import { registry } from '@web/core/registry';
 import { _t } from '@web/core/l10n/translation';
 import { useService } from '@web/core/utils/hooks';
-import { useState, useRef, onWillUnmount, onWillUpdateProps } from '@odoo/owl';
+import { exprToBoolean } from '@web/core/utils/strings';
+import { useState, useRef, onWillUnmount, onWillUpdateProps, useEffect } from '@odoo/owl';
 import { PartnerAutoCompleteCharField, partnerAutoCompleteCharField } from '@partner_autocomplete/js/partner_autocomplete_fieldchar';
 import { useGooglePlaceAutocompleteMapping } from '@web_widget_google_place_autocomplete/hooks/use_google_place_autocomplete_mapping';
 import { GooglePlaceAutocompleteElement } from '@web_widget_google_place_autocomplete/component/google_place_autocomplete';
@@ -36,6 +37,7 @@ export class PartnerAutoCompleteCharFieldWithGooglePlace extends PartnerAutoComp
         ...PartnerAutoCompleteCharField.props,
         mappingCode: { type: String, optional: true },
         mappingMode: { type: String, optional: true },
+        noManualEdit: { type: Boolean, optional: true }, // If true, the input field will be set to readonly to prevent manual edits. Other fields will still be populated based on the autocomplete selection. Default is false (manual edits allowed).
     };
 
     /**
@@ -55,6 +57,19 @@ export class PartnerAutoCompleteCharFieldWithGooglePlace extends PartnerAutoComp
         this.placeMapping = useGooglePlaceAutocompleteMapping();
         this.widgetId = this.placeMapping.getUniqueWidgetId();
         this.mappingConfig = {};
+
+        useEffect(
+            (inputRef, noManualEdit, readonly) => {
+                if (inputRef.el && !readonly) {
+                    if (noManualEdit) {
+                        inputRef.el.setAttribute('readonly', 'readonly');
+                    } else {
+                        inputRef.el.removeAttribute('readonly');
+                    }
+                }
+            },
+            () => [this.inputRef, this.props.noManualEdit, this.props.readonly]
+        );
 
         onWillUnmount(() => {
             this.closeGoogleAutocomplete();
@@ -255,6 +270,7 @@ export const partnerAutoCompleteCharFieldWithGooglePlace = {
         ...partnerAutoCompleteCharField.extractProps({ attrs, options, placeholder }),
         mappingCode: options.mapping_code,
         mappingMode: options.mapping_mode || 'places',
+        noManualEdit: exprToBoolean(options.no_manual_edit, false),
     }),
 };
 

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## 19.0.1.0.10
+
+### Added
+
+- **Pin-style Markers with Letter Glyphs**: Map markers now use Google's native `PinElement` instead of custom HTML elements. Each pin displays the first letter of the record's title as a glyph, giving a cleaner, map-native appearance.
+- **Styled Place Search Marker**: The place search result is now shown as a distinctive orange teardrop marker with a search icon, making it easy to distinguish from record markers.
+
+### Improved
+
+- **Selected Marker Feedback**: Selected markers now scale up (1.4×) and highlight with a blue border (`#4285F4`), making the active record immediately obvious on the map.
+- **Default Zoom Level**: Reduced the default zoom level when panning to a marker from 17 to 15 for better spatial context.
+- **Color Processing**: `processColor()` was refactored for cleaner null/undefined handling. `normalizeColor()` now returns immediately for hex colors without unnecessary DOM manipulation, improving performance.
+
+### Fixed
+
+- **Marker Click Event**: Changed marker event listener from the deprecated `click` to `gmp-click`, which is the correct event for `AdvancedMarkerElement`.
+- **Color Field Bug**: Fixed a bug in `parseRecord()` where `normalizeColor()` was incorrectly called with the field name instead of the actual color value, causing markers to always fall back to the default color.
+
 ## 19.0.1.0.9
 
 ### Removed

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.9',
+    'version': '1.0.10',
     'depends': ['base_google_map'],
     'data': [],
     'assets': {

--- a/web_view_google_map/static/src/views/google_map/components/search_places/search_places.js
+++ b/web_view_google_map/static/src/views/google_map/components/search_places/search_places.js
@@ -82,8 +82,15 @@ export class GoogleMapSearchPlaces extends Component {
                         this.props.googleMap.controls[
                             google.maps.ControlPosition.TOP_RIGHT
                         ].push(this.searchRef.el);
+
+                        const markerContent = document.createElement('div');
+                        markerContent.className = 'places-search-marker';
+                        const icon = document.createElement('i');
+                        icon.className = 'fa fa-search';
+                        markerContent.appendChild(icon);
                         this.markerPlacesSearch = new AdvancedMarkerElement({
                             map: this.props.googleMap,
+                            content: markerContent,
                         });
                         this.markerInfoWindow = new google.maps.InfoWindow();
                         this._boundHandlePlaceSelect = this.debouncedHandlePlaceSelect.bind(this);

--- a/web_view_google_map/static/src/views/google_map/components/search_places/search_places.scss
+++ b/web_view_google_map/static/src/views/google_map/components/search_places/search_places.scss
@@ -1,3 +1,23 @@
+.places-search-marker {
+    background: #FF6F00;
+    border: 2px solid darken(#FF6F00, 15%);
+    border-radius: 50% 50% 50% 0;
+    transform: rotate(-45deg);
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+
+    i {
+        transform: rotate(45deg);
+        color: #FFFFFF;
+        font-size: 14px;
+    }
+}
+
 .o_google_map_view {
     .google_search_places {
         margin-top: 10px;

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -14,6 +14,7 @@ import { GoogleMapGeolocate } from './components/geolocate/geolocate';
 import { GoogleMapSearchPlaces } from './components/search_places/search_places';
 import {
     darkenColor,
+    lightenColor,
     AdvancedMarkerBoxSelector,
     getRecordDataView,
 } from './utils';
@@ -46,10 +47,13 @@ const MARKER_CONFIG = {
             BORDER: '2px solid #fafafa',
         },
         ZOOM: {
-            DEFAULT: 17,
+            DEFAULT: 15,
             SHIFTED_DETAIL: 22,
         },
         TILT: 65,
+        DEFAULT_SCALE: 1,
+        SELECTED_SCALE: 1.4,
+        SELECTED_COLOR: '#4285F4',
     },
     BOUNDS: {
         DEFAULT_PADDING: 200,
@@ -610,7 +614,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
     }
 
     _handleAfterZoomAtMarker(marker) {
-        google.maps.event.trigger(marker, 'click');
+        google.maps.event.trigger(marker, 'gmp-click');
         const { ZOOM, TILT } = MARKER_CONFIG.VISUAL;
         this.googleMap.setTilt(TILT);
         if (this.googleMap.getZoom() < ZOOM.DEFAULT) {
@@ -814,7 +818,12 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
     async _selectMarker(marker) {
         if (!marker || !this.isMapLoaded()) return;
 
-        marker.content.className = this.markerSelectedClass;
+        if (marker._pin) {
+            marker._pin.scale = MARKER_CONFIG.VISUAL.SELECTED_SCALE;
+            marker._pin.borderColor = MARKER_CONFIG.VISUAL.SELECTED_COLOR;
+        } else {
+            marker.content.className = this.markerSelectedClass;
+        }
 
         try {
             // Center map on marker
@@ -833,7 +842,12 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
     async _deselectMarker(marker) {
         if (!marker || !this.isMapLoaded()) return;
 
-        marker.content.className = this.markerDefaultClass;
+        if (marker._pin) {
+            marker._pin.scale = MARKER_CONFIG.VISUAL.DEFAULT_SCALE;
+            marker._pin.borderColor = marker._elementValues?.borderColor;
+        } else {
+            marker.content.className = this.markerDefaultClass;
+        }
 
         try {
             // Center map on marker
@@ -1208,12 +1222,30 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      * @returns {Object} AdvancedMarkerElement
      */
     async _buildAdvancedMarker(record, geolocation, data, elementValues) {
-        const { AdvancedMarkerElement } = await this.apiLoader.importLibrary('marker');
-        const content = this._createMarkerElement(record, elementValues);
+        const { AdvancedMarkerElement, PinElement } = await this.apiLoader.importLibrary('marker');
+        const pinElOptions = {
+            background: elementValues.background,
+            borderColor: elementValues.borderColor,
+            glyphColor: elementValues.glyphColor,
+            scale: MARKER_CONFIG.VISUAL.DEFAULT_SCALE,
+        };
+        if (data.title) {
+            pinElOptions.glyphText = data.title.charAt(0).toUpperCase();
+            if (pinElOptions.glyphColor) {
+                pinElOptions.glyphColor = lightenColor(pinElOptions.glyphColor, 0.9);
+            }
+        }
+        if (record.selected) {
+            pinElOptions.scale = MARKER_CONFIG.VISUAL.SELECTED_SCALE;
+            pinElOptions.borderColor = MARKER_CONFIG.VISUAL.SELECTED_COLOR;
+        }
+        const pin = new PinElement(pinElOptions);
         const options = this._createMarkerOptions(geolocation, data);
-        options.content = content;
-        
-        return new AdvancedMarkerElement(options);
+        options.content = pin;
+
+        const marker = new AdvancedMarkerElement(options);
+        marker._pin = pin;
+        return marker;
     }
 
     /**
@@ -1249,7 +1281,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      */
     _attachMarkerEventListeners(marker, record) {
         const clickListener = marker.addListener(
-            'click',
+            'gmp-click',
             this._handleMarkerClick.bind(this, marker)
         );
         this._storeMarkerEventListener(record.id, 'click', clickListener);
@@ -1420,24 +1452,6 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      */
     _attachConnectionLineToMarker(marker, line) {
         marker._connectionLine = line;
-    }
-
-    /**
-     * Enhanced marker element creation with configuration
-     * @private
-     * @param {Object} record Record data
-     * @param {Object} elementValues Values for marker styling
-     * @returns {HTMLElement} Marker content element
-     */
-    _createMarkerElement(record, elementValues) {
-        const content = document.createElement('div');
-        const { MARKER } = MARKER_CONFIG.VISUAL;
-        
-        content.className = record.selected ? MARKER.SELECTED_CLASS : MARKER.DEFAULT_CLASS;
-        content.style.background = elementValues.background;
-        content.style.border = MARKER.BORDER;
-        
-        return content;
     }
 
     /**

--- a/web_view_google_map/static/src/views/google_map/utils.js
+++ b/web_view_google_map/static/src/views/google_map/utils.js
@@ -224,34 +224,57 @@ export function getRecordDataView(record, viewAttrs) {
     return dataView;
 }
 
+// Module-level cache — avoids repeated DOM reflows for the same color value
+const _normalizeColorCache = new Map();
+
 export function normalizeColor(color) {
-    // If already a hex color, return immediately without DOM manipulation
-    if (/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(color)) {
-        return color.toUpperCase();
+    // Return cached result if available
+    if (_normalizeColorCache.has(color)) {
+        return _normalizeColorCache.get(color);
     }
 
-    // Create a temporary element to leverage the browser's color parsing
-    let tempElement = document.createElement('div');
+    // Expand 3-digit hex → 6-digit before returning
+    if (/^#[0-9A-Fa-f]{3}$/.test(color)) {
+        const expanded = `#${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}`.toUpperCase();
+        _normalizeColorCache.set(color, expanded);
+        return expanded;
+    }
+
+    // 6-digit hex: return immediately without DOM manipulation
+    if (/^#[0-9A-Fa-f]{6}$/.test(color)) {
+        const upper = color.toUpperCase();
+        _normalizeColorCache.set(color, upper);
+        return upper;
+    }
+
+    // Use the browser's color parser via a temporary element
+    const tempElement = document.createElement('div');
     tempElement.style.color = color;
     document.body.appendChild(tempElement);
 
-    // Get the computed color in RGB format
-    let computedColor = window.getComputedStyle(tempElement).color;
-    document.body.removeChild(tempElement);
-
-    // Extract the RGB components
-    let rgbMatch = computedColor.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
-    if (rgbMatch) {
-        let r = parseInt(rgbMatch[1]);
-        let g = parseInt(rgbMatch[2]);
-        let b = parseInt(rgbMatch[3]);
-
-        // Convert RGB to hex
-        return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1).toUpperCase();
+    let computedColor;
+    try {
+        computedColor = window.getComputedStyle(tempElement).color;
+    } finally {
+        document.body.removeChild(tempElement);
     }
 
-    // If the input is already in hex format, return it as is
-    return color;
+    // Match both rgb(...) and rgba(...) — handles transparent and alpha colors
+    const rgbMatch = computedColor.match(
+        /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)$/
+    );
+    if (rgbMatch) {
+        const r = parseInt(rgbMatch[1]);
+        const g = parseInt(rgbMatch[2]);
+        const b = parseInt(rgbMatch[3]);
+        const hex = '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1).toUpperCase();
+        _normalizeColorCache.set(color, hex);
+        return hex;
+    }
+
+    // Fallback: browser could not parse the color — return safe default
+    _normalizeColorCache.set(color, DEFAULT_COLOR);
+    return DEFAULT_COLOR;
 }
 
 export function generateColor() {

--- a/web_view_google_map/static/src/views/google_map/utils.js
+++ b/web_view_google_map/static/src/views/google_map/utils.js
@@ -85,18 +85,21 @@ export function getCurrentActionId() {
  * @returns {string|null} - Normalized color value or null
  */
 export function processColor(color) {
-    let marker_color;
-    if (typeof color === 'number') {
-        marker_color = getHexColorPicker(color);
-    } else if (/(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:rgb|hsl)a?\([^\)]*\)/gi.test(color)) {
-        marker_color = color;
-    } else if (color && !marker_color) {
-        marker_color = normalizeColor(color);
+    let markerColor = null;
+    if (color !== undefined && color !== null) {
+        if (typeof color === 'number') {
+            markerColor = getHexColorPicker(color);
+        } else if (typeof color === 'string' && /(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:rgb|hsl)a?\([^\)]*\)/gi.test(color)) {
+            markerColor = color;
+        }
+        if (!markerColor) {
+            markerColor = normalizeColor(color);
+        }
     }
-    if (!marker_color) {
-        marker_color = DEFAULT_COLOR;
+    if (!markerColor) {
+        markerColor = DEFAULT_COLOR;
     }
-    return marker_color;
+    return markerColor;
 }
 
 /**
@@ -197,7 +200,7 @@ export function parseRecord(record, viewConfig = {}, isGrouped = false) {
             const color = record.data[otherFields.__geoColor];
             if (typeof color === 'string' || (!color && typeof color !== 'number')) {
                 try {
-                    other['__geoColor'] = normalizeColor(otherFields.__geoColor);                    
+                    other['__geoColor'] = normalizeColor(color);
                 } catch (error) {
                     console.warn('Failed to normalize color, using default color.', error);
                     other['__geoColor'] = DEFAULT_COLOR;
@@ -222,6 +225,11 @@ export function getRecordDataView(record, viewAttrs) {
 }
 
 export function normalizeColor(color) {
+    // If already a hex color, return immediately without DOM manipulation
+    if (/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(color)) {
+        return color.toUpperCase();
+    }
+
     // Create a temporary element to leverage the browser's color parsing
     let tempElement = document.createElement('div');
     tempElement.style.color = color;

--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 19.0.1.0.3
+
+### Added
+
+- **Place Search in Geolocation Dialog**: The geolocation edit dialog (the interactive map opened when editing latitude/longitude on a form view) now includes the in-map place search component. Users can search for a location directly inside the dialog and the map pans to the result.
+
+### Fixed
+
+- **URL Construction**: `generateSrc()` now uses the `URL` class to build the Google Maps Embed URL, ensuring query parameters are always correctly encoded.
+
+### Dependencies
+
+- Added `web_view_google_map` as a module dependency to support the place search integration.
+
 ## 19.0.1.0.2
 Fixed bug where updating (clicking the "edit" button below Google Maps view in form view) a record's geolocation in form view opened in a pop-up window caused an error.
 

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -12,8 +12,8 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.2',
-    'depends': ['base_google_map'],
+    'version': '1.0.3',
+    'depends': ['base_google_map', 'web_view_google_map'],
     'assets': {
         'web.assets_backend': [
             'web_widget_google_map/static/src/widgets/**/*',

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
@@ -4,10 +4,11 @@ import { sprintf } from '@web/core/utils/strings';
 import { useService } from '@web/core/utils/hooks';
 import { standardWidgetProps } from '@web/views/widgets/standard_widget_props';
 import { rpc } from '@web/core/network/rpc';
-import { Component, onWillStart, useRef, useEffect, useState, onWillUnmount } from '@odoo/owl';
+import { Component, onWillStart, useRef, useEffect, useState, onWillUnmount, useSubEnv } from '@odoo/owl';
 
 import { ConfirmationDialog } from '@web/core/confirmation_dialog/confirmation_dialog';
 import { useGoogleMapsAPILoader } from '@base_google_map/utils/loader_google_map';
+import { GoogleMapSearchPlaces } from '@web_view_google_map/views/google_map/components/search_places/search_places';
 
 /**
  * Dialog component for editing geolocation coordinates with an interactive Google Map.
@@ -17,6 +18,10 @@ import { useGoogleMapsAPILoader } from '@base_google_map/utils/loader_google_map
  */
 class GeolocationEditDialog extends ConfirmationDialog {
     static template = 'web_widget_google_map.GeolocationEditDialog';
+    static components = {
+        ...ConfirmationDialog.components,
+        GoogleMapSearchPlaces,
+    };
     static props = {
         ...ConfirmationDialog.props,
         confirm: Function,
@@ -46,7 +51,7 @@ class GeolocationEditDialog extends ConfirmationDialog {
         this.localLat = this.props.lat || 0.0;
         this.localLng = this.props.lng || 0.0;
 
-        this.state = useState({ isGoogleLoaded: false });
+        this.state = useState({ isGoogleLoaded: false, isMapReady: false });
 
         this.apiLoader = useGoogleMapsAPILoader(
             () => {
@@ -69,6 +74,12 @@ class GeolocationEditDialog extends ConfirmationDialog {
             },
             () => [this.state.isGoogleLoaded, this.mapRef]
         );
+
+        useSubEnv({
+            mapState: this.state,
+            apiLoader: this.apiLoader,
+            googleMap: () => this.googleMap,
+        });
 
         onWillUnmount(this._cleanupListeners.bind(this));
     }
@@ -142,6 +153,7 @@ class GeolocationEditDialog extends ConfirmationDialog {
                 resolve();
             });
         });
+        this.state.isMapReady = true;
         this.renderMarker();
     }
 
@@ -374,8 +386,10 @@ export class GoogleMapWidget extends Component {
      */
     generateSrc(api_key) {
         const params = { ...this.params, key: api_key };
+        const url = new URL(this.baseUrl);
         const searchParams = new URLSearchParams(params);
-        return `${this.baseUrl}?${searchParams.toString()}`;
+        url.search = searchParams.toString();
+        return url.toString();
     }
 
     /**

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
@@ -14,6 +14,7 @@
         <div class="o_google_map_form" >
             <div class="o_google_map_renderer">
                 <div class="o_google_map_view" t-ref="map"></div>
+                <GoogleMapSearchPlaces googleMap="googleMap" t-if="state.isMapReady"/>
             </div>
         </div>
         <t t-set-slot="footer">

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
@@ -5,7 +5,7 @@
             <div class="o_google_map_widget" t-if="iframeSrc">
                 <iframe t-att-width="props.width" t-att-height="props.height" frameborder="0" style="border:0" referrerpolicy="no-referrer-when-downgrade" t-att-src="iframeSrc" allowfullscreen="allowfullscreen"></iframe>
             </div>
-            <button type="button" class="btn btn-light" t-on-click="handleOnEdit" t-att-disabled="props.readonly">Edit</button>
+            <button type="button" class="btn btn-light" t-on-click="handleOnEdit" t-if="!props.readonly">Edit</button>
         </div>
     </t>
     <t t-name="web_widget_google_map.GeolocationEditDialog">

--- a/web_widget_google_place_autocomplete/CHANGELOG.md
+++ b/web_widget_google_place_autocomplete/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 19.0.1.0.6
+
+### Added
+
+- **Read-only Input Mode** (`no_manual_edit`): New widget option that locks the autocomplete input field to prevent free-text edits. When set to `True`, users can only populate the field by selecting a Google Places suggestion; all mapped fields are still filled as usual. Defaults to `False` (free-text input allowed).
+
 ## 19.0.1.0.5
 
 ### Improved

--- a/web_widget_google_place_autocomplete/README.md
+++ b/web_widget_google_place_autocomplete/README.md
@@ -11,6 +11,9 @@ This widget gives you full control over how Google Places data is mapped to your
 - [Screenshots](#screenshots)
 - [Widget: gplace_autocomplete_el](#widget-gplace_autocomplete_el)
   - [Usage](#usage)
+    - [Option 1: Using Mapping Code](#option-1-using-mapping-code-recommended)
+    - [Option 2: Using Mapping Mode](#option-2-using-mapping-mode)
+    - [Option 3: Disable Manual Edit](#option-3-disable-manual-edit)
   - [Configuration Options](#configuration-options)
   - [Street Formatting](#street-formatting)
 - [Installation & Configuration](#installation--configuration)
@@ -26,6 +29,7 @@ This widget gives you full control over how Google Places data is mapped to your
 - **Interactive Mapping Test**: Built-in testing tool to verify your field mappings
 - **Quick Access**: Shortcut button in form views to access mapping configuration
 - **Street Format Control**: Configure street formatting per country (route + number or number + route)
+- **Read-only input mode** (`no_manual_edit`): Optionally lock the autocomplete input so users can only select from Google Places suggestions, preventing free-text edits while still auto-filling all mapped fields
 
 ## Screenshots
 
@@ -55,7 +59,7 @@ Before using the widget, ensure you have:
 
 ### Usage
 
-To use the widget in your form views, you can configure it in two ways:
+To use the widget in your form views, you can configure it using the following options:
 
 #### Option 1: Using Mapping Code (Recommended)
 
@@ -95,6 +99,25 @@ There are two available mapping modes:
       ...
     </form>
     </field>
+</record>
+```
+
+#### Option 3: Disable Manual Edit
+
+By default, users can freely type in the autocomplete field. Set `no_manual_edit` to `True` to make the input read-only, so data can only be populated through a Google Places suggestion. All mapped fields are still filled as usual when a suggestion is selected.
+
+```xml
+<record id="view_form_your_model" model="ir.ui.view">
+  <field name="name">your.model.form</field>
+  <field name="model">your.model</field>
+  <field name="arch" type="xml">
+    <form>
+      ...
+      <field name="your_field_name" widget="gplace_autocomplete_el"
+             options="{'mapping_mode': 'address', 'no_manual_edit': True}"/>
+      ...
+    </form>
+  </field>
 </record>
 ```
 

--- a/web_widget_google_place_autocomplete/__manifest__.py
+++ b/web_widget_google_place_autocomplete/__manifest__.py
@@ -12,7 +12,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.5',
+    'version': '1.0.6',
     'depends': ['base_google_map'],
     'assets': {
         'web.assets_backend': [

--- a/web_widget_google_place_autocomplete/i18n/web_widget_google_place_autocomplete.pot
+++ b/web_widget_google_place_autocomplete/i18n/web_widget_google_place_autocomplete.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0-20260118\n"
+"Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-01 13:49+0000\n"
-"PO-Revision-Date: 2026-03-01 13:49+0000\n"
+"POT-Creation-Date: 2026-03-04 09:24+0000\n"
+"PO-Revision-Date: 2026-03-04 09:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -787,6 +787,14 @@ msgstr ""
 msgid ""
 "The format of \"route\" and \"street_number\" will be configured dynamically"
 " based on the address's country. Check the"
+msgstr ""
+
+#. module: web_widget_google_place_autocomplete
+#. odoo-javascript
+#: code:addons/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.js:0
+msgid ""
+"This field is read-only because manual edits are disabled. Please use the "
+"Google Place Autocomplete to update the value."
 msgstr ""
 
 #. module: web_widget_google_place_autocomplete

--- a/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.js
+++ b/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.js
@@ -1,7 +1,8 @@
 import { _t } from '@web/core/l10n/translation';
 import { registry } from '@web/core/registry';
 import { useService } from '@web/core/utils/hooks';
-import { useRef, useState, onWillUnmount, onWillUpdateProps } from '@odoo/owl';
+import { exprToBoolean } from '@web/core/utils/strings';
+import { useRef, useState, onWillUnmount, onWillUpdateProps, useEffect } from '@odoo/owl';
 import { CharField, charField } from '@web/views/fields/char/char_field';
 import { GooglePlaceAutocompleteElement } from '../../component/google_place_autocomplete';
 import { useGooglePlaceAutocompleteMapping } from '../../hooks/use_google_place_autocomplete_mapping';
@@ -27,6 +28,7 @@ export class GooglePlaceAutocompleteCharField extends CharField {
         ...CharField.props,
         mappingCode: { type: String, optional: true },
         mappingMode: { type: String, optional: true }, // 'address' or 'places'
+        noManualEdit: { type: Boolean, optional: true }, // If true, the input field will be set to readonly to prevent manual edits. Other fields will still be populated based on the autocomplete selection. Default is false (manual edits allowed).
     };
 
     /**
@@ -46,6 +48,19 @@ export class GooglePlaceAutocompleteCharField extends CharField {
         this.placeMapping = useGooglePlaceAutocompleteMapping();
         this.widgetId = this.placeMapping.getUniqueWidgetId();
         this.mappingConfig = {};
+
+        useEffect(
+            (inputRef, noManualEdit, readonly) => {
+                if (inputRef.el && !readonly) {
+                    if (noManualEdit) {
+                        inputRef.el.setAttribute('readonly', 'readonly');
+                    } else {
+                        inputRef.el.removeAttribute('readonly');
+                    }
+                }
+            },
+            () => [this.input, this.props.noManualEdit, this.props.readonly]
+        );
 
         onWillUpdateProps((nextProps) => {
             if (nextProps.record?.id !== this.props.record?.id) {
@@ -247,6 +262,7 @@ export const googlePlaceAutocompleteCharField = {
         ...charField.extractProps({ attrs, options, placeholder }),
         mappingCode: options.mapping_code,
         mappingMode: options.mapping_mode,
+        noManualEdit: exprToBoolean(options.no_manual_edit, false),
     }),
 };
 

--- a/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.js
+++ b/web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.js
@@ -50,16 +50,22 @@ export class GooglePlaceAutocompleteCharField extends CharField {
         this.mappingConfig = {};
 
         useEffect(
-            (inputRef, noManualEdit, readonly) => {
-                if (inputRef.el && !readonly) {
-                    if (noManualEdit) {
-                        inputRef.el.setAttribute('readonly', 'readonly');
-                    } else {
-                        inputRef.el.removeAttribute('readonly');
-                    }
+            () => {
+                if (this.input.el && !this.props.readonly && this.props.noManualEdit) {
+                    this.input.el.setAttribute('readonly', 'readonly');
+                    this.input.el.setAttribute(
+                        'data-tooltip',
+                        _t('This field is read-only because manual edits are disabled. Please use the Google Place Autocomplete to update the value.')
+                    );
                 }
+                return () => {
+                    if (this.input.el) {
+                        this.input.el.removeAttribute('readonly');
+                        this.input.el.removeAttribute('data-tooltip');
+                    }
+                };
             },
-            () => [this.input, this.props.noManualEdit, this.props.readonly]
+            () => [this.input.el, this.props.noManualEdit, this.props.readonly]
         );
 
         onWillUpdateProps((nextProps) => {


### PR DESCRIPTION
This pull request introduces significant improvements and bug fixes to the Google Maps integration modules, focusing on marker appearance, event handling, and usability enhancements. The most notable changes are the adoption of Google's native `PinElement` for record markers, improved marker selection feedback, and new options for the partner autocomplete widget. Several bugs related to color processing and event listeners have also been addressed.

**Google Maps Marker and UI Enhancements:**

* Record markers now use Google's native `PinElement`, displaying the first letter of the record's title as a glyph for a cleaner, map-native look. Marker selection visually scales up the pin and highlights it with a blue border. [[1]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R20) [[2]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8L49-R56) [[3]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8R821-R826) [[4]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8R845-R850) [[5]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8L1211-R1248)
* The place search marker is now a distinctive orange teardrop with a search icon for easier differentiation from record markers. [[1]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R20) [[2]](diffhunk://#diff-00259fec42e03e45b83c5b230be8c2c89e42bfabb094c7f9efa5d6df9b734eceR85-R93) [[3]](diffhunk://#diff-6a6f5d1db35c46cf146ac1b115bba0dccb2ebbba8338d39f4b9d7e767b22595fR1-R20)

**Event Handling and Bug Fixes:**

* Marker click events now use the correct `gmp-click` event instead of the deprecated `click`, ensuring compatibility with `AdvancedMarkerElement`. [[1]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R20) [[2]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8L613-R617) [[3]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8L1252-R1284)
* Fixed a bug where marker color normalization was incorrectly applied to the field name instead of the actual color value, ensuring correct marker colors. [[1]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R20) [[2]](diffhunk://#diff-d43692c50b2f2b079b9badf84784421a2204daf87ef65ecb7e2ed76f254b176aL200-R203)

**Color Processing Improvements:**

* Refactored `processColor()` and `normalizeColor()` for more robust handling of null/undefined values and optimized hex color processing without unnecessary DOM manipulation. [[1]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R20) [[2]](diffhunk://#diff-d43692c50b2f2b079b9badf84784421a2204daf87ef65ecb7e2ed76f254b176aL88-R102) [[3]](diffhunk://#diff-d43692c50b2f2b079b9badf84784421a2204daf87ef65ecb7e2ed76f254b176aR228-R232)

**Partner Autocomplete Widget Enhancements:**

* Added a new `noManualEdit` option to the `partner_autocomplete_with_gplace` widget, allowing the input field to be set as read-only to prevent manual edits while still populating other fields via autocomplete. [[1]](diffhunk://#diff-4346d70a3b67a73690eb1204565d7ad915f9020a043f6d555368fd36df961072R40) [[2]](diffhunk://#diff-4346d70a3b67a73690eb1204565d7ad915f9020a043f6d555368fd36df961072R61-R73) [[3]](diffhunk://#diff-4346d70a3b67a73690eb1204565d7ad915f9020a043f6d555368fd36df961072R273)
* Updated documentation to clarify that the widget is a drop-in replacement for `gplace_autocomplete_el` and inherits all its functionality.

**Module Version Updates:**

* Bumped version numbers for `partner_autocomplete_with_google_autocomplete` (to 1.0.3), `web_view_google_map` (to 1.0.10), and other related modules in the main `README.md` to reflect new features and fixes. [[1]](diffhunk://#diff-8dd86c50ecf104ae3a0faff410d170d3498aab1d566d6b2328d35a2f3ac4e2baL15-R15) [[2]](diffhunk://#diff-43e696f6e216406b879cfbbf6d820297dfc117930d25747387df839fc91fe59bL17-R17) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R23)