### PR TITLE
[IMP] web_view_google_map: Enhance nearby search coverage overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [project_google_map](/project_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Projects |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
-| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.15 | Base module for a new view "google_map" |
+| [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.16 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.11 | Base module for sub view of "google_map" for drawing capability |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.4 | Base module of Google Maps widget |
 | [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.6 | Implementation of Google Places Autocomplete Element |

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 19.0.1.0.16
+
+- [Added] **Nearby Search Crosshair Overlay**: The nearby search coverage area now renders two dotted polylines forming a crosshair at the bounding box center, visually marking the origin point used for the radius calculation
+- [Added] **Dedicated Nearby Search Styling Constants**: Extracted overlay styling (stroke color, opacity, fill opacity, dot scale/repeat) into a `NEARBY_SEARCH` block within `MARKER_CONFIG`, keeping visual configuration in one place
+- [Improved] **Nearby Coverage Area Rendering Order**: Moved `clearNearbySearchCoverageArea()` from `renderGeolocationData()` into `renderNearbySearchCoverageArea()` itself, so the coverage overlay is cleared and redrawn atomically on each render cycle
+- [Improved] **Bounding Box Validation**: Added a `Number.isFinite` guard on all four bbox coordinates before rendering; logs a warning and exits early if any value is invalid
+- [Improved] **Antimeridian-Aware Crosshair**: Midpoint longitude for the crosshair is computed correctly when the bounding box crosses the antimeridian (east < west)
+- [Fixed] **Polyline Cleanup**: `clearNearbySearchCoverageArea()` now also removes and resets `_nearbySearchCoveragePolylines`, preventing orphaned overlay elements when the nearby search is cleared
+
 ## 19.0.1.0.15
 
 - [Fixed] **Nearby Search Robustness**: Invalid `nearby_radius_search` config values (e.g. non-integer strings) now fall back to the default 1000 meters instead of raising an unhandled exception

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.15',
+    'version': '1.0.16',
     'depends': ['base_google_map'],
     'data': ['views/res_config_settings.xml'],
     'assets': {

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -55,6 +55,14 @@ const MARKER_CONFIG = {
         SELECTED_SCALE: 1.4,
         SELECTED_COLOR: '#4285F4',
     },
+    NEARBY_SEARCH: {
+        STROKE_COLOR: 'rgb(255, 61, 61)',
+        STROKE_OPACITY: 0.8,
+        STROKE_WEIGHT: 1.2,
+        FILL_OPACITY: 0.3,
+        DOT_SCALE: 0.5,
+        DOT_REPEAT: '5px',
+    },
     BOUNDS: {
         DEFAULT_PADDING: 200,
         MAX_AUTO_ZOOM: 15,
@@ -95,7 +103,9 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         this.googleMapBounds = null;
         this.googleMapBoundsSelected = null;
         this.markerClusterer = null;
+
         this._nearbySearchCoverageRectangle = null;
+        this._nearbySearchCoveragePolylines = [];
 
         // Make sidebar state non-reactive
         this._isSidebarAction = false;
@@ -248,8 +258,6 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
     async renderGeolocationData() {
         if (!this.isMapLoaded()) return;
 
-        this.clearNearbySearchCoverageArea();
-
         this.clearMarkers();
 
         await this.renderMarkers();
@@ -266,22 +274,75 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
      * indicate a nearby search.
      */
     renderNearbySearchCoverageArea() {
+        this.clearNearbySearchCoverageArea();
+
         const context = this.props.list.evalContext;
-        if (context?.is_nearby_search && context?.nearby_bounding_box) {
-            this._nearbySearchCoverageRectangle = new google.maps.Rectangle({
-                strokeColor: MARKER_CONFIG.VISUAL.CONNECTION_LINE.STROKE_COLOR,
-                strokeOpacity: 0.8,
-                strokeWeight: 1.5,
-                fillColor: MARKER_CONFIG.VISUAL.CONNECTION_LINE.STROKE_COLOR,
-                fillOpacity: 0.3,
-                map: this.googleMap,
-                bounds: context.nearby_bounding_box,
-            });
-            // Fit map to rectangle bounds
-            const bounds = this._nearbySearchCoverageRectangle.getBounds();
-            if (bounds) {
-                this._fitMapBoundsWithLimit(bounds);
-            }
+
+        if (!context?.is_nearby_search || !context.nearby_bounding_box) return;
+
+        const bbox = context.nearby_bounding_box;
+        const { north, south, east, west } = bbox;
+        if (![north, south, east, west].every(Number.isFinite)) {
+            console.warn('Invalid nearby search bounding box:', bbox);
+            return;
+        }
+
+        const {
+            FILL_OPACITY,
+            STROKE_WEIGHT,
+            DOT_REPEAT,
+            DOT_SCALE,
+            STROKE_COLOR,
+            STROKE_OPACITY
+        } = MARKER_CONFIG.NEARBY_SEARCH;
+        this._nearbySearchCoverageRectangle = new google.maps.Rectangle({
+            strokeColor: STROKE_COLOR,
+            strokeOpacity: STROKE_OPACITY,
+            strokeWeight: STROKE_WEIGHT,
+            fillColor: STROKE_COLOR,
+            fillOpacity: FILL_OPACITY,
+            map: this.googleMap,
+            bounds: bbox,
+        });
+
+        const polylineOptions = {
+            strokeOpacity: 0,
+            icons: [
+                {
+                    icon: {
+                        path: google.maps.SymbolPath.CIRCLE,
+                        fillOpacity: FILL_OPACITY,
+                        fillColor: STROKE_COLOR,
+                        strokeOpacity: STROKE_OPACITY,
+                        strokeColor: STROKE_COLOR,
+                        scale: DOT_SCALE,
+                    },
+                    offset: '0',
+                    repeat: DOT_REPEAT,
+                },
+            ],
+            map: this.googleMap,
+        };
+        const midLat = (north + south) / 2;
+        let midLng = (east + west) / 2;
+        if (east < west) {
+            // handle antimeridian crossing
+            midLng = midLng > 0 ? midLng - 180 : midLng + 180;
+        }
+
+        // Two midlines forming a crosshair at the center — marks the origin point used for the nearby search radius
+        const polylinePaths = [
+            [{ lat: midLat, lng: west }, { lat: midLat, lng: east }],    // E → W
+            [{ lat: north, lng: midLng }, { lat: south, lng: midLng }],  // N → S
+        ];
+        this._nearbySearchCoveragePolylines = polylinePaths.map(
+            (path) => new google.maps.Polyline({ ...polylineOptions, path })
+        );
+
+        // Fit map to rectangle bounds
+        const bounds = this._nearbySearchCoverageRectangle.getBounds();
+        if (bounds) {
+            this._fitMapBoundsWithLimit(bounds);
         }
     }
 
@@ -421,6 +482,12 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         if (this._nearbySearchCoverageRectangle) {
             this._nearbySearchCoverageRectangle.setMap(null);
             this._nearbySearchCoverageRectangle = null;
+        }
+        if (this._nearbySearchCoveragePolylines.length > 0) {
+            for (const polyline of this._nearbySearchCoveragePolylines) {
+                polyline.setMap(null);
+            }
+            this._nearbySearchCoveragePolylines = [];
         }
     }
 

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -332,7 +332,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
 
         // Two midlines forming a crosshair at the center — marks the origin point used for the nearby search radius
         const polylinePaths = [
-            [{ lat: midLat, lng: west }, { lat: midLat, lng: east }],    // E → W
+            [{ lat: midLat, lng: west }, { lat: midLat, lng: east }],    // W → E
             [{ lat: north, lng: midLng }, { lat: south, lng: midLng }],  // N → S
         ];
         this._nearbySearchCoveragePolylines = polylinePaths.map(
@@ -474,9 +474,9 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
     }
 
     /**
-     * Removes the nearby search coverage rectangle from the map and releases the reference.
-     * Called by {@link renderGeolocationData} on every re-render to prevent stale rectangles
-     * from accumulating. Safe to call when no rectangle is currently rendered.
+     * Typically invoked from {@link renderNearbySearchCoverageArea} during re-renders to
+     * prevent stale coverage shapes from accumulating. Safe to call when no rectangle is
+     * currently rendered.
      */
     clearNearbySearchCoverageArea() {
         if (this._nearbySearchCoverageRectangle) {


### PR DESCRIPTION
- Add dotted crosshair polylines at the bounding box center to mark the search origin point
- Extract nearby search overlay styling into a dedicated NEARBY_SEARCH block in MARKER_CONFIG
- Move clearNearbySearchCoverageArea() into renderNearbySearchCoverageArea() so the overlay is cleared and redrawn atomically
- Add Number.isFinite guard on bounding box coordinates before rendering
- Handle antimeridian crossing when computing the crosshair midpoint
- Fix polyline cleanup in clearNearbySearchCoverageArea() to prevent orphaned overlay elements
- Bump version to 19.0.1.0.16