### PR TITLE
[IMP] web_view_google_map_drawing: Remove showNearbyRecords prop from drawing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.17 | Base module for a new view "google_map" |
-| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.11 | Base module for sub view of "google_map" for drawing capability |
+| [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.12 | Base module for sub view of "google_map" for drawing capability |
 | [web_widget_google_map](/web_widget_google_map/README.md) | 19.0.1.0.4 | Base module of Google Maps widget |
 | [web_widget_google_place_autocomplete](/web_widget_google_place_autocomplete/README.md) | 19.0.1.0.6 | Implementation of Google Places Autocomplete Element |
 

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 19.0.1.0.12
+
+- [Fixed] **Props Compatibility**: Excluded `showNearbyRecords` from `GoogleMapsDrawingSidebar.props` — the prop is inherited from the base sidebar but unused in drawing mode, causing OWL prop validation warnings
+- [Improved] **Controller**: Overrode `rendererProps` in `GoogleMapDrawingController` to strip `showNearbyRecords` before passing props to the renderer, keeping the drawing view decoupled from nearby search functionality
+
 ## 19.0.1.0.11
 
 - [Improved] **Sidebar UI**: Removed the "Show Nearby" button from the drawing view's sidebar record items — the nearby search action is not applicable in the drawing context and the button was inherited from the base map view

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.11',
+    'version': '1.0.12',
     'depends': ['web_view_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_controller.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_controller.js
@@ -15,11 +15,9 @@ export class GoogleMapDrawingController extends GoogleMapController {
     }
 
     get rendererProps() {
-        const rendererProps = super.rendererProps;
+        const { showNearbyRecords, ...rendererProps } = super.rendererProps;
         // remove unnecessary properties
         // following properties are not used in drawing mode
-        delete rendererProps.showNearbyRecords;
-
         return rendererProps;
     }
 }

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_controller.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_controller.js
@@ -1,4 +1,3 @@
-import { _t } from '@web/core/l10n/translation';
 import { GoogleMapController } from '@web_view_google_map/views/google_map/google_map_controller';
 
 
@@ -13,5 +12,14 @@ export class GoogleMapDrawingController extends GoogleMapController {
         return Object.assign({}, viewConfig, {
             geoJsonField: this.archInfo.geoJsonField,
         });
+    }
+
+    get rendererProps() {
+        const rendererProps = super.rendererProps;
+        // remove unnecessary properties
+        // following properties are not used in drawing mode
+        delete rendererProps.showNearbyRecords;
+
+        return rendererProps;
     }
 }

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.js
@@ -1,7 +1,11 @@
-import { _t } from '@web/core/l10n/translation';
 import { GoogleMapSidebar } from '@web_view_google_map/views/google_map/google_map_sidebar';
+
+const googleMapSidebarProps = { ...GoogleMapSidebar.props };
+// remove unnecessary properties
+delete googleMapSidebarProps.showNearbyRecords;
 
 export class GoogleMapsDrawingSidebar extends GoogleMapSidebar {
     static recordItemTemplate = 'web_view_google_map_drawing.RecordItem';
     static groupItemTemplate = 'web_view_google_map_drawing.GroupItem';
+    static props = { ...googleMapSidebarProps };
 }

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.js
@@ -1,8 +1,7 @@
 import { GoogleMapSidebar } from '@web_view_google_map/views/google_map/google_map_sidebar';
 
-const googleMapSidebarProps = { ...GoogleMapSidebar.props };
-// remove unnecessary properties
-delete googleMapSidebarProps.showNearbyRecords;
+const { showNearbyRecords, ...googleMapSidebarProps } = GoogleMapSidebar.props;
+// remove unnecessary properties (showNearbyRecords is excluded via destructuring)
 
 export class GoogleMapsDrawingSidebar extends GoogleMapSidebar {
     static recordItemTemplate = 'web_view_google_map_drawing.RecordItem';


### PR DESCRIPTION
- Override `rendererProps` in `GoogleMapDrawingController` to strip `showNearbyRecords`, which is not applicable in drawing mode
- Exclude `showNearbyRecords` from `GoogleMapsDrawingSidebar.props` by deriving from `GoogleMapSidebar.props` and deleting the key