### PR TITLE
Add grouping support and defer sidebar rendering for Google Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | crm_gautocomplete_places_extended | 17.0.1.0.0 | Inherit `"crm_gautocomplete_places"` and add more data to lead from Google Place such as Google Address, Place ID, Place URL, Opening Hours, Types, Global Code, Compound Code, Plus Code URL, and Vicinity |
 | crm_google_map | 17.0.1.0.0 | Implementation of view "Google map" on CRM |
 | crm_google_places | 17.0.1.0.0 | Implementation of Google Places in the Google Maps view, allowing users to search for locations in a given area on maps and save them as your Lead |
+| sale_google_map | 17.0.1.0.1 | Implementation of view "Google map" on Sales (Quotations, Orders, Orders to Invoice, Orders to Upsell) |
 | web_view_google_map | 17.0.1.1.3 | Base module for a new view "google_map" |
 | web_view_google_map_drawing | 17.0.1.0.0 | Base module for sub view of "google_map" for drawing capability |
 | web_view_google_map_selector_area | 17.0.1.0.0 | An extension feature added to the Google Map view. It allows users to select an area on the map and capture all markers within that area |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | crm_gautocomplete_places_extended | 17.0.1.0.0 | Inherit `"crm_gautocomplete_places"` and add more data to lead from Google Place such as Google Address, Place ID, Place URL, Opening Hours, Types, Global Code, Compound Code, Plus Code URL, and Vicinity |
 | crm_google_map | 17.0.1.0.0 | Implementation of view "Google map" on CRM |
 | crm_google_places | 17.0.1.0.0 | Implementation of Google Places in the Google Maps view, allowing users to search for locations in a given area on maps and save them as your Lead |
-| web_view_google_map | 17.0.1.0.0 | Base module for a new view "google_map" |
+| web_view_google_map | 17.0.1.1.3 | Base module for a new view "google_map" |
 | web_view_google_map_drawing | 17.0.1.0.0 | Base module for sub view of "google_map" for drawing capability |
 | web_view_google_map_selector_area | 17.0.1.0.0 | An extension feature added to the Google Map view. It allows users to select an area on the map and capture all markers within that area |
 | web_widget_google_map | 17.0.1.0.0 | Base module of widget Google Autocomplete |

--- a/sale_google_map/CHANGELOG.md
+++ b/sale_google_map/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Change Log
 
+## 17.0.1.0.1
+
+* Improvement:
+  * Sales map views (Quotations, Orders, Orders to Invoice, Orders to Upsell) now group
+    records by `partner_id` by default using the new `default_group_by` arch attribute,
+    so each customer appears as a single marker on the map.
+  * Added `groups_limit="100"` and `limit="1"` to all sales map views to cap the number
+    of groups fetched and limit records per group to one (used for marker placement).
+  * `isGrouped` prop added to `GoogleMapSidebarSales` so the sidebar is aware of the
+    current grouping state.
+  * Sidebar now automatically unfolds all folded groups on mount and when records change,
+    using a debounced loader with UI blocking to prevent partial rendering.
+  * `maxGroupByDepth` is now only enforced when a `defaultGroupBy` is active, making
+    the controller more flexible when grouping is not configured.
+  * Removed hardcoded `defaultGroupBy: 'partner_id'` from the controller; grouping is
+    now driven by the arch definition.
+
 ## 17.0.1.0.0
- - Added Google Maps view to Sales
+
+* Added Google Maps view to Sales

--- a/sale_google_map/__manifest__.py
+++ b/sale_google_map/__manifest__.py
@@ -8,7 +8,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/Sales',
-    'version': '17.0.1.0.0',
+    'version': '17.0.1.0.1',
     'depends': ['sale_management', 'web_view_google_map'],
     'data': ['views/sale_order.xml'],
     'assets': {

--- a/sale_google_map/static/src/views/google_map/google_map_controller.js
+++ b/sale_google_map/static/src/views/google_map/google_map_controller.js
@@ -7,10 +7,9 @@ export class GoogleMapControllerSales extends GoogleMapController {
         const config = Object.assign(params.config, {
             openGroupsByDefault: true,
         });
-        return Object.assign(params, {
-            config,
-            defaultGroupBy: 'partner_id',
-            maxGroupByDepth: 1,
-        });
+        if (params.defaultGroupBy) {
+            params.maxGroupByDepth = 1;
+        }
+        return Object.assign(params, { config });
     }
 }

