### PR TITLE
[IMP] sale_google_map: Pre-load groups, reduce debounce, show order count on markers (v1.0.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Most of the implementation in this modules are inspired from the samples that yo
 | [crm_google_map_add_place](/crm_google_map_add_place/README.md) | 19.0.1.0.0 | Click on Google Map to add CRM Lead/Opportunity with Google Places data |
 | [partner_autocomplete_with_google_autocomplete](/partner_autocomplete_with_google_autocomplete/README.md) | 19.0.1.0.3 | Implementation of Google Places Autocomplete along with existing Odoo Partner Autocomplete on Contact form |
 | [project_google_map](/project_google_map/README.md) | 19.0.1.0.1 | Implementation of view "Google Maps" on Projects |
-| [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.8 | Implementation of view "Google Maps" on Sale Order |
+| [sale_google_map](/sale_google_map/README.md) | 19.0.1.0.9 | Implementation of view "Google Maps" on Sale Order |
 | [stock_google_map](/stock_google_map/README.md) | 19.0.1.0.0 | Implementation of view "Google Maps" on Inventory |
 | [web_view_google_map](/web_view_google_map/README.md) | 19.0.1.0.20 | Base module for a new view "google_map" |
 | [web_view_google_map_drawing](/web_view_google_map_drawing/README.md) | 19.0.1.0.13 | Base module for sub view of "google_map" for drawing capability |

--- a/sale_google_map/CHANGELOG.md
+++ b/sale_google_map/CHANGELOG.md
@@ -1,6 +1,19 @@
 <!-- markdownlint-disable MD024 -->
 # Change Log
 
+## 19.0.1.0.9
+
+### Performance
+
+- **Pre-unfolded Groups on Load**: `GoogleMapControllerSaleOrder.modelParams` now sets `openGroupsByDefault: true` on the model config when `defaultGroupBy` is active; this passes `auto_unfold: true` to `web_read_group`, returning each group's records in the initial RPC and eliminating the per-group `web_search_read` that `group.toggle()` would otherwise fire
+- **Immediate Group Loading on Mount**: `loadGroupRecord` is now called directly in `onMounted` instead of through the debounced wrapper, eliminating the 500 ms forced wait before the first group toggle RPC fires
+- **Reduced `onWillUpdateProps` Debounce**: Debounce delay for prop-triggered group loading reduced from 500 ms to 200 ms, cutting re-render latency after filter or search changes while still batching rapid updates
+
+### Improved
+
+- **Marker Display Name Shows Count**: `_createMarkerElement` now renders the group display name as `"{Customer} ({count})"` using `sprintf`, giving a quick visual count of orders per customer directly on the map marker
+- **Manifest Description**: Expanded `summary` and `description` in `__manifest__.py` to document key features, supported action windows, and configuration requirements
+
 ## 19.0.1.0.8
 
 ### Added

--- a/sale_google_map/__manifest__.py
+++ b/sale_google_map/__manifest__.py
@@ -1,14 +1,29 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Sales Google Maps',
-    'summary': 'Show your Sales on Google Maps',
-    'description': '',
+    'summary': 'Visualize sale orders and customers on an interactive Google Maps view',
+    'description': """
+Sales Google Maps
+=================
+Adds a Google Maps view to Sale Orders and Quotations, grouping orders by customer
+and placing each customer as a marker on the map.
+
+Key features:
+- Interactive map view available on Quotations, Orders, Orders to Invoice, and Orders to Upsell
+- Markers show customer name and aggregated order total at a glance
+- Click a marker to open the customer's sale orders in a list
+- "Find Nearby" button on each marker to locate other customers in the area
+- Partner avatar displayed on each marker for quick visual identification
+- Sidebar listing all customers with totals, synced with the map
+
+Requires a Google API Key configured in Settings → General Settings → Google Maps.
+    """,
     'license': 'AGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/Sales',
-    'version': '1.0.8',
+    'version': '1.0.9',
     'depends': ['sale_management', 'web_view_google_map'],
     'data': ['views/sale_order.xml', 'views/res_partner.xml'],
     'assets': {

--- a/sale_google_map/docs/FEATURES.md
+++ b/sale_google_map/docs/FEATURES.md
@@ -12,11 +12,11 @@
 ---
 
 ### Marker Content
-**What it does**: Each marker shows the customer name, aggregated order total, and customer avatar (when available).
+**What it does**: Each marker shows the customer name with order count, aggregated order total, and customer avatar (when available).
 
-**Why it matters**: Sales teams can scan the map and immediately see the value of each customer's orders without opening any records.
+**Why it matters**: Sales teams can scan the map and immediately see both the value and the volume of each customer's orders without opening any records.
 
-**How it works**: The marker renders a card with a color-coded left border (matching the group color), the customer's `avatar_128` image, the group display name, and the sum of `amount_total` for all orders in the group, formatted according to the user's locale.
+**How it works**: The marker renders a card with a color-coded left border (matching the group color), the customer's `avatar_128` image, the group display name suffixed with the record count (e.g. `"Acme Corp (3)"`), and the sum of `amount_total` for all orders in the group, formatted according to the user's locale.
 
 ---
 
@@ -82,11 +82,11 @@
 ---
 
 ### Automatic Group Loading
-**What it does**: When the map view opens, all groups are automatically expanded in batches so their markers appear without any manual action.
+**What it does**: When the map view opens, all groups are automatically expanded so their markers appear without any manual action.
 
 **Why it matters**: Without this, the sidebar would show collapsed groups and the map would be empty until the user manually expanded each one.
 
-**How it works**: On `onMounted` and `onWillUpdateProps`, a debounced `loadGroupRecord` call iterates through folded groups in batches of 10 and toggles them open. The UI is blocked during this process to prevent interaction conflicts.
+**How it works**: The model sets `openGroupsByDefault: true` when a default group-by is active, instructing the initial `web_read_group` RPC to return each group's records in the same response. This means markers are available immediately after the first load — no extra per-group requests are needed. On `onMounted`, `loadGroupRecord` also runs immediately (without a debounce delay) as a safety net for any groups that may still be folded; `onWillUpdateProps` uses a 200 ms debounce to handle filter and search changes. The UI is blocked during this process to prevent interaction conflicts.
 
 ---
 

--- a/sale_google_map/static/src/views/google_map/google_map_controller.js
+++ b/sale_google_map/static/src/views/google_map/google_map_controller.js
@@ -5,6 +5,9 @@ export class GoogleMapControllerSaleOrder extends GoogleMapController {
         const params = super.modelParams;
         if (params.defaultGroupBy) {
             params.maxGroupByDepth = 1;
+            params.config = Object.assign({}, params.config, {
+                openGroupsByDefault: true,
+            });
         }
         return params;
     }

--- a/sale_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/sale_google_map/static/src/views/google_map/google_map_renderer.js
@@ -1,5 +1,6 @@
 import { _t } from '@web/core/l10n/translation';
 import { user } from '@web/core/user';
+import { sprintf } from "@web/core/utils/strings";
 import { GoogleMapRenderer } from '@web_view_google_map/views/google_map/google_map_renderer';
 import { formatNumber } from '@web_view_google_map/views/google_map/utils';
 import { GoogleMapSidebarSaleOrder } from './google_map_sidebar';
@@ -98,9 +99,9 @@ export class GoogleMapRendererSaleOrder extends GoogleMapRenderer {
             return this._createFallbackMarkerElement();
         }
 
-        const { aggregates } = group;
+        const { aggregates, count } = group;
         const amountTotal = aggregates.amount_total || 0;
-        const displayName = group.displayName || _t('Customer');
+        const displayName = sprintf("%s (%s)", (group.displayName || _t('Customer')), count);
         const formattedAmount = formatNumber(amountTotal, 2, user.context.lang);
 
         const container = this._createMarkerContainer(group.groupColor);

--- a/sale_google_map/static/src/views/google_map/google_map_sidebar.js
+++ b/sale_google_map/static/src/views/google_map/google_map_sidebar.js
@@ -20,7 +20,7 @@ export class GoogleMapSidebarSaleOrder extends GoogleMapSidebar {
      * Initializes the component.
      * Sets up Google Maps event listeners and lifecycle hooks.
      * When the map tiles are loaded, automatically triggers group record loading
-     * with a 500ms delay to ensure proper rendering.
+     * with a 200ms delay to ensure proper rendering.
      */
     setup() {
         super.setup();
@@ -28,12 +28,12 @@ export class GoogleMapSidebarSaleOrder extends GoogleMapSidebar {
 
         this.uiService = useService('ui');
 
-        this.debouncedLoadGroupRecord = debounce(this.loadGroupRecord.bind(this), 500);
+        this.debouncedLoadGroupRecord = debounce(this.loadGroupRecord.bind(this), 200);
 
         onMounted(() => {
             const googleMap = this.env.googleMap();
             if (!googleMap) return;
-            this.debouncedLoadGroupRecord();
+            this.loadGroupRecord();
         });
 
         onWillUpdateProps((nextProps) => {

--- a/sale_google_map/static/src/views/google_map/google_map_view.scss
+++ b/sale_google_map/static/src/views/google_map/google_map_view.scss
@@ -36,12 +36,12 @@
                 position: absolute;
                 left: 50%;
                 top: 100%;
-                transform: translate(-50%, 0);
-                width: 0;
-                height: 0;
-                border-left: 12px solid transparent;
-                border-right: 12px solid transparent;
-                border-top: 12px solid light-dark(#fafafa, black);
+                transform: translate(-50%, -48%) rotate(45deg);
+                width: 14px;
+                height: 14px;
+                background-color: light-dark(#fafafa, black);
+                border-right: 1px solid light-dark(rgba(140, 139, 139, 0.5), rgba(118, 116, 116, 0.5));
+                border-bottom: 1px solid light-dark(rgba(140, 139, 139, 0.5), rgba(118, 116, 116, 0.5));
             }
 
             &.marker-drop-animation {

--- a/sale_google_map/views/sale_order.xml
+++ b/sale_google_map/views/sale_order.xml
@@ -12,7 +12,6 @@
                 <field name="name"/>
                 <field name="partner_id"/>
                 <field name="amount_total"/>
-                <field name="currency_id"/>
             </google_map>
         </field>
     </record>
@@ -111,7 +110,6 @@
                 <field name="name"/>
                 <field name="partner_id"/>
                 <field name="amount_total"/>
-                <field name="currency_id"/>
             </google_map>
         </field>
     </record>


### PR DESCRIPTION
Performance:
- Set openGroupsByDefault: true in GoogleMapControllerSaleOrder.modelParams when defaultGroupBy is active, passing auto_unfold: true to web_read_group so each group's records are returned in the initial RPC — eliminating per-group web_search_read calls from group.toggle()
- Call loadGroupRecord() directly in onMounted instead of through the debounced wrapper, removing the 500 ms forced wait before group loading starts
- Reduce onWillUpdateProps debounce from 500 ms to 200 ms

Improved:
- Marker display name now shows order count: "{Customer} (N)" via sprintf
- Marker tail pointer switched from a CSS border-triangle to a rotated square element for a cleaner, shadow-compatible appearance
- Remove currency_id field from google_map view definitions (unused by the renderer)
- Expand __manifest__.py summary and description with feature list and requirements

Docs:
- Update CHANGELOG.md with v19.0.1.0.9 entry
- Update docs/FEATURES.md to reflect new marker content and group loading behavior