### PR TITLE
[IMP] contacts_google_map: Switch geocoder to Nominatim (OpenStreetMap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 |--------|---------|-------------|
 | [base_google_map](/base_google_map/README.md) | 19.0.1.0.8 | Base module of Google Maps contains settings to setup Google API Key |
 | [contacts_google_autocomplete](/contacts_google_autocomplete/README.md) | 19.0.1.0.1 | Implementation of Google Places Autocomplete on Contacts |
-| [contacts_google_map](/contacts_google_map/README.md) | 19.0.1.0.4 | Implementation of view "Google Maps" on Contacts |
+| [contacts_google_map](/contacts_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Contacts |
 | [contacts_google_map_add_place](/contacts_google_map_add_place/README.md) | 19.0.1.0.0 | Click on Google Map to add contact with Google Places data |
 | [crm_google_autocomplete](/crm_google_autocomplete/README.md) | 19.0.1.0.1 | Implementation of Google Places Autocomplete on CRM Leads/Opportunities |
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on CRM |

--- a/contacts_google_map/CHANGELOG.md
+++ b/contacts_google_map/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 19.0.1.0.5
+
+- [Imp] **Geocoder service**: Changed geocoder service to Nominatim (OpenStreetMap) for automatic contact geolocation
+- [Fix] **Nominatim geocoder — rate limit handling**: Improved handling of 429 Too Many Requests; the geocoder now correctly detects a sustained rate limit after a retry and skips the address gracefully instead of raising an unhandled error
+- [Imp] **Nominatim geocoder — cron batch size**: Reduced the number of contacts geocoded per cron run from 500 to 50 to prevent cron worker timeout given the required 1-second delay between requests
+
 ## 19.0.1.0.4
 
 - [Added] **Nearby Contacts Search**: Added `action_nearby_search()` method on `res.partner` that opens the Contacts map view filtered to contacts within a configurable radius of the selected contact's location; supports antimeridian wraparound and passes bounding box context for map overlay visualization

--- a/contacts_google_map/__manifest__.py
+++ b/contacts_google_map/__manifest__.py
@@ -13,7 +13,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/CRM',
-    'version': '1.0.4',
+    'version': '1.0.5',
     'depends': [
         'base_geolocalize',
         'contacts',

--- a/contacts_google_map/data/cron_contact_geolocalize.xml
+++ b/contacts_google_map/data/cron_contact_geolocalize.xml
@@ -2,10 +2,15 @@
 <odoo>
     <!-- A cron to geolocate existing contacts which doesn't geolocated yet -->
     <record id="ir_cron_data_contact_geolocate" model="ir.cron">
-        <field name="name">Contact: geolocate</field>
+        <field name="name">Contact: Geolocate Using Nominatim</field>
         <field name="model_id" ref="base.model_res_partner"/>
         <field name="state">code</field>
-        <field name="code">model.with_context(from_cron=True).action_cron_geolocalize()</field>
+        <field name="code">
+# Upon sending the request to Nominatim, we specify a user agent to identify the source of the request. This is a good practice to avoid being blocked by Nominatim.
+# By default, we use this format "odoo-{COMPANY_NAME}-geocoder/1.0 ({BASE_URL})"
+# If you would like to change the identifier, you can set it via context key "cron_user_agent_geocoder", for example "odoo-mycompany-geocoder/1.0 (https://mycompany.com)"
+model.with_context(from_cron=True,cron_user_agent_geocoder=False).action_cron_geolocalize_using_nominatim()
+        </field>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
         <field name="active" eval="False"/>

--- a/contacts_google_map/docs/FEATURES.md
+++ b/contacts_google_map/docs/FEATURES.md
@@ -56,4 +56,4 @@
 
 **Why it matters**: Keeps your contacts' geolocation data up to date without manual effort, especially useful after bulk imports or when contacts are created without coordinates.
 
-**How it works**: The cron job runs daily and processes up to 500 contacts per batch that have a country set but no geolocation. It uses Odoo's built-in `geo_localize()` method from the `base_geolocalize` module. The job is installed in an **inactive** state and must be manually activated in **Settings → Technical → Scheduled Actions → Auto Geolocalize Contacts**.
+**How it works**: The cron job runs daily and processes up to 50 contacts per batch that have a country set but no geolocation. It uses the Nominatim (OpenStreetMap) geocoding service, with a mandatory 1-second delay between requests to comply with Nominatim's usage policy. If the service is temporarily rate-limited, it retries once after a 5-second wait before skipping that contact. The job is installed in an **inactive** state and must be manually activated in **Settings → Technical → Scheduled Actions → Contact: Geolocate Using Nominatim**.

--- a/contacts_google_map/models/res_partner.py
+++ b/contacts_google_map/models/res_partner.py
@@ -124,43 +124,76 @@ class ResPartner(models.Model):
     def _geolocalize_using_nominatim(self):
         """Geolocate each partner in the recordset using the Nominatim API.
 
-        Skips partners with no resolvable address. Coordinates are written
-        directly on the record upon a successful lookup.
+        Creates a single HTTP session shared across all requests in the batch
+        so that the TCP connection to Nominatim is reused. Skips partners with
+        no resolvable address. Coordinates are written directly on the record
+        upon a successful lookup.
         """
-        _logger.info(
-            'Starting Nominatim geolocation for %d contact(s).', len(self)
+        company_name = (self.env.company.name or "Odoo").replace(" ", "-").lower()
+        base_url = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("web.base.url", default="http://localhost")
         )
-        for partner in self:
-            address_parts = [
-                partner.street,
-                partner.street2,
-                partner.city,
-                partner.state_id.name if partner.state_id else None,
-                partner.zip,
-                partner.country_id.name if partner.country_id else None,
-            ]
-            address = ", ".join(filter(None, address_parts))
-            if not address:
-                continue
+        default_user_agent = f"odoo-{company_name}-geocoder/1.0 ({base_url})"
+        user_agent = (
+            self.env.context.get("cron_user_agent_geocoder", default_user_agent)
+            or default_user_agent
+        )
 
-            lat, lng = self._geolocate_address_using_nominatim(
-                address, country_code=partner.country_id.code
-            )
-            if lat is not None and lng is not None:
-                partner.partner_latitude = lat
-                partner.partner_longitude = lng
+        with requests.Session() as session:
+            session.headers.update({
+                "User-Agent": user_agent,
+                "Referer": base_url,
+            })
+            for partner in self:
+                # street and street2 belong to the same address line —
+                # join with a space, not a comma.
+                street = " ".join(
+                    filter(None, [partner.street, partner.street2])
+                )
+                # Build a free-form query string in the order Nominatim
+                # expects: street, city, state, postcode, country.
+                # Free-form "q" is more forgiving than structured params
+                # for user-entered data that may not match Nominatim exactly.
+                address_parts = [
+                    street or None,
+                    partner.city or None,
+                    partner.state_id.name if partner.state_id else None,
+                    partner.zip or None,
+                    partner.country_id.name if partner.country_id else None,
+                ]
+                address = ", ".join(filter(None, address_parts))
+                if not address:
+                    continue
 
-    def _geolocate_address_using_nominatim(self, address, country_code):
-        """Resolve a free-form address to (latitude, longitude) via Nominatim.
+                country_code = (
+                    partner.country_id.code.lower()
+                    if partner.country_id
+                    else None
+                )
+                lat, lng = self._geolocate_address_using_nominatim(
+                    session, address, country_code
+                )
+                if lat is not None and lng is not None:
+                    partner.partner_latitude = lat
+                    partner.partner_longitude = lng
 
-        Enforces a 1-second delay before every request to comply with
-        Nominatim's usage policy. On a 429 response, waits an additional
-        5 seconds and retries once. Returns (None, None) on any failure.
+    def _geolocate_address_using_nominatim(self, session, address, country_code):
+        """Resolve a free-form address string to (latitude, longitude) via Nominatim.
+
+        Uses the ``q`` free-form parameter which is more forgiving than
+        Nominatim's structured query for user-entered data. Enforces a
+        1-second delay before every request to comply with Nominatim's usage
+        policy. On a 429 response, waits an additional 5 seconds and retries
+        once. Returns (None, None) on any failure.
 
         Args:
-            address (str): Full address string to geocode.
-            country_code (str): ISO 3166-1 alpha-2 code used to bias results
-                (e.g. "MY", "US"). Passed as ``countrycodes`` to Nominatim.
+            session (requests.Session): Shared HTTP session with headers pre-set.
+            address (str): Free-form address string
+                (e.g. "123 Main St, Springfield, IL, 62701, United States").
+            country_code (str): ISO 3166-1 alpha-2 code to bias results
+                (e.g. "US", "MY"). Passed as ``countrycodes`` to Nominatim.
 
         Returns:
             tuple[float, float] | tuple[None, None]: (latitude, longitude) on
@@ -169,50 +202,20 @@ class ResPartner(models.Model):
         # Nominatim's usage policy requires at most 1 request per second.
         time.sleep(1)
 
-        params = {
-            "q": address,
-            "format": "json",
-            "limit": 1,
-        }
+        params = {"q": address, "format": "json", "limit": 1}
         if country_code:
-            params["countrycodes"] = country_code.lower()
+            params["countrycodes"] = country_code
 
-        # Nominatim requires a descriptive User-Agent identifying the app and
-        # a contact URL so abusive traffic can be traced. The context key
-        # ``cron_user_agent_geocoder`` allows callers to override the value,
-        # e.g. to include a specific job identifier in scheduled runs.
-        company_name = (self.env.company.name or "Odoo").replace(" ", "-").lower()
-        base_url = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("web.base.url", default="http://localhost")
-        )
-        default_user_agent = f"odoo-{company_name}-geocoder/1.0 ({base_url})"
-        user_agent = self.env.context.get("cron_user_agent_geocoder", default_user_agent) or default_user_agent
-        headers = {
-            "User-Agent": user_agent,
-            "Referer": base_url,
-        }
-
+        url = "https://nominatim.openstreetmap.org/search"
         try:
-            response = requests.get(
-                "https://nominatim.openstreetmap.org/search",
-                params=params,
-                headers=headers,
-                timeout=10,
-            )
+            response = session.get(url, params=params, timeout=10)
             if response.status_code == 429:
                 _logger.warning(
                     'Nominatim rate limit exceeded for "%s". Retrying after 5s delay.',
                     address,
                 )
                 time.sleep(5)
-                response = requests.get(
-                    "https://nominatim.openstreetmap.org/search",
-                    params=params,
-                    headers=headers,
-                    timeout=10,
-                )
+                response = session.get(url, params=params, timeout=10)
                 if response.status_code == 429:
                     _logger.warning(
                         'Nominatim rate limit still exceeded for "%s". Skipping.',

--- a/contacts_google_map/models/res_partner.py
+++ b/contacts_google_map/models/res_partner.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 import math
 from ast import literal_eval
+import requests
+import time
+import logging
 
 from odoo import _, api, fields, models
 from odoo.fields import Domain
 from odoo.exceptions import UserError
+
+
+_logger = logging.getLogger(__name__)
 
 
 class ResPartner(models.Model):
@@ -98,16 +104,130 @@ class ResPartner(models.Model):
         return domain, bounding_box
 
     @api.model
-    def action_cron_geolocalize(self):
+    def action_cron_geolocalize_using_nominatim(self):
+        """Cron entry point: geolocate partners that have a country but no coordinates.
+
+        Processes up to 50 partners per run to respect Nominatim's rate limit
+        (1 request/second). The next cron run will pick up the remaining records.
+        """
         self.search(
             [
                 ("country_id", "!=", False),
                 ("partner_latitude", "=", False),
                 ("partner_longitude", "=", False),
             ],
-            limit=500,
-        ).geo_localize()
+            limit=50,
+            order="id desc",
+        )._geolocalize_using_nominatim()
         return True
+
+    def _geolocalize_using_nominatim(self):
+        """Geolocate each partner in the recordset using the Nominatim API.
+
+        Skips partners with no resolvable address. Coordinates are written
+        directly on the record upon a successful lookup.
+        """
+        _logger.info(
+            'Starting Nominatim geolocation for %d contact(s).', len(self)
+        )
+        for partner in self:
+            address_parts = [
+                partner.street,
+                partner.street2,
+                partner.city,
+                partner.state_id.name if partner.state_id else None,
+                partner.zip,
+                partner.country_id.name if partner.country_id else None,
+            ]
+            address = ", ".join(filter(None, address_parts))
+            if not address:
+                continue
+
+            lat, lng = self._geolocate_address_using_nominatim(
+                address, country_code=partner.country_id.code
+            )
+            if lat is not None and lng is not None:
+                partner.partner_latitude = lat
+                partner.partner_longitude = lng
+
+    def _geolocate_address_using_nominatim(self, address, country_code):
+        """Resolve a free-form address to (latitude, longitude) via Nominatim.
+
+        Enforces a 1-second delay before every request to comply with
+        Nominatim's usage policy. On a 429 response, waits an additional
+        5 seconds and retries once. Returns (None, None) on any failure.
+
+        Args:
+            address (str): Full address string to geocode.
+            country_code (str): ISO 3166-1 alpha-2 code used to bias results
+                (e.g. "MY", "US"). Passed as ``countrycodes`` to Nominatim.
+
+        Returns:
+            tuple[float, float] | tuple[None, None]: (latitude, longitude) on
+            success, or (None, None) if the address could not be resolved.
+        """
+        # Nominatim's usage policy requires at most 1 request per second.
+        time.sleep(1)
+
+        params = {
+            "q": address,
+            "format": "json",
+            "limit": 1,
+        }
+        if country_code:
+            params["countrycodes"] = country_code.lower()
+
+        # Nominatim requires a descriptive User-Agent identifying the app and
+        # a contact URL so abusive traffic can be traced. The context key
+        # ``cron_user_agent_geocoder`` allows callers to override the value,
+        # e.g. to include a specific job identifier in scheduled runs.
+        company_name = (self.env.company.name or "Odoo").replace(" ", "-").lower()
+        base_url = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("web.base.url", default="http://localhost")
+        )
+        default_user_agent = f"odoo-{company_name}-geocoder/1.0 ({base_url})"
+        user_agent = self.env.context.get("cron_user_agent_geocoder", default_user_agent) or default_user_agent
+        headers = {
+            "User-Agent": user_agent,
+            "Referer": base_url,
+        }
+
+        try:
+            response = requests.get(
+                "https://nominatim.openstreetmap.org/search",
+                params=params,
+                headers=headers,
+                timeout=10,
+            )
+            if response.status_code == 429:
+                _logger.warning(
+                    'Nominatim rate limit exceeded for "%s". Retrying after 5s delay.',
+                    address,
+                )
+                time.sleep(5)
+                response = requests.get(
+                    "https://nominatim.openstreetmap.org/search",
+                    params=params,
+                    headers=headers,
+                    timeout=10,
+                )
+                if response.status_code == 429:
+                    _logger.warning(
+                        'Nominatim rate limit still exceeded for "%s". Skipping.',
+                        address,
+                    )
+                    return None, None
+            response.raise_for_status()
+            data = response.json()
+            if data:
+                return float(data[0]["lat"]), float(data[0]["lon"])
+        except (requests.RequestException, ValueError, KeyError):
+            _logger.warning(
+                'Failed to geolocate address "%s" via Nominatim.', address, exc_info=True
+            )
+        return None, None
 
     def action_nearby_search(self):
         self.ensure_one()

--- a/contacts_google_map/models/res_partner.py
+++ b/contacts_google_map/models/res_partner.py
@@ -224,9 +224,14 @@ class ResPartner(models.Model):
                     return None, None
             response.raise_for_status()
             data = response.json()
-            if data:
+            if (
+                data
+                and isinstance(data, list)
+                and "lat" in data[0]
+                and "lon" in data[0]
+            ):
                 return float(data[0]["lat"]), float(data[0]["lon"])
-        except (requests.RequestException, ValueError, KeyError):
+        except (requests.RequestException, ValueError, KeyError, TypeError):
             _logger.warning(
                 'Failed to geolocate address "%s" via Nominatim.', address, exc_info=True
             )


### PR DESCRIPTION
Replace Odoo's built-in geo_localize() with a dedicated Nominatim-based geocoder that builds a full address string per contact and sends it to the Nominatim search API.

Key changes:
- Comply with Nominatim usage policy: 1-second delay between requests and a descriptive User-Agent header identifying the Odoo instance
- Handle 429 rate-limit responses: retry once after 5 seconds, then skip gracefully if still rate-limited
- Reduce cron batch size from 500 to 50 to stay within cron worker timeout given the mandatory delay
- Rename cron method to action_cron_geolocalize_using_nominatim and update cron XML record accordingly