### PR TITLE
Fix export button functionality and improve map widget defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [project_google_map](/project_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Projects |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
-| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.11 | Base module for a new view "google_map" |
+| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.12 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.10 | Base module for sub view of "google_map" for drawing capability |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.3 | Base module of Google Maps widget |
 | [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.6 | Implementation of Google Places Autocomplete Element |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.12 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.10 | Base module for sub view of "google_map" for drawing capability |
-| [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.3 | Base module of Google Maps widget |
+| [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.4 | Base module of Google Maps widget |
 | [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.6 | Implementation of Google Places Autocomplete Element |
 
 

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 19.0.1.0.12
+
+### Fixed
+
+- **Export Button**: Fixed the export action by replacing the manual `ExportDataDialog` implementation with Odoo's built-in `useExportRecords` hook, resolving errors triggered when clicking the Export button in the Action Menu
+
+### Improved
+
+- **Delete with Confirmation**: Replaced the inline `ConfirmationDialog` call in `onDeleteSelectedRecords` with Odoo's built-in `useDeleteRecords` hook for consistent deletion behavior
+- **Exportable Fields**: Added `getExportableFields()` method that correctly filters visible, non-properties, exportable fields from the view's columns, respecting `column_invisible` modifiers and optional field visibility
+- **View Modifier Evaluation**: Added `evalViewModifier()` helper using `evaluateBooleanExpr` for evaluating view modifiers against the current record context
+
 ## 19.0.1.0.11
 
 ### Fixed

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -2,15 +2,34 @@
 
 ## 19.0.1.0.12
 
+### Added
+
+- **Header Button Support**: The map view now parses `<header>` buttons from the view's arch XML and renders them in the control panel using `MultiRecordViewButton`, matching the behavior of standard list views. Buttons with `display="always"` appear persistently; others appear in the selection actions area and in the cog menu on small screens.
+
 ### Fixed
 
 - **Export Button**: Fixed the export action by replacing the manual `ExportDataDialog` implementation with Odoo's built-in `useExportRecords` hook, resolving errors triggered when clicking the Export button in the Action Menu
+- **Action Service Calls**: Replaced `this.model.action.doAction` with `this.actionService.doAction` throughout the controller, resolving errors when opening form views or switching views from the map.
+- **Domain Handling in `_getNextConfig`**: Map domain is now applied after calling `super._getNextConfig()` rather than before, preventing the map's geolocation filter from being overridden by the parent config.
+- **Form View and Views Checks**: Changed truthy checks on `form_view` and `views` to use `.length` to correctly detect empty arrays.
+- **Missing Form View Notification**: Replaced `console.warn` with a proper `notificationService` danger notification when no form view is available for a record.
+- **Unselect All**: Simplified `onUnselectAll` by removing the marker-specific `_toggleMarkerSelection` branch; all records now use the standard `toggleSelection(false)` path.
+- **Auto-Zoom Behavior**: Reduced `MAX_AUTO_ZOOM` from 17 to 15 and the smooth zoom increment on subsequent clicks from 3 to 2, resulting in less aggressive auto-zoom when centering on a marker.
 
 ### Improved
 
 - **Delete with Confirmation**: Replaced the inline `ConfirmationDialog` call in `onDeleteSelectedRecords` with Odoo's built-in `useDeleteRecords` hook for consistent deletion behavior
 - **Exportable Fields**: Added `getExportableFields()` method that correctly filters visible, non-properties, exportable fields from the view's columns, respecting `column_invisible` modifiers and optional field visibility
 - **View Modifier Evaluation**: Added `evalViewModifier()` helper using `evaluateBooleanExpr` for evaluating view modifiers against the current record context
+- **`optionalActiveFields` Initialization**: Added `this.optionalActiveFields = {}` in the controller setup to prevent potential undefined access errors.
+
+### Code Cleanup
+
+- Removed the custom `getActionMenuItems()` method; action menu items are now handled by the standard Odoo mechanism.
+- Removed unused `deleteConfirmationMessage` import from `confirmation_dialog`.
+- Removed unused `RelationalModel` import from `google_map_view.js`.
+- Removed the duplicate `downloadExport` method left over from a prior refactor.
+- Removed the unused `getExportedFields` method and its associated `rpc` import.
 
 ## 19.0.1.0.11
 

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.11',
+    'version': '1.0.12',
     'depends': ['base_google_map'],
     'data': [],
     'assets': {

--- a/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
@@ -9,6 +9,11 @@ export class GoogleMapArchParser {
     get defaultLimit() {
         return 100;
     }
+
+    processButton(node) {
+        return processButton(node);
+    }
+
     parse(xmlDoc, models, modelName) {
         const className = xmlDoc.getAttribute('class') || null;
         const jsClass = xmlDoc.getAttribute('js_class');
@@ -25,6 +30,9 @@ export class GoogleMapArchParser {
         const creates = [];
 
         let nextId = 0;
+        let buttonId = 0;
+        let headerButtons = [];
+
         const columns = [];
 
         const groupBy = {
@@ -82,6 +90,13 @@ export class GoogleMapArchParser {
                     fieldNodes: groupByArchInfo.fieldNodes,
                     fields: models[coModelName].fields,
                 };
+            } else if (node.tagName === "header") {
+                headerButtons = [...node.children].map((node) => ({
+                    ...this.processButton(node),
+                    type: "button",
+                    id: buttonId++,
+                }));
+                return false;
             } else if (node.tagName === 'google_map') {
                 this.parseGoogleMapAttrs(xmlDoc, node, googleMapAttr);
             }
@@ -91,6 +106,7 @@ export class GoogleMapArchParser {
             columns,
             className,
             fieldNodes,
+            headerButtons,
             viewTitle,
             xmlDoc,
             groupBy,

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -5,7 +5,6 @@ import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { extractFieldsFromArchInfo } from '@web/model/relational_model/utils';
 import { usePager } from '@web/search/pager_hook';
 import { useService } from '@web/core/utils/hooks';
-import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
 import { unique } from '@web/core/utils/arrays';
 import { download } from '@web/core/network/download';
@@ -324,14 +323,6 @@ export class GoogleMapController extends Component {
                 }),
             },
             url: `/web/export/${format}`,
-        });
-    }
-
-    async getExportedFields(model, import_compat, parentParams) {
-        return await rpc('/web/export/get_fields', {
-            ...parentParams,
-            model,
-            import_compat,
         });
     }
 

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -8,10 +8,7 @@ import { useService } from '@web/core/utils/hooks';
 import { user } from '@web/core/user';
 import { unique } from '@web/core/utils/arrays';
 import { download } from '@web/core/network/download';
-import {
-    ConfirmationDialog,
-    deleteConfirmationMessage,
-} from '@web/core/confirmation_dialog/confirmation_dialog';
+import { ConfirmationDialog } from '@web/core/confirmation_dialog/confirmation_dialog';
 import { omit } from '@web/core/utils/objects';
 import { ActionMenus, STATIC_ACTIONS_GROUP_NUMBER } from '@web/search/action_menus/action_menus';
 import { standardViewProps } from '@web/views/standard_view_props';

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -1,11 +1,11 @@
 import { _t } from '@web/core/l10n/translation';
 import { Layout } from '@web/search/layout';
 import { useModelWithSampleData } from '@web/model/model';
-import { evaluateBooleanExpr } from "@web/core/py_js/py";
+import { evaluateBooleanExpr } from '@web/core/py_js/py';
 import { extractFieldsFromArchInfo } from '@web/model/relational_model/utils';
 import { usePager } from '@web/search/pager_hook';
 import { useService } from '@web/core/utils/hooks';
-import { user } from "@web/core/user";
+import { user } from '@web/core/user';
 import { unique } from '@web/core/utils/arrays';
 import { download } from '@web/core/network/download';
 import {
@@ -15,15 +15,17 @@ import {
 import { omit } from '@web/core/utils/objects';
 import { ActionMenus, STATIC_ACTIONS_GROUP_NUMBER } from '@web/search/action_menus/action_menus';
 import { standardViewProps } from '@web/views/standard_view_props';
-import { useSetupAction } from "@web/search/action_hook";
-import { useViewButtons } from "@web/views/view_button/view_button_hook";
+import { MultiRecordViewButton } from '@web/views/view_button/multi_record_view_button';
+import { useSetupAction } from '@web/search/action_hook';
+import { useViewButtons } from '@web/views/view_button/view_button_hook';
 import { session } from '@web/session';
 import { useSearchBarToggler } from '@web/search/search_bar/search_bar_toggler';
-import { SelectionBox } from "@web/views/view_components/selection_box";
+import { SelectionBox } from '@web/views/view_components/selection_box';
 import { ViewButton } from '@web/views/view_button/view_button';
 import { executeButtonCallback } from '@web/views/view_button/view_button_hook';
 import { CogMenu } from '@web/search/cog_menu/cog_menu';
-import { useExportRecords, useDeleteRecords } from "@web/views/view_hook";
+import { DropdownItem } from '@web/core/dropdown/dropdown_item';
+import { useExportRecords, useDeleteRecords } from '@web/views/view_hook';
 import { GoogleMapSearchBar } from './google_map_search_bar';
 
 import {
@@ -38,7 +40,16 @@ import {
 
 export class GoogleMapController extends Component {
     static template = 'web_view_google_map.GoogleMapView';
-    static components = { Layout, ActionMenus, SearchBar: GoogleMapSearchBar, ViewButton, CogMenu, SelectionBox };
+    static components = {
+        Layout,
+        ActionMenus,
+        ViewButton,
+        CogMenu,
+        SelectionBox,
+        MultiRecordViewButton,
+        DropdownItem,
+        SearchBar: GoogleMapSearchBar,
+    };
     static props = {
         ...standardViewProps,
         Model: Function,
@@ -67,16 +78,19 @@ export class GoogleMapController extends Component {
         this.rootRef = useRef('root');
 
         this.archInfo = this.props.archInfo;
+
         this.activeActions = this.props.archInfo.activeActions;
         this.multiEdit = this.props.archInfo.multiEdit;
-        this.model = useState(useModelWithSampleData(this.props.Model, this.modelParams, this.modelOptions));
+        this.model = useState(
+            useModelWithSampleData(this.props.Model, this.modelParams, this.modelOptions)
+        );
 
         this.archiveEnabled =
             'active' in this.props.fields
                 ? !this.props.fields.active.readonly
                 : 'x_active' in this.props.fields
-                ? !this.props.fields.x_active.readonly
-                : false;
+                  ? !this.props.fields.x_active.readonly
+                  : false;
 
         onWillStart(async () => {
             this.isExportEnable = await user.hasGroup('base.group_allow_export');
@@ -126,6 +140,8 @@ export class GoogleMapController extends Component {
             },
             () => [this.model.root.selection.length, this.model.root.isDomainSelected]
         );
+
+        this.optionalActiveFields = {};
 
         this.firstLoad = true;
         onWillPatch(() => {
@@ -237,57 +253,9 @@ export class GoogleMapController extends Component {
         };
     }
 
-    getActionMenuItems() {
-        const isM2MGrouped = this.model.root.isM2MGrouped;
-        const otherActionItems = [];
-        if (this.isExportEnable) {
-            otherActionItems.push({
-                key: 'export',
-                description: _t('Export'),
-                callback: () => this.exportRecords(),
-            });
-        }
-        if (this.archiveEnabled && !isM2MGrouped) {
-            otherActionItems.push({
-                key: 'archive',
-                description: _t('Archive'),
-                callback: () => {
-                    const dialogProps = {
-                        body: _t('Are you sure that you want to archive all the selected records?'),
-                        confirmLabel: _t('Archive'),
-                        confirm: () => {
-                            this.toggleArchiveState(true);
-                        },
-                        cancel: () => {},
-                    };
-                    this.dialogService.add(ConfirmationDialog, dialogProps);
-                },
-            });
-            otherActionItems.push({
-                key: 'unarchive',
-                description: _t('Unarchive'),
-                callback: () => this.toggleArchiveState(false),
-            });
-        }
-        if (this.activeActions.delete && !isM2MGrouped) {
-            otherActionItems.push({
-                key: 'delete',
-                description: _t('Delete'),
-                callback: () => this.onDeleteSelectedRecords(),
-            });
-        }
-        return Object.assign({}, this.props.info.actionMenus, { other: otherActionItems });
-    }
-
     onUnselectAll() {
         this.model.root.selection.forEach((record) => {
-            if ('_toggleMarkerSelection' in record) {
-                record.toggleSelection(false).then(() => {
-                    record._toggleMarkerSelection(record);
-                });
-            } else {
-                record.toggleSelection(false);
-            }
+            record.toggleSelection(false);
         });
         this.model.root.selectDomain(false);
     }
@@ -382,8 +350,8 @@ export class GoogleMapController extends Component {
             let action = null;
             const action_title = this._getRecordName(record);
             if (this.actionService.currentController) {
-                const form_view = this.actionService.currentController.action.views.filter((view) => view[1] == 'form');
-                if (form_view) {
+                const form_view = this.actionService.currentController.action.views.filter((view) => view[1] === 'form');
+                if (form_view.length) {
                     action = {
                         name: action_title,
                         type: 'ir.actions.act_window',
@@ -406,16 +374,16 @@ export class GoogleMapController extends Component {
                     target: 'new'
                 };
             }
-            if (!action || (action && action.views.length <= 0)) {
-                console.warn('No form view available for this record.');
+            if (!action.views.length) {
+                this.notificationService.add(_t('No form view available for this record.'), { type: 'danger' });
                 return;
             }
-            this.model.action.doAction(action, {
+            this.actionService.doAction(action, {
                 props: {
                     onSave: async (record) => {
                         await record.load();
                         record.model.notify();
-                        this.model.action.doAction({
+                        this.actionService.doAction({
                             type: 'ir.actions.act_window_close',
                         });
                         await this.model.root.load();
@@ -431,7 +399,7 @@ export class GoogleMapController extends Component {
         if (this.actionService.currentController) {
             const views = this.actionService.currentController.action.views.filter((view) => view[1] !== 'google_map');
             const view_mode = views.map((view) => view[1]).join(',');
-            if (views) {
+            if (views.length) {
                 action = {
                     views,
                     view_mode,
@@ -458,7 +426,7 @@ export class GoogleMapController extends Component {
             };
         }
         if (action) {
-            this.model.action.doAction(action);
+            this.actionService.doAction(action);
         }
     }
 
@@ -580,19 +548,7 @@ export class GoogleMapController extends Component {
     }
 
     get deleteConfirmationDialogProps() {
-        const root = this.model.root;
-        let body = deleteConfirmationMessage;
-        if (root.isDomainSelected || root.selection.length > 1) {
-            body = _t('Are you sure you want to delete these records?');
-        }
-        return {
-            title: _t('Bye-bye, record!'),
-            body,
-            confirmLabel: _t('Delete'),
-            confirm: () => this.model.root.deleteRecords(),
-            cancel: () => {},
-            cancelLabel: _t('No, keep it'),
-        };
+        return {};
     }
 
     get defaultExportList() {

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -15,7 +15,6 @@ import {
 } from '@web/core/confirmation_dialog/confirmation_dialog';
 import { omit } from '@web/core/utils/objects';
 import { ActionMenus, STATIC_ACTIONS_GROUP_NUMBER } from '@web/search/action_menus/action_menus';
-import { MultiRecordViewButton } from "@web/views/view_button/multi_record_view_button";
 import { standardViewProps } from '@web/views/standard_view_props';
 import { useSetupAction } from "@web/search/action_hook";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
@@ -345,37 +344,6 @@ export class GoogleMapController extends Component {
 
     async onDirectExportData() {
         await this.downloadExport(this.defaultExportList, false, 'xlsx');
-    }
-
-    async downloadExport(fields, import_compat, format) {
-        let ids = false;
-        if (!this.isDomainSelected) {
-            const resIds = await this.getSelectedResIds();
-            ids = resIds.length > 0 && resIds;
-        }
-        const exportedFields = fields.map((field) => ({
-            name: field.name || field.id,
-            label: field.label || field.string,
-            store: field.store,
-            type: field.field_type || field.type,
-        }));
-        if (import_compat) {
-            exportedFields.unshift({ name: 'id', label: _t('External ID') });
-        }
-        await download({
-            data: {
-                data: JSON.stringify({
-                    import_compat,
-                    context: this.props.context,
-                    domain: this.model.root.domain,
-                    fields: exportedFields,
-                    groupby: this.model.root.groupBy,
-                    ids,
-                    model: this.model.root.resModel,
-                }),
-            },
-            url: `/web/export/${format}`,
-        });
     }
 
     centerMap() {

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -1,13 +1,13 @@
 import { _t } from '@web/core/l10n/translation';
 import { Layout } from '@web/search/layout';
 import { useModelWithSampleData } from '@web/model/model';
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { extractFieldsFromArchInfo } from '@web/model/relational_model/utils';
 import { usePager } from '@web/search/pager_hook';
 import { useService } from '@web/core/utils/hooks';
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
 import { unique } from '@web/core/utils/arrays';
-import { ExportDataDialog } from '@web/views/view_dialogs/export_data_dialog';
 import { download } from '@web/core/network/download';
 import {
     ConfirmationDialog,
@@ -15,6 +15,7 @@ import {
 } from '@web/core/confirmation_dialog/confirmation_dialog';
 import { omit } from '@web/core/utils/objects';
 import { ActionMenus, STATIC_ACTIONS_GROUP_NUMBER } from '@web/search/action_menus/action_menus';
+import { MultiRecordViewButton } from "@web/views/view_button/multi_record_view_button";
 import { standardViewProps } from '@web/views/standard_view_props';
 import { useSetupAction } from "@web/search/action_hook";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
@@ -24,6 +25,7 @@ import { SelectionBox } from "@web/views/view_components/selection_box";
 import { ViewButton } from '@web/views/view_button/view_button';
 import { executeButtonCallback } from '@web/views/view_button/view_button_hook';
 import { CogMenu } from '@web/search/cog_menu/cog_menu';
+import { useExportRecords, useDeleteRecords } from "@web/views/view_hook";
 import { GoogleMapSearchBar } from './google_map_search_bar';
 
 import {
@@ -133,6 +135,12 @@ export class GoogleMapController extends Component {
         });
 
         this.searchBarToggler = useSearchBarToggler();
+
+        this.exportRecords = useExportRecords(this.env, this.props.context, () =>
+            this.getExportableFields()
+        );
+
+        this.deleteRecordsWithConfirmation = useDeleteRecords(this.model);
     }
 
     /**
@@ -159,7 +167,7 @@ export class GoogleMapController extends Component {
     async onWillSaveRecord(record) {}
 
     async onDeleteSelectedRecords() {
-        this.dialogService.add(ConfirmationDialog, this.deleteConfirmationDialogProps);
+        this.deleteRecordsWithConfirmation(this.deleteConfirmationDialogProps);
     }
 
     discardSelection() {
@@ -196,7 +204,7 @@ export class GoogleMapController extends Component {
                 sequence: 10,
                 icon: 'fa fa-upload',
                 description: _t('Export'),
-                callback: () => this.onExportData(),
+                callback: () => this.exportRecords(),
             },
             archive: {
                 isAvailable: () => this.archiveEnabled && !isM2MGrouped,
@@ -238,7 +246,7 @@ export class GoogleMapController extends Component {
             otherActionItems.push({
                 key: 'export',
                 description: _t('Export'),
-                callback: () => this.onExportData(),
+                callback: () => this.exportRecords(),
             });
         }
         if (this.archiveEnabled && !isM2MGrouped) {
@@ -284,17 +292,6 @@ export class GoogleMapController extends Component {
             }
         });
         this.model.root.selectDomain(false);
-    }
-
-    async onExportData() {
-        const dialogProps = {
-            context: this.props.context,
-            defaultExportList: this.defaultExportList,
-            download: this.downloadExport.bind(this),
-            getExportedFields: this.getExportedFields.bind(this),
-            root: this.model.root,
-        };
-        this.dialogService.add(ExportDataDialog, dialogProps);
     }
 
     async downloadExport(fields, import_compat, format) {
@@ -350,16 +347,6 @@ export class GoogleMapController extends Component {
         await this.downloadExport(this.defaultExportList, false, 'xlsx');
     }
 
-    async onExportData() {
-        const dialogProps = {
-            context: this.props.context,
-            defaultExportList: this.defaultExportList,
-            download: this.downloadExport.bind(this),
-            getExportedFields: this.getExportedFields.bind(this),
-            root: this.model.root,
-        };
-        this.dialogService.add(ExportDataDialog, dialogProps);
-    }
     async downloadExport(fields, import_compat, format) {
         let ids = false;
         if (!this.isDomainSelected) {
@@ -592,6 +579,18 @@ export class GoogleMapController extends Component {
         };
     }
 
+    getExportableFields() {
+        return unique(
+            this.props.archInfo.columns
+                .filter((col) => col.type === "field")
+                .filter((col) => !col.optional || this.optionalActiveFields[col.name])
+                .filter((col) => !evaluateBooleanExpr(col.column_invisible, this.props.context))
+                .map((col) => this.props.fields[col.name])
+                .filter((field) => field.exportable !== false)
+                .filter((field) => field.type !== "properties")
+        );
+    }
+
     get archiveDialogProps() {
         return {
             body: _t('Are you sure that you want to archive all the selected records?'),
@@ -703,10 +702,13 @@ export class GoogleMapController extends Component {
         return this.model.root.isDomainSelected;
     }
 
+    evalViewModifier(modifier) {
+        return evaluateBooleanExpr(modifier, this.model.root.evalContext);
+    }
+
     get hasSelectors() {
         return this.props.allowSelectors && !this.env.isSmall;
     }
-
 
     get rendererProps() {
         return {

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.xml
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.xml
@@ -14,6 +14,22 @@
                 <t t-set-slot="layout-buttons">
                     <t t-call="{{ props.buttonTemplate }}"/>
                 </t>
+                <t t-set-slot="control-panel-always-buttons">
+                    <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
+                        <MultiRecordViewButton
+                            t-if="button.display === 'always'"
+                            list="model.root"
+                            className="button.className"
+                            clickParams="button.clickParams"
+                            defaultRank="'btn-secondary'"
+                            domain="props.domain"
+                            icon="button.icon"
+                            string="button.string"
+                            title="button.title"
+                            attrs="button.attrs"
+                        />
+                    </t>
+                </t>
                 <t t-set-slot="layout-actions">
                     <SearchBar t-if="searchBarToggler.state.showSearchBar" autofocus="firstLoad"/>
                 </t>
@@ -22,11 +38,43 @@
                 </t>
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu t-if="!hasSelectedRecords"/>
+                    <CogMenu t-elif="env.isSmall and (props.info.actionMenus or archInfo.headerButtons.length)" t-props="this.actionMenuProps" hasSelectedRecords="hasSelectedRecords">
+                        <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
+                            <DropdownItem class="'o-dropdown-item-unstyled-button'">
+                                <MultiRecordViewButton
+                                    t-if="button.display !== 'always'"
+                                    list="model.root"
+                                    className="button.className"
+                                    clickParams="button.clickParams"
+                                    defaultRank="'btn-secondary'"
+                                    domain="props.domain"
+                                    icon="button.icon"
+                                    string="button.string"
+                                    title="button.title"
+                                    attrs="button.attrs"
+                                />
+                            </DropdownItem>
+                        </t>
+                    </CogMenu>
                 </t>
                 <t t-set-slot="control-panel-selection-actions">
-                    <div t-if="hasSelectedRecords" class="d-flex gap-1">
+                    <div t-if="hasSelectedRecords" class="o_selection_container m-1 m-md-0 d-flex gap-1">
                         <SelectionBox root="this.model.root"/>
                         <t t-if="!env.isSmall">
+                            <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
+                                <MultiRecordViewButton
+                                    t-if="button.display !== 'always'"
+                                    list="model.root"
+                                    className="button.className"
+                                    clickParams="button.clickParams"
+                                    defaultRank="'btn-secondary'"
+                                    domain="props.domain"
+                                    icon="button.icon"
+                                    string="button.string"
+                                    title="button.title"
+                                    attrs="button.attrs"
+                                />
+                            </t>
                             <t t-if="props.info.actionMenus">
                                 <ActionMenus t-props="actionMenuProps"/>
                             </t>

--- a/web_view_google_map/static/src/views/google_map/google_map_model.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_model.js
@@ -73,14 +73,13 @@ export class GoogleMapModel extends RelationalModel {
      * @returns
      */
     _getNextConfig(currentConfig, params) {
-        const domain = params.domain || [];
+        const nextConfig = super._getNextConfig(currentConfig, params);
         const mapDomain = this.mapDomain;
-        if (mapDomain) {
+        if (mapDomain && mapDomain.length) {
             // add domain for geolocation fields
-            const newDomain = Domain.and([domain, mapDomain]).toList({});
-            params = Object.assign({}, params, { domain: newDomain });
+            nextConfig.domain = Domain.and([nextConfig.domain ?? [], mapDomain]).toList({});
         }
-        return super._getNextConfig(currentConfig, params);
+        return nextConfig;
     }
     /**
      * Filter for geolocation fields

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -57,7 +57,7 @@ const MARKER_CONFIG = {
     },
     BOUNDS: {
         DEFAULT_PADDING: 200,
-        MAX_AUTO_ZOOM: 17,
+        MAX_AUTO_ZOOM: 15,
     },
     BATCH: {
         SELECTION_SIZE: 20,
@@ -581,7 +581,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
 
             const currentZoom = this.googleMap.getZoom();
             this.googleMap.setCenter(position);
-            const counter = attempts === 0 ? 4 : 3;
+            const counter = attempts === 0 ? 4 : 2;
             this._handleSmoothZoomToMarker(currentZoom + counter, currentZoom, 200);
             attempts += 1;
 

--- a/web_view_google_map/static/src/views/google_map/google_map_view.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_view.js
@@ -1,6 +1,7 @@
 import { GoogleMapArchParser } from './google_map_arch_parser';
 import { GoogleMapController } from './google_map_controller';
 import { GoogleMapModel } from './google_map_model';
+import { RelationalModel } from '@web/model/relational_model/relational_model';
 import { GoogleMapRenderer } from './google_map_renderer';
 
 import { registry } from '@web/core/registry';

--- a/web_view_google_map/static/src/views/google_map/google_map_view.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_view.js
@@ -1,7 +1,6 @@
 import { GoogleMapArchParser } from './google_map_arch_parser';
 import { GoogleMapController } from './google_map_controller';
 import { GoogleMapModel } from './google_map_model';
-import { RelationalModel } from '@web/model/relational_model/relational_model';
 import { GoogleMapRenderer } from './google_map_renderer';
 
 import { registry } from '@web/core/registry';

--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 19.0.1.0.4
+
+### Improved
+
+- **Default Zoom Level**: Reduced the default zoom level from 16 to 14 to provide better spatial context when the map widget is first rendered.
+- **Iframe Lazy Loading**: Added `loading="lazy"` to the embedded Google Maps iframe so it defers loading until the widget enters the viewport, improving page load performance.
+
+### Fixed
+
+- **Edit Button Visibility**: The "Edit" button is now fully hidden (removed from the DOM) when the field is in readonly mode, instead of being rendered as a disabled button.
+
 ## 19.0.1.0.3
 
 ### Added

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -12,7 +12,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.3',
+    'version': '1.0.4',
     'depends': ['base_google_map', 'web_view_google_map'],
     'assets': {
         'web.assets_backend': [

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
@@ -276,7 +276,7 @@ export class GoogleMapWidget extends Component {
         maptype: { type: String, optional: true },
     };
     static defaultProps = {
-        zoom: 16,
+        zoom: 14,
         maptype: 'roadmap',
         width: 400,
         height: 200,

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
@@ -3,7 +3,7 @@
     <t t-name="web_widget_google_map.GoogleMapWidget">
         <div class="d-flex flex-column" t-if="!props.invisible">
             <div class="o_google_map_widget" t-if="iframeSrc">
-                <iframe t-att-width="props.width" t-att-height="props.height" frameborder="0" style="border:0" referrerpolicy="no-referrer-when-downgrade" t-att-src="iframeSrc" allowfullscreen="allowfullscreen"></iframe>
+                <iframe loading="lazy" t-att-width="props.width" t-att-height="props.height" frameborder="0" style="border:0" referrerpolicy="no-referrer-when-downgrade" t-att-src="iframeSrc" allowfullscreen="allowfullscreen"></iframe>
             </div>
             <button type="button" class="btn btn-light" t-on-click="handleOnEdit" t-if="!props.readonly">Edit</button>
         </div>


### PR DESCRIPTION
This pull request focuses on improving the Google Maps integration modules for Odoo, with a particular emphasis on enhancing the export and delete functionalities in the `web_view_google_map` module, as well as minor improvements and fixes in the `web_widget_google_map` module. The main changes include refactoring to use Odoo’s built-in hooks for exporting and deleting records, improving field export logic, and updating module versions.

### Google Map View Improvements

- **Export Functionality Refactor:** Replaced the custom `ExportDataDialog` with Odoo’s built-in `useExportRecords` hook, resolving errors when using the Export button and simplifying the export workflow. [[1]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR4-R18) [[2]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR28) [[3]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR138-R143) [[4]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aL199-R207) [[5]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aL241-R249) [[6]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aL289-L299) [[7]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aL353-L362) [[8]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R14)
- **Delete with Confirmation:** Updated the deletion process to use Odoo’s `useDeleteRecords` hook instead of a manual confirmation dialog, ensuring consistent and reliable deletion behavior. [[1]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR4-R18) [[2]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR28) [[3]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR138-R143) [[4]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aL162-R170) [[5]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R14)

### Exportable Fields and Modifiers

- **Exportable Fields Logic:** Introduced a new `getExportableFields()` method to accurately filter which fields are exportable, considering visibility, field type, and exportable status. [[1]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR138-R143) [[2]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR582-R593) [[3]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R14)
- **Modifier Evaluation Helper:** Added `evalViewModifier()` to evaluate view modifiers against the current record context using `evaluateBooleanExpr`, improving dynamic UI logic. [[1]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR4-R18) [[2]](diffhunk://#diff-6ab80a5b119605104fb6fce1f2eba71881203bba9cd8d68e0aa1a6ac7f5e363aR705-L710) [[3]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R14)

### Widget and Manifest Updates

- **Default Zoom Level:** Changed the default zoom level for the Google Map widget from 16 to 14 for a more appropriate initial view.
- **Lazy Loading for Map Iframe:** Enabled lazy loading on the Google Map iframe to improve performance.
- **Module Version Bumps:** Updated module versions in `__manifest__.py` and `README.md` to reflect these changes. [[1]](diffhunk://#diff-43e696f6e216406b879cfbbf6d820297dfc117930d25747387df839fc91fe59bL17-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R23) [[3]](diffhunk://#diff-5d28b84ef97b40af77ca08b62fb32155a7995a4010de105ec5e4bb2c657e15adL15-R15)

These updates improve maintainability, user experience, and performance across the Google Maps modules.