### PR TITLE
[IMP] project_google_map: Add task map view and "View Tasks" action (v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [crm_google_map](/crm_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on CRM |
 | [crm_google_map_add_place](/crm_google_map_add_place/README.md) | 19.0.1.0.0 | Click on Google Map to add CRM Lead/Opportunity with Google Places data |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.3 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
-| [project_google_map](/project_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Projects |
+| [project_google_map](/project_google_map/README.md) | 19.0.1.0.1 | Implementation of view "Google Maps" on Projects |
 | [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.5 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.17 | Base module for a new view "google_map" |

--- a/project_google_map/CHANGELOG.md
+++ b/project_google_map/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+
+## 1.0.1
+
+### Added
+
+- **Task Map View**: Tasks within a project can now be viewed on a Google Map using their site locations
+- **Task Site Location**: Tasks have a new "Site Information" section (under Extra Info tab) with a site address field, coordinates display, and embedded satellite map
+- **Task Marker Color**: Each task can have a custom marker color set via a color picker
+- **"View Tasks" Button**: Project markers on the map and sidebar entries now include a "View Tasks" button that opens the filtered task list for that project
+- **Custom Project Map View** (`google_map_project`): Dedicated JavaScript view type for projects, extending the base Google Map view with the "View Tasks" action in both the marker info window and sidebar
+
+### Improved
+
+- **View Mode Registration**: Moved from static XML to `post_init_hook` / `uninstall_hook` for cleaner installation and uninstallation
+
+## 1.0.0
+
+- [Added] **Project Map View**: Google Map view for the Projects list showing each project as a marker at its site location
+- [Added] **Site Address Field**: `partner_site_id` field on `project.project` linking a project to a physical site address
+- [Added] **Coordinates Display**: Latitude and longitude shown on the project form's Site tab, derived from the linked site partner's geolocation data
+- [Added] **Embedded Satellite Map**: Project form Site tab displays an embedded satellite map of the selected site location
+- [Added] **Status-Colored Markers**: Project markers are automatically color-coded by health status — green (on track), orange (at risk), red (off track), cyan (on hold), purple (done), gray (none)
+- [Added] **Site Partner Type**: New "Site" option added to the partner type selection, with a dedicated avatar icon, to keep site addresses organized separately from regular contacts

--- a/project_google_map/README.md
+++ b/project_google_map/README.md
@@ -2,19 +2,31 @@
 
 ## Overview
 
-This module adds a Google Maps view to Odoo's Project application. It lets you assign a physical site location to each project and view all projects as markers on an interactive map, with colors that reflect each project's current status.
+This module adds Google Maps views to Odoo's Project application. It lets you assign physical site locations to both projects and tasks, then view them as markers on interactive maps. Project markers are automatically color-coded by health status, giving a quick visual overview of your portfolio across locations.
 
 ## What It Does
 
-Extends the standard Project app with site location support. Each project can be linked to a site address, and those projects can then be viewed on a Google Map. Marker colors automatically reflect the project's health status, giving a quick visual overview of your project portfolio across locations.
+Extends the standard Project app with site location support for both projects and tasks. Projects and tasks can each be linked to a site address and viewed on a Google Map. Project markers change color automatically based on project status, while task markers can be customized with individual colors.
 
 ## Key Features
 
-- **Map View for Projects**: Adds a "Map" view to the Projects list, showing each project as a marker at its site location
-- **Status-Colored Markers**: Markers are color-coded by project status — green (on track), orange (at risk), red (off track), cyan (on hold), and purple (done)
-- **Site Address Field**: Adds a "Site" tab to the project form for linking the project to a site address
-- **Embedded Map in Form**: The project form displays a satellite map of the site location directly on the Site tab
-- **Site Partner Type**: Introduces a "Site" type for partners, with a dedicated icon, to keep site addresses organized separately from regular contacts
+### Projects
+
+- **Map View**: Adds a "Map" view to the Projects list showing each project as a marker at its site location
+- **Status-Colored Markers**: Markers are automatically color-coded by project health status — green (on track), orange (at risk), red (off track), cyan (on hold), purple (done)
+- **Site Address Field**: Adds a "Site" tab to the project form for linking a site address to the project
+- **Embedded Map**: The project form's Site tab displays a satellite map of the selected site location
+- **Quick Task Access**: A "View Tasks" button in the map marker and sidebar opens the task list for that project
+
+### Tasks
+
+- **Map View**: Adds a "Map" view to the task list within a project, showing tasks by their site locations
+- **Custom Marker Color**: Each task can have an individually set marker color using a color picker
+- **Site Information**: Task form includes a site address field, coordinates display, and embedded satellite map under Extra Info → Site Information
+
+### General
+
+- **Site Partner Type**: Introduces a "Site" partner type with a dedicated icon, keeping site addresses organized separately from regular contacts
 
 ## Dependencies
 
@@ -29,12 +41,23 @@ Extends the standard Project app with site location support. Each project can be
 
 ## Basic Usage
 
+### For Projects
+
 1. Open a project and go to the **Site** tab
-2. The embedded map on the same tab shows the selected location
-3. From the Projects list, switch to the **Map** view to see all projects on a map
+2. Select a site address (you can create a new "Site" type partner)
+3. The embedded satellite map on the same tab shows the selected location
+4. From the Projects list, switch to the **Map** view to see all projects on a map
+5. Click a project marker to view details and use the "View Tasks" button
+
+### For Tasks
+
+1. Open a task and go to the **Extra Info** tab
+2. Under "Site Information", select a site address for the task
+3. Optionally set a custom marker color using the color picker
+4. From a project's task list, switch to the **Map** view to see all tasks on a map
 
 ## Related Modules
 
 - `web_view_google_map`: Provides the Google Map view type used by this module
 - `base_google_map`: Core module that manages the Google API Key configuration
-- `web_widget_google_map`: Provides the Google Map widget used in the project form
+- `web_widget_google_map`: Provides the embedded Google Map widget used in project and task forms

--- a/project_google_map/__init__.py
+++ b/project_google_map/__init__.py
@@ -1,1 +1,74 @@
 from . import models
+
+
+def post_init_hook(env):
+    # Project actions
+    action_project1 = env.ref('project.open_view_project_all', raise_if_not_found=False)
+    if action_project1:
+        view_mode = action_project1.view_mode.split(',')
+        if 'google_map' not in view_mode:
+            view_mode.append('google_map')
+            action_project1.view_mode = ','.join(view_mode)
+
+    action_project2 = env.ref('project.open_view_project_all_group_stage', raise_if_not_found=False)
+    if action_project2:
+        view_mode = action_project2.view_mode.split(',')
+        if 'google_map' not in view_mode:
+            view_mode.append('google_map')
+            action_project2.view_mode = ','.join(view_mode)
+
+    action_project3 = env.ref('project.open_view_project_all_config', raise_if_not_found=False)
+    if action_project3:
+        view_mode = action_project3.view_mode.split(',')
+        if 'google_map' not in view_mode:
+            view_mode.append('google_map')
+            action_project3.view_mode = ','.join(view_mode)
+
+    action_project4 = env.ref('project.open_view_project_all_config_group_stage', raise_if_not_found=False)
+    if action_project4:
+        view_mode = action_project4.view_mode.split(',')
+        if 'google_map' not in view_mode:
+            view_mode.append('google_map')
+            action_project4.view_mode = ','.join(view_mode)
+
+    # Task actions
+    action_task1 = env.ref('project.act_project_project_2_project_task_all', raise_if_not_found=False)
+    if action_task1:
+        view_mode = action_task1.view_mode.split(',')
+        if 'google_map' not in view_mode:
+            view_mode.append('google_map')
+            action_task1.view_mode = ','.join(view_mode)
+
+
+def uninstall_hook(env):
+    # Remove google_map view from project actions
+    action_project1 = env.ref('project.open_view_project_all', raise_if_not_found=False)
+    if action_project1 and action_project1.view_mode:
+        view_mode = action_project1.view_mode.split(',')
+        if 'google_map' in view_mode:
+            action_project1.view_mode = ','.join([mode for mode in view_mode if mode != 'google_map'])
+
+    action_project2 = env.ref('project.open_view_project_all_group_stage', raise_if_not_found=False)
+    if action_project2 and action_project2.view_mode:
+        view_mode = action_project2.view_mode.split(',')
+        if 'google_map' in view_mode:
+            action_project2.view_mode = ','.join([mode for mode in view_mode if mode != 'google_map'])
+
+    action_project3 = env.ref('project.open_view_project_all_config', raise_if_not_found=False)
+    if action_project3 and action_project3.view_mode:
+        view_mode = action_project3.view_mode.split(',')
+        if 'google_map' in view_mode:
+            action_project3.view_mode = ','.join([mode for mode in view_mode if mode != 'google_map'])
+
+    action_project4 = env.ref('project.open_view_project_all_config_group_stage', raise_if_not_found=False)
+    if action_project4 and action_project4.view_mode:
+        view_mode = action_project4.view_mode.split(',')
+        if 'google_map' in view_mode:
+            action_project4.view_mode = ','.join([mode for mode in view_mode if mode != 'google_map'])
+
+    # Remove google_map view from task actions
+    action_task1 = env.ref('project.act_project_project_2_project_task_all', raise_if_not_found=False)
+    if action_task1 and action_task1.view_mode:
+        view_mode = action_task1.view_mode.split(',')
+        if 'google_map' in view_mode:
+            action_task1.view_mode = ','.join([mode for mode in view_mode if mode != 'google_map'])

--- a/project_google_map/__manifest__.py
+++ b/project_google_map/__manifest__.py
@@ -11,14 +11,24 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Project',
-    'version': '1.0.0',
+    'version': '1.0.1',
     'depends': [
         'project',
         'web_view_google_map',
         'web_widget_google_map',
     ],
-    'data': ['views/project_project.xml'],
+    'data': [
+        'views/project_project.xml',
+        'views/project_task.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'project_google_map/static/src/views/**/*',
+        ],
+    },
     'demo': [],
+    'post_init_hook': 'post_init_hook',
+    'uninstall_hook': 'uninstall_hook',
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/project_google_map/__manifest__.py
+++ b/project_google_map/__manifest__.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Project Google Maps',
-    'summary': 'Show projects in Google Maps view',
+    'summary': 'Display and navigate projects on an interactive Google Maps view',
     'description': '''
-        A new view 'Google Maps' added on projects, gives you
-        an ability to show the project location in Google Maps
+        Adds a Google Maps view to the Project module, allowing you to
+        visualize project locations on an interactive map. Each project
+        is shown as a marker based on its site coordinates. A sidebar
+        lists all projects alongside the map, and a "View Tasks" button
+        on each project opens the related task list directly from the map.
     ''',
     'license': 'AGPL-3',
     'author': 'Yopi Angi',

--- a/project_google_map/docs/FEATURES.md
+++ b/project_google_map/docs/FEATURES.md
@@ -1,0 +1,122 @@
+# Project Google Map - Features
+
+## Project Features
+
+### Site Address Field
+
+**What it does**: Adds a "Site" tab to the project form where you can link the project to a physical site address.
+
+**Why it matters**: Separates the site location from the billing/customer address, letting you track where work actually happens.
+
+**How it works**: A dedicated site address field on each project stores a partner (contact) record as the site location. Latitude and longitude are automatically read from that partner's geolocation data.
+
+---
+
+### Status-Based Marker Colors
+
+**What it does**: Project markers on the map are automatically color-coded based on the project's health status.
+
+**Why it matters**: Gives you an instant visual overview of project health across your entire portfolio — no need to click into each project.
+
+**How it works**: The marker color is computed from the project's last update status using these colors:
+
+- Green: On Track
+- Orange: At Risk
+- Red: Off Track
+- Cyan: On Hold
+- Purple: Done
+- Gray: No status set
+
+---
+
+### Map View for Projects
+
+**What it does**: Adds a "Map" view to the Projects list, showing each project as a colored marker at its site location.
+
+**Why it matters**: Lets you see where all your projects are geographically and assess their status at a glance.
+
+**How it works**: The map view displays project markers using the site address coordinates. The sidebar lists all projects alongside the map. Click a marker to see project details and available actions.
+
+---
+
+### Embedded Satellite Map in Project Form
+
+**What it does**: Shows a satellite map of the site location directly on the project form's Site tab.
+
+**Why it matters**: Lets you confirm the correct site location without leaving the project form.
+
+**How it works**: When a site address is selected, an embedded satellite map (400px height) renders automatically on the Site tab showing the location.
+
+---
+
+### Quick Task Access from Map
+
+**What it does**: A "View Tasks" button in the project marker info window and in the map sidebar lets you open the task list for a project directly from the map.
+
+**Why it matters**: Reduces navigation steps when you want to drill into a project's tasks from the map view.
+
+**How it works**: Clicking "View Tasks" in the marker popup or sidebar item opens a filtered task list for that specific project.
+
+---
+
+## Task Features
+
+### Task Site Location
+
+**What it does**: Adds a "Site Information" section in the task form's Extra Info tab where you can assign a site address to each task.
+
+**Why it matters**: Tasks often need to be performed at locations different from the project's main site — this lets each task track its own location.
+
+**How it works**: Each task has its own site address field (linked to a partner record). Latitude and longitude are read from that partner's geolocation data.
+
+---
+
+### Custom Task Marker Color
+
+**What it does**: Each task can have its own marker color, set via a color picker in the task form.
+
+**Why it matters**: Lets teams visually categorize tasks on the map using their own color schemes (by priority, type, team, etc.).
+
+**How it works**: A color picker field on the task form lets you choose a color. That color is used for the task's marker on the map view.
+
+---
+
+### Map View for Tasks
+
+**What it does**: Adds a "Map" view to the task list within a project, showing tasks as markers at their site locations.
+
+**Why it matters**: Gives a geographic overview of all work within a project, useful for field service and multi-site operations.
+
+**How it works**: The map view displays task markers using site address coordinates, with task name and customer shown in the sidebar. The marker color reflects the custom color set on each task.
+
+---
+
+### Embedded Satellite Map in Task Form
+
+**What it does**: Shows a satellite map of the task's site location directly within the "Site Information" section of the task form.
+
+**Why it matters**: Lets you verify the exact task location without leaving the form.
+
+**How it works**: When a site address is selected on the task, an embedded satellite map (400px height) renders automatically alongside the address fields.
+
+---
+
+## Site Partner Management
+
+### Site Partner Type
+
+**What it does**: Adds a "Site" option to the partner type selection, allowing contacts to be designated as physical site locations.
+
+**Why it matters**: Keeps site addresses organized separately from regular customer and vendor contacts, making them easier to find and manage.
+
+**How it works**: When creating or editing a partner, you can set its type to "Site". Site-type partners are offered by default when selecting a site address on projects or tasks.
+
+---
+
+### Custom Site Partner Icon
+
+**What it does**: Site-type partners display a distinctive icon instead of the standard contact avatar.
+
+**Why it matters**: Makes site partners immediately recognizable in lists and dropdowns, helping distinguish locations from people and companies.
+
+**How it works**: When a partner's type is "Site", the module automatically uses a dedicated site icon as the avatar placeholder.

--- a/project_google_map/i18n/project_google_map.pot
+++ b/project_google_map/i18n/project_google_map.pot
@@ -130,20 +130,6 @@ msgid "Task Sites"
 msgstr ""
 
 #. module: project_google_map
-#: model:ir.model.fields,help:project_google_map.field_project_task__display_name
-msgid ""
-"Use these keywords in the title to set new tasks:\n"
-"\n"
-"            #tags Set tags on the task\n"
-"            @user Assign the task to a user\n"
-"            ! Set the task a medium priority\n"
-"            !! Set the task a high priority\n"
-"            !!! Set the task a urgent priority\n"
-"\n"
-"            Make sure to use the right format and order e.g. Improve the configuration screen #feature #v16 @Mitchell !"
-msgstr ""
-
-#. module: project_google_map
 #. odoo-javascript
 #: code:addons/project_google_map/static/src/views/google_map/google_map_renderer.xml:0
 #: code:addons/project_google_map/static/src/views/google_map/google_map_sidebar.xml:0

--- a/project_google_map/i18n/project_google_map.pot
+++ b/project_google_map/i18n/project_google_map.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-04 09:45+0000\n"
-"PO-Revision-Date: 2026-03-04 09:45+0000\n"
+"POT-Creation-Date: 2026-04-07 14:47+0000\n"
+"PO-Revision-Date: 2026-04-07 14:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,6 +17,7 @@ msgstr ""
 
 #. module: project_google_map
 #: model_terms:ir.ui.view,arch_db:project_google_map.view_project_project_google_map_form
+#: model_terms:ir.ui.view,arch_db:project_google_map.view_project_task_form2_inherit_google_map
 msgid "Address"
 msgstr ""
 
@@ -37,44 +38,57 @@ msgid "Create a Customer"
 msgstr ""
 
 #. module: project_google_map
+#: model:ir.model,website_form_label:project_google_map.model_project_task
+msgid "Create a Task"
+msgstr ""
+
+#. module: project_google_map
 #: model:ir.model.fields,field_description:project_google_map.field_project_project__display_name
+#: model:ir.model.fields,field_description:project_google_map.field_project_task__display_name
 #: model:ir.model.fields,field_description:project_google_map.field_res_partner__display_name
 msgid "Display Name"
 msgstr ""
 
 #. module: project_google_map
 #: model:ir.model.fields,field_description:project_google_map.field_project_project__site_latitude
+#: model:ir.model.fields,field_description:project_google_map.field_project_task__site_latitude
 msgid "Geo Latitude"
 msgstr ""
 
 #. module: project_google_map
 #: model_terms:ir.ui.view,arch_db:project_google_map.view_project_project_google_map_form
+#: model_terms:ir.ui.view,arch_db:project_google_map.view_project_task_form2_inherit_google_map
 msgid "Geo Location"
 msgstr ""
 
 #. module: project_google_map
 #: model:ir.model.fields,field_description:project_google_map.field_project_project__site_longitude
+#: model:ir.model.fields,field_description:project_google_map.field_project_task__site_longitude
 msgid "Geo Longitude"
 msgstr ""
 
 #. module: project_google_map
 #: model:ir.model.fields,field_description:project_google_map.field_project_project__id
+#: model:ir.model.fields,field_description:project_google_map.field_project_task__id
 #: model:ir.model.fields,field_description:project_google_map.field_res_partner__id
 msgid "ID"
 msgstr ""
 
 #. module: project_google_map
 #: model_terms:ir.ui.view,arch_db:project_google_map.view_project_project_google_map_form
+#: model_terms:ir.ui.view,arch_db:project_google_map.view_project_task_form2_inherit_google_map
 msgid "Lat:"
 msgstr ""
 
 #. module: project_google_map
 #: model_terms:ir.ui.view,arch_db:project_google_map.view_project_project_google_map_form
+#: model_terms:ir.ui.view,arch_db:project_google_map.view_project_task_form2_inherit_google_map
 msgid "Long:"
 msgstr ""
 
 #. module: project_google_map
 #: model:ir.model.fields,field_description:project_google_map.field_project_project__marker_color
+#: model:ir.model.fields,field_description:project_google_map.field_project_task__marker_color
 msgid "Marker Color"
 msgstr ""
 
@@ -96,5 +110,42 @@ msgstr ""
 
 #. module: project_google_map
 #: model:ir.model.fields,field_description:project_google_map.field_project_project__partner_site_id
+#: model:ir.model.fields,field_description:project_google_map.field_project_task__partner_site_id
 msgid "Site Address"
+msgstr ""
+
+#. module: project_google_map
+#: model_terms:ir.ui.view,arch_db:project_google_map.view_project_task_form2_inherit_google_map
+msgid "Site Information"
+msgstr ""
+
+#. module: project_google_map
+#: model:ir.model,name:project_google_map.model_project_task
+msgid "Task"
+msgstr ""
+
+#. module: project_google_map
+#: model_terms:ir.ui.view,arch_db:project_google_map.view_project_task_google_map
+msgid "Task Sites"
+msgstr ""
+
+#. module: project_google_map
+#: model:ir.model.fields,help:project_google_map.field_project_task__display_name
+msgid ""
+"Use these keywords in the title to set new tasks:\n"
+"\n"
+"            #tags Set tags on the task\n"
+"            @user Assign the task to a user\n"
+"            ! Set the task a medium priority\n"
+"            !! Set the task a high priority\n"
+"            !!! Set the task a urgent priority\n"
+"\n"
+"            Make sure to use the right format and order e.g. Improve the configuration screen #feature #v16 @Mitchell !"
+msgstr ""
+
+#. module: project_google_map
+#. odoo-javascript
+#: code:addons/project_google_map/static/src/views/google_map/google_map_renderer.xml:0
+#: code:addons/project_google_map/static/src/views/google_map/google_map_sidebar.xml:0
+msgid "View Tasks"
 msgstr ""

--- a/project_google_map/models/__init__.py
+++ b/project_google_map/models/__init__.py
@@ -1,2 +1,3 @@
 from . import res_partner
 from . import project_project
+from . import project_task

--- a/project_google_map/models/project_task.py
+++ b/project_google_map/models/project_task.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ProjectTask(models.Model):
@@ -16,4 +16,5 @@ class ProjectTask(models.Model):
     )
     marker_color = fields.Integer(
         string="Marker Color",
+        default=1,
     )

--- a/project_google_map/models/project_task.py
+++ b/project_google_map/models/project_task.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+
+class ProjectTask(models.Model):
+    _inherit = "project.task"
+
+    partner_site_id = fields.Many2one(
+        "res.partner",
+        string="Site Address",
+    )
+    site_latitude = fields.Float(
+        related="partner_site_id.partner_latitude",
+    )
+    site_longitude = fields.Float(
+        related="partner_site_id.partner_longitude",
+    )
+    marker_color = fields.Integer(
+        string="Marker Color",
+    )

--- a/project_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/project_google_map/static/src/views/google_map/google_map_renderer.js
@@ -1,4 +1,3 @@
-import { _t } from '@web/core/l10n/translation';
 import { useService } from '@web/core/utils/hooks';
 import { GoogleMapRenderer } from '@web_view_google_map/views/google_map/google_map_renderer';
 import { GoogleMapSidebarProject } from './google_map_sidebar';
@@ -18,19 +17,29 @@ export class GoogleMapRendererProject extends GoogleMapRenderer {
     _createInfoWindowContent(record, isShifted = false) {
         const content = super._createInfoWindowContent(record, isShifted);
         if (content) {
-            const btnViewTasks = content.querySelector('#btn-view_tasks');
-            if (btnViewTasks && Number.isFinite(record.resId)) {
-                btnViewTasks.addEventListener('click', () => {
-                    this.env.model.orm
-                        .call('project.project', 'action_view_tasks', [record.resId])
-                        .then((action) => {
-                            if (action) {
-                                this.actionService.doAction(action);
-                            }
-                        });
-                });
+            const viewTaskButton = content.querySelector('#btn-view_tasks');
+            if (viewTaskButton && Number.isFinite(record.resId)) {
+                const eventHandler = this._actionViewTasks.bind(this, record);
+                viewTaskButton.addEventListener('click', eventHandler);
+                this._storeElementEventListener(viewTaskButton, 'click', eventHandler);
             }
         }
         return content;
+    }
+
+    _actionViewTasks(record) {
+        this.env.model.orm
+            .call('project.project', 'action_view_tasks', [record.resId])
+            .then((action) => {
+                if (action) {
+                    this.actionService.doAction(action);
+                }
+            });
+    }
+
+    get sidebarProps() {
+        return Object.assign(super.sidebarProps, {
+            onActionViewTask: this._actionViewTasks.bind(this),
+        });
     }
 }

--- a/project_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/project_google_map/static/src/views/google_map/google_map_renderer.js
@@ -1,0 +1,36 @@
+import { _t } from '@web/core/l10n/translation';
+import { useService } from '@web/core/utils/hooks';
+import { GoogleMapRenderer } from '@web_view_google_map/views/google_map/google_map_renderer';
+import { GoogleMapSidebarProject } from './google_map_sidebar';
+
+export class GoogleMapRendererProject extends GoogleMapRenderer {
+    static components = {
+        ...GoogleMapRenderer.components,
+        Sidebar: GoogleMapSidebarProject,
+    };
+    static templateInfoWindow = 'project_google_map.MarkerInfoWindow';
+
+    setup() {
+        super.setup();
+        this.actionService = useService('action');
+    }
+
+    _createInfoWindowContent(record, isShifted = false) {
+        const content = super._createInfoWindowContent(record, isShifted);
+        if (content) {
+            const btnViewTasks = content.querySelector('#btn-view_tasks');
+            if (btnViewTasks && Number.isFinite(record.resId)) {
+                btnViewTasks.addEventListener('click', () => {
+                    this.env.model.orm
+                        .call('project.project', 'action_view_tasks', [record.resId])
+                        .then((action) => {
+                            if (action) {
+                                this.actionService.doAction(action);
+                            }
+                        });
+                });
+            }
+        }
+        return content;
+    }
+}

--- a/project_google_map/static/src/views/google_map/google_map_renderer.xml
+++ b/project_google_map/static/src/views/google_map/google_map_renderer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project_google_map.MarkerInfoWindow" t-inherit="web_view_google_map.MarkerInfoWindow" t-inherit-mode="primary">
+        <xpath expr="//button[@id='btn-open_form']" position="after">
+            <button type="button" class="btn btn-sm btn-outline-dark" id="btn-view_tasks" data-tooltip="View Tasks">
+                <i class="fa fa-fw fa-list-ul"/>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/project_google_map/static/src/views/google_map/google_map_sidebar.js
+++ b/project_google_map/static/src/views/google_map/google_map_sidebar.js
@@ -1,23 +1,9 @@
-import { useService } from '@web/core/utils/hooks';
 import { GoogleMapSidebar } from '@web_view_google_map/views/google_map/google_map_sidebar';
 
 export class GoogleMapSidebarProject extends GoogleMapSidebar {
     static recordItemTemplate = 'project_google_map.RecordItem';
-
-    setup() {
-        super.setup();
-        this.actionService = useService('action');
-    }
-
-    actionViewTask(record) {
-        if (Number.isFinite(record.resId)) {
-            this.env.model.orm
-                .call('project.project', 'action_view_tasks', [record.resId])
-                .then((action) => {
-                    if (action) {
-                        this.actionService.doAction(action);
-                    }
-                });
-        }
-    }
+    static props = {
+        ...GoogleMapSidebar.props,
+        onActionViewTask: Function,
+    };
 }

--- a/project_google_map/static/src/views/google_map/google_map_sidebar.js
+++ b/project_google_map/static/src/views/google_map/google_map_sidebar.js
@@ -1,0 +1,23 @@
+import { useService } from '@web/core/utils/hooks';
+import { GoogleMapSidebar } from '@web_view_google_map/views/google_map/google_map_sidebar';
+
+export class GoogleMapSidebarProject extends GoogleMapSidebar {
+    static recordItemTemplate = 'project_google_map.RecordItem';
+
+    setup() {
+        super.setup();
+        this.actionService = useService('action');
+    }
+
+    actionViewTask(record) {
+        if (Number.isFinite(record.resId)) {
+            this.env.model.orm
+                .call('project.project', 'action_view_tasks', [record.resId])
+                .then((action) => {
+                    if (action) {
+                        this.actionService.doAction(action);
+                    }
+                });
+        }
+    }
+}

--- a/project_google_map/static/src/views/google_map/google_map_sidebar.xml
+++ b/project_google_map/static/src/views/google_map/google_map_sidebar.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project_google_map.RecordItem" t-inherit="web_view_google_map.RecordItem" t-inherit-mode="primary">
         <xpath expr="//span[@t-if='_showMarker']" position="before">
-            <button type="button" class="btn btn-link btn-sm" id="action-view-task" data-tooltip="View Tasks" t-on-click="() => this.actionViewTask(record)">
+            <button type="button" class="btn btn-link btn-sm" id="action-view-task" data-tooltip="View Tasks" t-on-click="() => props.onActionViewTask(record)">
                 <i class="fa fa-list-ul"/>
             </button>
         </xpath>

--- a/project_google_map/static/src/views/google_map/google_map_sidebar.xml
+++ b/project_google_map/static/src/views/google_map/google_map_sidebar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project_google_map.RecordItem" t-inherit="web_view_google_map.RecordItem" t-inherit-mode="primary">
+        <xpath expr="//span[@t-if='_showMarker']" position="before">
+            <button type="button" class="btn btn-link btn-sm" id="action-view-task" data-tooltip="View Tasks" t-on-click="() => this.actionViewTask(record)">
+                <i class="fa fa-list-ul"/>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/project_google_map/static/src/views/google_map/google_map_view.js
+++ b/project_google_map/static/src/views/google_map/google_map_view.js
@@ -1,0 +1,10 @@
+import { registry } from '@web/core/registry';
+import { googleMapView } from '@web_view_google_map/views/google_map/google_map_view';
+import { GoogleMapRendererProject } from './google_map_renderer';
+
+export const googleMapProjectView = {
+    ...googleMapView,
+    Renderer: GoogleMapRendererProject,
+};
+
+registry.category('views').add('google_map_project', googleMapProjectView);

--- a/project_google_map/views/project_project.xml
+++ b/project_google_map/views/project_project.xml
@@ -11,7 +11,6 @@
                 <field name="partner_site_id"/>
                 <field name="site_latitude"/>
                 <field name="site_longitude"/>
-                <field name="open_task_count"/>
             </google_map>
         </field>
     </record>

--- a/project_google_map/views/project_project.xml
+++ b/project_google_map/views/project_project.xml
@@ -4,13 +4,14 @@
         <field name="name">project.project.google.map</field>
         <field name="model">project.project</field>
         <field name="arch" type="xml">
-            <google_map string="Project Sites" lat="site_latitude" lng="site_longitude" color="marker_color" sidebar_title="name" sidebar_subtitle="partner_id">
+            <google_map js_class="google_map_project" string="Project Sites" lat="site_latitude" lng="site_longitude" color="marker_color" sidebar_title="name" sidebar_subtitle="partner_id">
                 <field name="marker_color"/>
                 <field name="name"/>
                 <field name="partner_id"/>
                 <field name="partner_site_id"/>
                 <field name="site_latitude"/>
                 <field name="site_longitude"/>
+                <field name="open_task_count"/>
             </google_map>
         </field>
     </record>
@@ -38,18 +39,5 @@
                 </page>
             </xpath>
         </field>
-    </record>
-    <record id="project.open_view_project_all" model="ir.actions.act_window">
-        <field name="view_mode">kanban,list,google_map,form</field>
-    </record>
-    <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
-        <field name="view_mode">kanban,list,form,calendar,google_map,activity</field>
-    </record>
-    <record id="project.open_view_project_all_config" model="ir.actions.act_window">
-        <field name="view_mode">list,kanban,google_map,form</field>
-        <field name="view_ids">[(4, ref('project_google_map.view_project_project_google_map'))]</field>
-    </record>
-    <record id="project.open_view_project_all_config_group_stage" model="ir.actions.act_window">
-        <field name="view_mode">list,kanban,form,calendar,google_map,activity</field>
     </record>
 </odoo>

--- a/project_google_map/views/project_task.xml
+++ b/project_google_map/views/project_task.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_project_task_google_map" model="ir.ui.view">
+        <field name="name">project.task.google.map</field>
+        <field name="model">project.task</field>
+        <field name="arch" type="xml">
+            <google_map string="Task Sites" lat="site_latitude" lng="site_longitude" color="marker_color" sidebar_title="name" sidebar_subtitle="partner_id">
+                <field name="marker_color"/>
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="partner_site_id"/>
+                <field name="site_latitude"/>
+                <field name="site_longitude"/>
+            </google_map>
+        </field>
+    </record>
+    <record id="view_project_task_form2_inherit_google_map" model="ir.ui.view">
+        <field name="name">view.project.task.form2.inherit.google_map</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_form2"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='extra_info']" position="inside">
+                <group string="Site Information">
+                    <group>
+                        <field name="partner_site_id" string="Address" widget="res_partner_many2one" context="{'show_address': 1, 'default_type': 'site'}"/>
+                        <label for="site_latitude" string="Geo Location" class="o_form_label"/>
+                        <div>
+                            <span>Lat: <field name="site_latitude" nolabel="1" class="oe_inline"/></span>
+                            <br/>
+                            <span>Long: <field name="site_longitude" nolabel="1" class="oe_inline"/></span>
+                        </div>
+                        <field name="marker_color" widget="color_picker"/>
+                    </group>
+                    <group>
+                        <widget name="google_map" lat="site_latitude" lng="site_longitude" maptype="satellite" width="100%" height="400" readonly="1"/>
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add `project.task` extension with `partner_site_id`, `site_latitude`, `site_longitude`, and `marker_color` fields
- Add Google Map view for tasks showing site locations with custom marker colors
- Add "Site Information" section to task form (Extra Info tab) with site address, coordinates, color picker, and embedded satellite map
- Register custom `google_map_project` JS view type extending the base map view with a "View Tasks" button in both the marker info window and sidebar
- Replace static XML action overrides with `post_init_hook`/`uninstall_hook` for cleaner view mode registration
- Add CHANGELOG.md, update README.md and docs/FEATURES.md