--- a/sale_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/sale_google_map/static/src/views/google_map/google_map_renderer.js
@@ -196,6 +196,7 @@ export class GoogleMapRendererSales extends GoogleMapRenderer {
     get sidebarProps() {
         let props = super.sidebarProps;
         props.records = this.props.list.groups;
+        props.isGrouped = !!this.props.list.groupBy;
         props.openCustomerSales = this.actionSeeSales.bind(this);
         return props;
     }

--- a/sale_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/sale_google_map/static/src/views/google_map/google_map_renderer.js
@@ -196,7 +196,7 @@ export class GoogleMapRendererSales extends GoogleMapRenderer {
     get sidebarProps() {
         let props = super.sidebarProps;
         props.records = this.props.list.groups;
-        props.isGrouped = !!this.props.list.groupBy;
+        props.isGrouped = this.isGrouped;
         props.openCustomerSales = this.actionSeeSales.bind(this);
         return props;
     }

--- a/sale_google_map/static/src/views/google_map/google_map_sidebar.js
+++ b/sale_google_map/static/src/views/google_map/google_map_sidebar.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 import { onWillUnmount, onMounted, onWillUpdateProps } from '@odoo/owl';
 import { useService } from '@web/core/utils/hooks';
-import { debounce as debounceFn } from "@web/core/utils/timing";
+import { debounce as debounceFn } from '@web/core/utils/timing';
 import { GoogleMapSidebar } from '@web_view_google_map/views/google_map/google_map_sidebar';
 
 export class GoogleMapSidebarSales extends GoogleMapSidebar {
@@ -50,8 +50,14 @@ export class GoogleMapSidebarSales extends GoogleMapSidebar {
         if (currentRecords.length !== nextRecords.length) {
             return true;
         }
-        const currentIds = currentRecords.map(r => r.id).sort().join(',');
-        const nextIds = nextRecords.map(r => r.id).sort().join(',');
+        const currentIds = currentRecords
+            .map((r) => r.id)
+            .sort()
+            .join(',');
+        const nextIds = nextRecords
+            .map((r) => r.id)
+            .sort()
+            .join(',');
         return currentIds !== nextIds;
     }
 
@@ -61,17 +67,23 @@ export class GoogleMapSidebarSales extends GoogleMapSidebar {
         const foldedGroups = this.props.records.filter((g) => g.isFolded);
         if (foldedGroups.length === 0) return;
 
+        const BATCH_SIZE = 10;
+
         try {
             this._isLoading = true;
             this.uiService.block();
-            const groupPromises = foldedGroups.map(async (group) => {
-                try {
-                    await group.toggle();
-                } catch (error) {
-                    console.error('Error toggling group:', error);
-                }
-            });
-            await Promise.all(groupPromises);
+            for (let i = 0; i < foldedGroups.length; i += BATCH_SIZE) {
+                const batchGroups = foldedGroups.slice(i, i + BATCH_SIZE);
+                await Promise.all(
+                    batchGroups.map(async (group) => {
+                        try {
+                            await group.toggle();
+                        } catch (error) {
+                            console.error(`Failed to load group ${group.displayName}:`, error);
+                        }
+                    })
+                );
+            }
         } finally {
             this._isLoading = false;
             this.uiService.unblock();

--- a/sale_google_map/static/src/views/google_map/google_map_sidebar.js
+++ b/sale_google_map/static/src/views/google_map/google_map_sidebar.js
@@ -1,10 +1,82 @@
 /** @odoo-module **/
-
+import { onWillUnmount, onMounted, onWillUpdateProps } from '@odoo/owl';
+import { useService } from '@web/core/utils/hooks';
+import { debounce as debounceFn } from "@web/core/utils/timing";
 import { GoogleMapSidebar } from '@web_view_google_map/views/google_map/google_map_sidebar';
 
 export class GoogleMapSidebarSales extends GoogleMapSidebar {
     static template = 'sales_google_map.GoogleMapSidebar';
-    static props = [...GoogleMapSidebar.props, 'openCustomerSales'];
+    static props = [...GoogleMapSidebar.props, 'openCustomerSales', 'isGrouped'];
+
+    setup() {
+        super.setup();
+        this.uiService = useService('ui');
+        this._isLoading = false;
+
+        this.debouncedLoadGroupRecord = debounceFn(this.loadGroupRecord.bind(this), 500);
+
+        onMounted(() => {
+            const googleMap = this.env.googleMap();
+            if (!googleMap) return;
+
+            if (this.debouncedLoadGroupRecord.cancel) {
+                this.debouncedLoadGroupRecord.cancel();
+            }
+
+            this.debouncedLoadGroupRecord();
+        });
+
+        onWillUpdateProps((nextProps) => {
+            const googleMap = this.env.googleMap();
+            if (!googleMap) return;
+
+            if (this._checkRecordsChange(this.props.records, nextProps.records)) {
+                if (this.debouncedLoadGroupRecord.cancel) {
+                    this.debouncedLoadGroupRecord.cancel();
+                }
+                this.debouncedLoadGroupRecord();
+            }
+        });
+
+        onWillUnmount(() => {
+            this._isLoading = false;
+            if (this.debouncedLoadGroupRecord.cancel) {
+                this.debouncedLoadGroupRecord.cancel();
+            }
+        });
+    }
+
+    _checkRecordsChange(currentRecords, nextRecords) {
+        if (currentRecords.length !== nextRecords.length) {
+            return true;
+        }
+        const currentIds = currentRecords.map(r => r.id).sort().join(',');
+        const nextIds = nextRecords.map(r => r.id).sort().join(',');
+        return currentIds !== nextIds;
+    }
+
+    async loadGroupRecord() {
+        if (this._isLoading || !this.props.isGrouped) return;
+
+        const foldedGroups = this.props.records.filter((g) => g.isFolded);
+        if (foldedGroups.length === 0) return;
+
+        try {
+            this._isLoading = true;
+            this.uiService.block();
+            const groupPromises = foldedGroups.map(async (group) => {
+                try {
+                    await group.toggle();
+                } catch (error) {
+                    console.error('Error toggling group:', error);
+                }
+            });
+            await Promise.all(groupPromises);
+        } finally {
+            this._isLoading = false;
+            this.uiService.unblock();
+        }
+    }
 
     aggregateTotal(group) {
         let total = 0;

--- a/sale_google_map/views/sale_order.xml
+++ b/sale_google_map/views/sale_order.xml
@@ -5,7 +5,7 @@
         <field name="model">sale.order</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <google_map js_class="google_map_sales" disable_area_selector="1" string="Quotations" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#ad2df7">
+            <google_map js_class="google_map_sales" groups_limit="100" limit="1" default_group_by="partner_id" disable_area_selector="1" string="Quotations" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#ad2df7">
                 <field name="partner_latitude"/>
                 <field name="partner_longitude"/>
                 <field name="name"/>
@@ -24,7 +24,7 @@
         <field name="model">sale.order</field>
         <field name="priority" eval="200"/>
         <field name="arch" type="xml">
-            <google_map js_class="google_map_sales" disable_area_selector="1" string="Orders" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#482df7">
+            <google_map js_class="google_map_sales" groups_limit="100" limit="1" default_group_by="partner_id"  disable_area_selector="1" string="Orders" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#482df7">
                 <field name="partner_latitude"/>
                 <field name="partner_longitude"/>
                 <field name="name"/>
@@ -48,7 +48,7 @@
         <field name="model">sale.order</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <google_map js_class="google_map_sales" disable_area_selector="1" string="Orders to Invoice" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#0dbaa9">
+            <google_map js_class="google_map_sales" groups_limit="100" limit="1" default_group_by="partner_id" disable_area_selector="1" string="Orders to Invoice" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#0dbaa9">
                 <field name="partner_latitude"/>
                 <field name="partner_longitude"/>
                 <field name="name"/>
@@ -109,7 +109,7 @@
         <field name="model">sale.order</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <google_map js_class="google_map_sales" disable_area_selector="1" string="Orders to Upsell" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#6c0dba">
+            <google_map js_class="google_map_sales" groups_limit="100" limit="1" default_group_by="partner_id" disable_area_selector="1" string="Orders to Upsell" sidebar_title="partner_id" lat="partner_latitude" lng="partner_longitude" marker_icon="circle" icon_scale="0.6" color="#6c0dba">
                 <field name="partner_latitude"/>
                 <field name="partner_longitude"/>
                 <field name="name"/>

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 17.0.1.1.3
+
+* Improvement:
+    - Added support for `default_group_by` and `groups_limit` attributes in the `google_map` view arch.
+      Views can now define a default grouping field directly in the XML definition.
+    - `defaultGroupBy` is now configurable from the arch parser instead of being hardcoded to `false`.
+    - `groupsLimit` falls back to `Number.MAX_SAFE_INTEGER` when not specified, effectively removing the group limit by default.
+    - Exposed `googleMap` instance through the component environment (`this.env.googleMap()`), allowing child components to access the map instance directly.
+    - Added `isMapReady` state to the renderer. The sidebar is now deferred until the Google Map has fully loaded its tiles (`tilesloaded` event), preventing premature rendering of sidebar content before the map is ready.
+
 ## 17.0.1.1.2
 * Bug fixes:    
     - Fix the bug related to marker info window and marker cluster.

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '17.0.1.1.2',
+    'version': '17.0.1.1.3',
     'depends': ['base_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
@@ -84,6 +84,12 @@ export class GoogleMapArchParser {
                     xmlDoc.getAttribute('default_order') || null
                 );
 
+                const defaultGroupBy = node.getAttribute('default_group_by');
+                googleMapAttr.defaultGroupBy = defaultGroupBy;
+
+                const groupsLimitAttr = node.getAttribute("groups_limit");
+                googleMapAttr.groupsLimit = groupsLimitAttr && parseInt(groupsLimitAttr, 10);
+
                 // custom open action when clicking on record row
                 const action = xmlDoc.getAttribute('action');
                 const type = xmlDoc.getAttribute('type');

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -75,8 +75,8 @@ export class GoogleMapController extends Component {
             'active' in this.props.fields
                 ? !this.props.fields.active.readonly
                 : 'x_active' in this.props.fields
-                ? !this.props.fields.x_active.readonly
-                : false;
+                  ? !this.props.fields.x_active.readonly
+                  : false;
 
         onWillStart(async () => {
             this.isExportEnable = await this.userService.hasGroup('base.group_allow_export');
@@ -159,6 +159,11 @@ export class GoogleMapController extends Component {
             openGroupsByDefault: false,
         };
 
+        const groupsLimit =
+            Number.isFinite(this.archInfo.groupsLimit) && this.archInfo.groupsLimit > 0
+                ? this.archInfo.groupsLimit
+                : Number.MAX_SAFE_INTEGER;
+
         return {
             config: modelConfig,
             state: this.props.state?.modelState,
@@ -167,7 +172,7 @@ export class GoogleMapController extends Component {
             countLimit: this.archInfo.countLimit,
             defaultOrderBy: this.archInfo.defaultOrder,
             defaultGroupBy: this.archInfo.defaultGroupBy,
-            groupsLimit: this.archInfo.groupsLimit || Number.MAX_SAFE_INTEGER,
+            groupsLimit: groupsLimit,
             multiEdit: this.archInfo.multiEdit,
             activeIdsLimit: session.active_ids_limit,
             hooks: {

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -166,8 +166,8 @@ export class GoogleMapController extends Component {
             limit: this.archInfo.limit || this.props.limit,
             countLimit: this.archInfo.countLimit,
             defaultOrderBy: this.archInfo.defaultOrder,
-            defaultGroupBy: false,
-            groupsLimit: this.archInfo.groupsLimit,
+            defaultGroupBy: this.archInfo.defaultGroupBy,
+            groupsLimit: this.archInfo.groupsLimit || Number.MAX_SAFE_INTEGER,
             multiEdit: this.archInfo.multiEdit,
             activeIdsLimit: session.active_ids_limit,
             hooks: {

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -33,7 +33,11 @@ export class GoogleMapRenderer extends BaseGoogleMap {
         this.isShiftKeyPressed = false;
         this.cache = new Map();
 
-        this.state = useState({ ...this.state, sidebarIsFolded: false });
+        this.state = useState({
+            ...this.state,
+            isMapReady: null,
+            sidebarIsFolded: false,
+        });
 
         if (this.props.allowSelectors) {
             const ui = useService('ui');
@@ -44,6 +48,7 @@ export class GoogleMapRenderer extends BaseGoogleMap {
             getRecordMarker: (recordId) => this.cache.get(recordId),
             hasGeolocation: (record) => this.getLatLng(record),
             getMarkerColor: (record) => this.getMarkerColor(record),
+            googleMap: () => this.googleMap,
         });
 
         useEffect(
@@ -149,10 +154,24 @@ export class GoogleMapRenderer extends BaseGoogleMap {
         if (!this.googleMap) {
             const options = this.getMapOptions();
             this.googleMap = new google.maps.Map(this.mapRef.el, options);
+            this.onMapReady(this.googleMap);
             this.setMapTheme();
         }
         this.markerInfoWindow = new google.maps.InfoWindow({ disableAutoPan: true });
         this.renderGooglePlaceSearch(this.searchPlacesRef, this.markerInfoWindow);
+    }
+
+    async onMapReady(map) {
+        // Wait for map to be fully loaded
+        await new Promise((resolve) => {
+            const listener = map.addListener('tilesloaded', () => {
+                google.maps.event.removeListener(listener);
+                resolve();
+            });
+        });
+        this.state.isMapReady = true;
+        // Trigger resize to ensure proper rendering
+        google.maps.event.trigger(map, 'resize');
     }
 
     /**

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -164,10 +164,7 @@ export class GoogleMapRenderer extends BaseGoogleMap {
     async onMapReady(map) {
         // Wait for map to be fully loaded
         await new Promise((resolve) => {
-            const listener = map.addListener('tilesloaded', () => {
-                google.maps.event.removeListener(listener);
-                resolve();
-            });
+            google.maps.event.addListenerOnce(map, 'tilesloaded', resolve);
         });
         this.state.isMapReady = true;
         // Trigger resize to ensure proper rendering
@@ -344,17 +341,17 @@ export class GoogleMapRenderer extends BaseGoogleMap {
         if (typeof color === 'number') {
             const ColorList = [
                 null,
-                '#F06050', // Red
-                '#F4A460', // Orange
-                '#F7CD1F', // Yellow
-                '#6CC1ED', // Light blue
-                '#814968', // Dark purple
-                '#EB7E7F', // Salmon pink
-                '#2C8397', // Medium blue
-                '#475577', // Dark blue
-                '#D6145F', // Fuchsia
-                '#30C381', // Green
-                '#9365B8', // Purple
+                '#ee2d2d', // Red
+                '#dc8534', // Orange
+                '#e8bc1d', // Yellow
+                '#5793dd', // Light blue
+                '#9f628f', // Dark purple
+                '#db8865', // Salmon pink
+                '#41a9a2', // Medium blue
+                '#304ae0', // Dark blue
+                '#ee2f8b', // Fuchsia
+                '#61c36e', // Green
+                '#9972e6', // Purple
             ];
             markerColor = ColorList[color] || markerColor;
         } else if (/(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})\b|(?:rgb|hsl)a?\([^\)]*\)/gi.test(color)) {
@@ -486,6 +483,10 @@ export class GoogleMapRenderer extends BaseGoogleMap {
                 this.markerInfoWindow.setPosition(position);
             });
         }
+    }
+
+    get isGrouped() {
+        return this.props.list.isGrouped;
     }
 
     get isEmpty() {

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -2,7 +2,7 @@
 
 import { _t } from '@web/core/l10n/translation';
 import { DynamicRecordList } from '@web/model/relational_model/dynamic_record_list';
-import { useRef, useState, useChildSubEnv, onRendered, useEffect } from '@odoo/owl';
+import { useRef, useState, useChildSubEnv, onRendered, useEffect, onWillUnmount } from '@odoo/owl';
 import { renderToString } from '@web/core/utils/render';
 import { useBus, useService } from '@web/core/utils/hooks';
 
@@ -31,6 +31,7 @@ export class GoogleMapRenderer extends BaseGoogleMap {
         this.searchPlacesRef = useRef('searchPlaces');
         this.markerCluster = null;
         this.isShiftKeyPressed = false;
+        this._isDestroyed = false;
         this.cache = new Map();
 
         this.state = useState({
@@ -38,6 +39,9 @@ export class GoogleMapRenderer extends BaseGoogleMap {
             isMapReady: null,
             sidebarIsFolded: false,
         });
+
+        this._boundOnMapKeydown = this.onMapKeydown.bind(this);
+        this._boundOnMapKeyup = this.onMapKeyup.bind(this);
 
         if (this.props.allowSelectors) {
             const ui = useService('ui');
@@ -52,19 +56,22 @@ export class GoogleMapRenderer extends BaseGoogleMap {
         });
 
         useEffect(
-            (mapEl, loaderStatus) => {
+            (mapEl, loaderStatus, isMapReady) => {
                 // Allow you to select a marker in the map, by pressing a Shift key + click the marker
-                if (mapEl && loaderStatus === LOADER_STATUS.SUCCESS) {
+                if (mapEl && loaderStatus === LOADER_STATUS.SUCCESS && isMapReady) {
                     this.addMapCustomEvListeners();
                     return () => this.removeMapCustomEvListeners();
                 }
             },
-            () => [this.mapRef.el, this.state.loaderStatus]
+            () => [this.mapRef.el, this.state.loaderStatus, this.state.isMapReady]
         );
 
         // The following lifecycle hooks are to maintain the data rendered on the map
         // When the same list ID is rendered, I won't re-render the markers and also won't change the current map center
         onRendered(this.handleOnRendered);
+
+        // When the component is unmounted, I need to clear all markers and clusters on the map and reset the cache
+        onWillUnmount(this.cleanUp);
     }
 
     /**
@@ -72,16 +79,16 @@ export class GoogleMapRenderer extends BaseGoogleMap {
      */
     addMapCustomEvListeners() {
         // Allow you to select a marker in the map, by pressing a Shift key + click the marker
-        this.mapRef.el.addEventListener('keydown', this.onMapKeydown.bind(this));
-        this.mapRef.el.addEventListener('keyup', this.onMapKeyup.bind(this));
+        this.mapRef.el.addEventListener('keydown', this._boundOnMapKeydown);
+        this.mapRef.el.addEventListener('keyup', this._boundOnMapKeyup);
     }
 
     /**
      * Remove custom event listeners added to the map element
      */
     removeMapCustomEvListeners() {
-        this.mapRef.el.removeEventListener('keydown', this.onMapKeydown.bind(this));
-        this.mapRef.el.removeEventListener('keyup', this.onMapKeyup.bind(this));
+        this.mapRef.el.removeEventListener('keydown', this._boundOnMapKeydown);
+        this.mapRef.el.removeEventListener('keyup', this._boundOnMapKeyup);
     }
 
     onMapKeydown(ev) {
@@ -104,9 +111,13 @@ export class GoogleMapRenderer extends BaseGoogleMap {
             isMarkerSelected = this.props.list.selection.length > 0;
         }
         this.isMarkerSelected = isMarkerSelected;
-        if (this.state.loaderStatus === LOADER_STATUS.SUCCESS) {
+        if (this.isReadyToRender()) {
             this.renderMap();
         }
+    }
+
+    isReadyToRender() {
+        return this.state.isMapReady && this.state.loaderStatus === LOADER_STATUS.SUCCESS;
     }
 
     /**
@@ -146,19 +157,27 @@ export class GoogleMapRenderer extends BaseGoogleMap {
      * Initialize Google Map instance & Google search places (if enabled)
      */
     initialize() {
-        this._initializeGoogleMap();
-        this.handleSearchPlaceBounds();
+        this._initializeGoogleMap()
+            .then(() => {
+                this.handleSearchPlaceBounds();
+            })
+            .catch((error) => {
+                console.error('Error initializing Google Map:', error);
+                this.notification.add(_t('Failed to load Google Map. Please try again later.'), {
+                    type: 'danger',
+                });
+            });
     }
 
-    _initializeGoogleMap() {
+    async _initializeGoogleMap() {
         if (!this.googleMap) {
             const options = this.getMapOptions();
             this.googleMap = new google.maps.Map(this.mapRef.el, options);
-            this.onMapReady(this.googleMap);
+            await this.onMapReady(this.googleMap);
             this.setMapTheme();
+            this.markerInfoWindow = new google.maps.InfoWindow({ disableAutoPan: true });
+            this.renderGooglePlaceSearch(this.searchPlacesRef, this.markerInfoWindow);
         }
-        this.markerInfoWindow = new google.maps.InfoWindow({ disableAutoPan: true });
-        this.renderGooglePlaceSearch(this.searchPlacesRef, this.markerInfoWindow);
     }
 
     async onMapReady(map) {
@@ -166,9 +185,9 @@ export class GoogleMapRenderer extends BaseGoogleMap {
         await new Promise((resolve) => {
             google.maps.event.addListenerOnce(map, 'tilesloaded', resolve);
         });
-        this.state.isMapReady = true;
-        // Trigger resize to ensure proper rendering
-        google.maps.event.trigger(map, 'resize');
+        if (!this._isDestroyed) {
+            this.state.isMapReady = true;
+        }
     }
 
     /**
@@ -640,5 +659,22 @@ export class GoogleMapRenderer extends BaseGoogleMap {
                 this._handleActionSeeMore(actionId, domain);
             }
         }
+    }
+
+    cleanUp() {
+        this._isDestroyed = true;
+        this.cache.forEach((marker) => {
+            google.maps.event.clearInstanceListeners(marker);
+            marker.setMap(null);
+        });
+        if (this.googleMap) {
+            google.maps.event.clearInstanceListeners(this.googleMap);
+        }
+        if (this.markerCluster) {
+            google.maps.event.clearInstanceListeners(this.markerCluster);
+            this.markerCluster.clearMarkers();
+            this.markerCluster.setMap(null);
+        }
+        this.cache.clear();
     }
 }

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.xml
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.xml
@@ -13,7 +13,7 @@
             </div>
             <div t-attf-class="o_map_right_sidebar #{state.sidebarIsFolded ? 'closed': 'open'}">
                 <div class="content">
-                    <Sidebar t-props="sidebarProps"/>
+                    <Sidebar t-props="sidebarProps" t-if="state.isMapReady"/>
                 </div>
                 <div class="toggle_right_sidenav">
                     <button data-toggle="tooltip" data-placement="right" title="Expand side panel" t-on-click="() => this.toggleSidebar()"></button>


### PR DESCRIPTION
This pull request introduces significant improvements to the Google Maps integration in Sales and the core map view module. The main focus is on enhancing group-by functionality, improving sidebar and map readiness handling, and making configuration more flexible and robust. Now, Sales map views group records by customer by default, limit the number of groups and records per group, and provide a better user experience with automatic group unfolding and improved sidebar rendering. The base map module (`web_view_google_map`) now supports new XML attributes, exposes the map instance to components, and ensures the sidebar only renders after the map is fully loaded.

**Sales Google Map Improvements:**

* Sales map views (`sale_order.xml`) now group records by `partner_id` by default using the new `default_group_by` attribute, so each customer appears as a single marker on the map. Limits for group count (`groups_limit="100"`) and records per group (`limit="1"`) are enforced for better performance and clarity. [[1]](diffhunk://#diff-124ef5c0f6a2d3eafc367dc4353c106fd534ad17d1e53008caafa721545fe2d1L8-R8) [[2]](diffhunk://#diff-124ef5c0f6a2d3eafc367dc4353c106fd534ad17d1e53008caafa721545fe2d1L27-R27) [[3]](diffhunk://#diff-124ef5c0f6a2d3eafc367dc4353c106fd534ad17d1e53008caafa721545fe2d1L51-R51) [[4]](diffhunk://#diff-124ef5c0f6a2d3eafc367dc4353c106fd534ad17d1e53008caafa721545fe2d1L112-R112)
* The sidebar (`GoogleMapSidebarSales`) now automatically unfolds all folded groups on mount and when records change, using a debounced loader with UI blocking to prevent partial rendering. It is also aware of the current grouping state via the new `isGrouped` prop. [[1]](diffhunk://#diff-508fb2cb7d50e5fd28fe74308fe994646617b7bc511466ba848b06378ef51084L2-R79) [[2]](diffhunk://#diff-e23a3950edd80a48176fa90d575af9882be0f8c10033d9fc722cf68d933f656dR199)
* The controller (`GoogleMapControllerSales`) no longer hardcodes the default grouping; instead, it enforces `maxGroupByDepth` only when a `defaultGroupBy` is present, making it more flexible.
* Version bump and changelog updates for `sale_google_map` to reflect these improvements. [[1]](diffhunk://#diff-abbbb8c4bfa19129efb2a3398b6c7020c675810b7e8c2ef656be15285bfd5899L11-R11) [[2]](diffhunk://#diff-ee393bec13e0a575878961f1a27791c20fc151c68cec9c7fca235d0390be0b19R3-R22) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R22)

**Core Map View Enhancements (`web_view_google_map`):**

* Added support for `default_group_by` and `groups_limit` attributes in the map view XML parser, allowing views to specify default grouping and group limits directly in their definitions. [[1]](diffhunk://#diff-e1a9c604b6a0041a6e37ac7775d77cc65d89ff9a4db94f26eff6e36d8de6ebbeR87-R92) [[2]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R12)
* The controller now uses the parsed `defaultGroupBy` and falls back to unlimited groups if not specified.
* Exposes the `googleMap` instance to the component environment (`this.env.googleMap()`), enabling child components to interact with the map directly.
* The renderer now tracks an `isMapReady` state, deferring sidebar rendering until the map has fully loaded its tiles, preventing premature sidebar display. [[1]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8L36-R40) [[2]](diffhunk://#diff-7d9a0d51aa2bf84825407552550ec6f29f2e38f293862c32dd2530deaadcd5c8R157-R176) [[3]](diffhunk://#diff-2866d3bf0f48ca455b6a42300655b741ac5253435e076b5c366e4c5334fd49d2L16-R16)
* Version bump and changelog updates for `web_view_google_map` to document these changes. [[1]](diffhunk://#diff-43e696f6e216406b879cfbbf6d820297dfc117930d25747387df839fc91fe59bL17-R17) [[2]](diffhunk://#diff-00daa88f7487c35ccb8b666b3c2b110879be2ba88d07c3e80a0745cf6c0fe428R3-R12)