### PR TITLE
[FIX] Use gmp-click event for AdvancedMarkerElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [project_google_map](/project_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Projects |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
-| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.10 | Base module for a new view "google_map" |
+| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.11 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.10 | Base module for sub view of "google_map" for drawing capability |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.3 | Base module of Google Maps widget |
 | [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.6 | Implementation of Google Places Autocomplete Element |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [contacts_google_autocomplete](/contacts_google_autocomplete/README.md) | 19.0.1.0.1 | Implementation of Google Places Autocomplete on Contacts |
 | [contacts_google_map](/contacts_google_map/README.md) | 19.0.1.0.3 | Implementation of view "Google Maps" on Contacts |
 | [crm_google_autocomplete](/crm_google_autocomplete/README.md) | 19.0.1.0.1 | Implementation of Google Places Autocomplete on CRM Leads/Opportunities |
-| [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.4 | Implementation of view "Google Maps" on CRM |
+| [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on CRM |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.3 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
 | [project_google_map](/project_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Projects |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |

--- a/crm_google_map/CHANGELOG.md
+++ b/crm_google_map/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 19.0.1.0.5
+
+### Fixed
+
+- **Marker Click Event**: Changed marker click listener from deprecated `'click'` to `'gmp-click'` for `AdvancedMarkerElement` compatibility
+
 ## 19.0.1.0.4
 ### Improved
 - **Marker Responsiveness**: Enhanced marker sizing with flexible dimensions using min/max constraints

--- a/crm_google_map/__manifest__.py
+++ b/crm_google_map/__manifest__.py
@@ -13,7 +13,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/CRM',
-    'version': '1.0.4',
+    'version': '1.0.5',
     'depends': [
         'crm',
         'web_view_google_map',

--- a/crm_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/crm_google_map/static/src/views/google_map/google_map_renderer.js
@@ -178,9 +178,10 @@ export class GoogleMapRendererCRM extends GoogleMapRenderer {
         options.content = this._createMarkerElement(record, elementValues);
 
         const advMarkerElement = new AdvancedMarkerElement(options);
-        advMarkerElement.addListener('gmp-click', () => {
+        const clickListener = advMarkerElement.addListener('gmp-click', () => {
             this.toggleMarkerHighlight(advMarkerElement);
         });
+        this._storeMarkerEventListener(record.id, 'gmp-click', clickListener);
         return advMarkerElement;
     }
 

--- a/crm_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/crm_google_map/static/src/views/google_map/google_map_renderer.js
@@ -178,7 +178,7 @@ export class GoogleMapRendererCRM extends GoogleMapRenderer {
         options.content = this._createMarkerElement(record, elementValues);
 
         const advMarkerElement = new AdvancedMarkerElement(options);
-        advMarkerElement.addListener('click', () => {
+        advMarkerElement.addListener('gmp-click', () => {
             this.toggleMarkerHighlight(advMarkerElement);
         });
         return advMarkerElement;

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 19.0.1.0.11
+
+### Fixed
+
+- **Marker Listener Storage Key**: Fixed `_storeMarkerEventListener` being called with `'click'` instead of `'gmp-click'`, ensuring the stored listener key matches the actual event name used for proper cleanup
+
 ## 19.0.1.0.10
 
 ### Added

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.10',
+    'version': '1.0.11',
     'depends': ['base_google_map'],
     'data': [],
     'assets': {

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -1284,7 +1284,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
             'gmp-click',
             this._handleMarkerClick.bind(this, marker)
         );
-        this._storeMarkerEventListener(record.id, 'click', clickListener);
+        this._storeMarkerEventListener(record.id, 'gmp-click', clickListener);
     }
 
     /**


### PR DESCRIPTION
This pull request updates the `crm_google_map` and `web_view_google_map` modules to fix issues related to Google Maps marker event listeners, ensuring compatibility with the latest Google Maps APIs and improving event listener management. The most important changes are grouped below:

**Google Maps Marker Event Listener Fixes:**

* Changed marker click event from the deprecated `'click'` to `'gmp-click'` in `crm_google_map` to ensure compatibility with `AdvancedMarkerElement` and the latest Google Maps APIs.
* Updated the storage of marker event listeners in `web_view_google_map` so that the event key matches the actual event name (`'gmp-click'`), ensuring proper cleanup and management of listeners.

**Version and Documentation Updates:**

* Bumped the version of `crm_google_map` to `1.0.5` and updated the changelog to reflect the marker click event fix. [[1]](diffhunk://#diff-c0c08aa0012d0fd99916b745d6ec568d5c1d118de1f7f5057470560cbe50509fL16-R16) [[2]](diffhunk://#diff-b295dd368e298e460488bb68c555a3db4530232f5aa4a35905558aa0e4385651R3-R8)
* Bumped the version of `web_view_google_map` to `1.0.11` and updated the changelog to document the event listener key fix. [[1]](diffhunk://#diff-43e696f6e216406b879cfbbf6d820297dfc117930d25747387df839fc91fe59bL17-R17) [[2]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R8)
* Updated the main `README.md` to reflect the new versions of both modules.- Replace deprecated `'click'` listener with `'gmp-click'` on AdvancedMarkerElement to fix marker toggle interaction
- Bump version to 1.0.5
- Update CHANGELOG.md and README.md version reference