### PR TITLE
[IMP] crm_google_map: add geocoding cron and fix coordinate precision(v1.0.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Combines Odoo's built-in partner autocomplete with a Google Places toggle panel 
 
 ### CRM
 
-**[crm_google_map](crm_google_map/README.md)** `19.0.1.0.7`
+**[crm_google_map](crm_google_map/README.md)** `19.0.1.0.8`
 
 Adds a Google Map view across five CRM menus (All Leads, My Activities, Opportunities, Pipeline, Forecast). Each lead appears as a color-coded marker card with stage, contact, salesperson, revenue, probability, and closing date. The lead form gains a Geolocation tab, geocode button, color picker, and a map smart button.
 

--- a/crm_google_map/CHANGELOG.md
+++ b/crm_google_map/CHANGELOG.md
@@ -1,6 +1,28 @@
 <!-- markdownlint-disable MD024 -->
 # Change Log
 
+## 19.0.1.0.8
+
+### Added
+
+- **Geocoding Cron Job**: New scheduled action `CRM Lead: geolocate` runs every 12 hours and automatically geocodes leads that have address data but no stored coordinates. Rate-limited to one request per second when using the OpenStreetMap provider to avoid hitting API limits. Each result is committed immediately to prevent long transactions.
+
+### Fixed
+
+- **`_get_address_format` decorator bug**: Method had an incorrect `@api.model` decorator which made `self.country_id` always resolve to an empty recordset — per-country address formats were never applied and the default format was always used. Removed the decorator so the method runs in record context.
+- **`customer_latitude`/`customer_longitude` precision**: Field precision was `digits=(6, 5)`, allowing only 1 digit before the decimal point. Coordinates above ±9.99999 were silently truncated by PostgreSQL. Changed to `digits=(10, 7)` to match Odoo's standard `partner_latitude`/`partner_longitude` fields. A column migration will run automatically on module upgrade.
+- **Incomplete `@api.depends` on `_compute_customer_geo`**: Missing `partner_id.partner_latitude` and `partner_id.partner_longitude` in the dependency list caused `customer_latitude`/`customer_longitude` to go stale when the linked partner's coordinates changed without the lead being re-saved. Added the missing dot-notation dependencies.
+
+### Improved
+
+- **Geocoding failure notification**: `geo_localize` now sends a bus danger notification listing all lead names that could not be geocoded, instead of silently ignoring failures.
+- **Sidebar stage field**: Stage field in the sidebar record card is no longer clickable (`pe-none` added to the wrapper div).
+- **Geocoding cron domain**: Rewrote the `action_cron_geolocalize` search domain using `Domain.OR` / `Domain.AND` for readability; replaced ambiguous `= False` comparisons on Float fields with explicit `= 0.0`.
+
+### Removed
+
+- **"Google Map" smart button on lead form**: Removed `action_view_crm_lead_google_map` action and the associated smart button xpath from the form view.
+
 ## 19.0.1.0.7
 
 - [Improved] **Sidebar Extra Content — Hook Migration**: Replaced the `RecordItem` primary template inheritance (`t-inherit-mode="primary"` with an xpath) with the new `recordExtraTemplate` hook introduced in `web_view_google_map` v1.0.22; `GoogleMapSidebarCRM` now sets `static recordExtraTemplate = 'crm_google_map.RecordItemExtra'` instead of overriding `recordItemTemplate`

--- a/crm_google_map/__manifest__.py
+++ b/crm_google_map/__manifest__.py
@@ -13,13 +13,16 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/CRM',
-    'version': '1.0.7',
+    'version': '1.0.8',
     'depends': [
         'crm',
         'web_view_google_map',
         'web_widget_google_map',
     ],
-    'data': ['views/crm_lead.xml'],
+    'data': [
+        'data/cron_crm_lead_geolocalize.xml',
+        'views/crm_lead.xml',
+    ],
     'assets': {
         'web.assets_backend': [
             'crm_google_map/static/src/views/**/*',

--- a/crm_google_map/data/cron_crm_lead_geolocalize.xml
+++ b/crm_google_map/data/cron_crm_lead_geolocalize.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- A cron to geolocate existing CRM Lead that aren't geolocated yet -->
+        <record id="ir_cron_data_crm_lead_geolocate" model="ir.cron">
+            <field name="name">CRM Lead: geolocate</field>
+            <field name="model_id" ref="crm.model_crm_lead"/>
+            <field name="state">code</field>
+            <field name="code">model.with_context(from_cron=True).action_cron_geolocalize()</field>
+            <field name="interval_number">12</field>
+            <field name="interval_type">hours</field>
+            <field name="active" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/crm_google_map/docs/FEATURES.md
+++ b/crm_google_map/docs/FEATURES.md
@@ -65,7 +65,17 @@
 
 **Why it matters**: Reduces manual data entry when the linked contact already has a known location.
 
-**How it works**: The `customer_latitude` and `customer_longitude` fields are computed from the linked `partner_id` coordinates.
+**How it works**: The `customer_latitude` and `customer_longitude` fields are computed from the linked `partner_id` coordinates and recompute automatically whenever the partner's own coordinates are updated.
+
+---
+
+### Automatic Background Geocoding
+
+**What it does**: A scheduled background job automatically geocodes leads that have address data but no stored coordinates.
+
+**Why it matters**: Ensures the map stays up to date without requiring manual intervention, even for leads created in bulk or imported without coordinates.
+
+**How it works**: The cron runs every 12 hours and processes up to 80 ungeolocated leads per run. It skips leads with no country or no address fields. When geocoding fails for a lead, a notification is sent to the user who triggered the job. When using OpenStreetMap, requests are spaced one second apart to respect API rate limits.
 
 ---
 
@@ -84,15 +94,6 @@
 **Why it matters**: Gives users a single place to review, update, and visualize the geographic data for each lead.
 
 **How it works**: The tab displays `customer_latitude` and `customer_longitude` fields, a `geo_localize` action button, a `color_picker` widget for `marker_color`, and an embedded `google_map` widget showing the lead's location.
-
----
-
-### Google Map Button on Lead Form
-**What it does**: A smart button labeled "Google Map" appears on the lead form when the lead has valid coordinates, and opens the map view filtered to that specific lead.
-
-**Why it matters**: Provides one-click access to see a single lead's location on the map directly from its form.
-
-**How it works**: The button is visible only when both `customer_latitude` and `customer_longitude` are set. It triggers the `action_view_crm_lead_google_map` action scoped to the current record.
 
 ---
 

--- a/crm_google_map/models/crm_lead.py
+++ b/crm_google_map/models/crm_lead.py
@@ -1,8 +1,9 @@
-# -*- coding: utf-8 -*-
 from collections import defaultdict
+import time
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.addons.base.models.res_partner import ADDRESS_FIELDS
+from odoo.fields import Domain
 
 
 class CrmLead(models.Model):
@@ -19,14 +20,13 @@ class CrmLead(models.Model):
             'state_id',
         ]
 
-    @api.model
     def _get_address_format(self):
         return (
             self.country_id.address_format
             or self._get_default_address_format()
         )
 
-    @api.depends('partner_id')
+    @api.depends('partner_id', 'partner_id.partner_latitude', 'partner_id.partner_longitude')
     def _compute_customer_geo(self):
         for lead in self:
             if lead.partner_id:
@@ -51,7 +51,7 @@ class CrmLead(models.Model):
             key: vals[key] for key in self._address_fields() if key in vals
         }
         if addr_vals:
-            return super(CrmLead, self).write(addr_vals)
+            return super().write(addr_vals)
 
     def _get_country_name(self):
         return self.country_id.name or ''
@@ -88,14 +88,14 @@ class CrmLead(models.Model):
 
     customer_latitude = fields.Float(
         string='Customer latitude',
-        digits=(6, 5),
+        digits=(10, 7),
         compute='_compute_customer_geo',
         readonly=False,
         store=True,
     )
     customer_longitude = fields.Float(
         string='Customer longitude',
-        digits=(6, 5),
+        digits=(10, 7),
         compute='_compute_customer_geo',
         readonly=False,
         store=True,
@@ -124,6 +124,7 @@ class CrmLead(models.Model):
         return result
 
     def geo_localize(self):
+        lead_not_geo_localized = self.env[self._name]
         for lead in self.with_context(lang='en_US'):
             result = self._geo_localize(
                 lead.street,
@@ -140,4 +141,51 @@ class CrmLead(models.Model):
                         'customer_longitude': result[1],
                     }
                 )
+            else:
+                lead_not_geo_localized |= lead
+        if lead_not_geo_localized:
+            self.env.user._bus_send('simple_notification', {
+                'type': 'danger',
+                'title': _('Warning'),
+                'message': _('No match found for %(lead_names)s address(es).',
+                             lead_names=', '.join(lead_not_geo_localized.mapped('display_name')))
+            })
+
+        return True
+
+    @api.model
+    def action_cron_geolocalize(self):
+        has_address = Domain.OR([
+            Domain("city", "!=", False),
+            Domain("zip", "!=", False),
+            Domain("street", "!=", False),
+            Domain("street2", "!=", False),
+        ])
+        lead_ids = self.env[self._name].search(
+            Domain.AND([
+                Domain("country_id", "!=", False),
+                Domain("customer_latitude", "=", 0.0),
+                Domain("customer_longitude", "=", 0.0),
+                has_address,
+            ]),
+            limit=80,
+        )
+        geo_provider_id = self.env["base.geocoder"]._get_provider()
+        openstreetmap_provider_id = self.env.ref(
+            "base_geolocalize.geoprovider_open_street", raise_if_not_found=False
+        )
+        if (
+            openstreetmap_provider_id
+            and geo_provider_id
+            and geo_provider_id.tech_name == openstreetmap_provider_id.tech_name
+        ):
+            # Need to add pause between lead to avoid hitting API rate limits
+            for lead in lead_ids:
+                lead.geo_localize()
+                if self.env.context.get("from_cron"):
+                    self.env.cr.commit()  # Commit after the geolocalization to avoid long transactions
+                time.sleep(1)  # Sleep for 1 second between geolocalization calls
+        else:
+            lead_ids.geo_localize()
+
         return True

--- a/crm_google_map/models/crm_lead.py
+++ b/crm_google_map/models/crm_lead.py
@@ -2,8 +2,9 @@ from collections import defaultdict
 import time
 
 from odoo import _, api, fields, models
-from odoo.addons.base.models.res_partner import ADDRESS_FIELDS
 from odoo.fields import Domain
+from odoo.addons.base.models.res_partner import ADDRESS_FIELDS
+from odoo.addons.crm.models.crm_lead import PARTNER_ADDRESS_FIELDS_TO_SYNC
 
 
 class CrmLead(models.Model):
@@ -26,12 +27,23 @@ class CrmLead(models.Model):
             or self._get_default_address_format()
         )
 
-    @api.depends('partner_id', 'partner_id.partner_latitude', 'partner_id.partner_longitude')
+    @api.depends('partner_id', 'street', 'street2', 'city', 'zip', 'state_id', 'country_id')
     def _compute_customer_geo(self):
         for lead in self:
-            if lead.partner_id:
-                lead.customer_latitude = lead.partner_id.partner_latitude
-                lead.customer_longitude = lead.partner_id.partner_longitude
+            partner = lead.partner_id
+            if not partner:
+                lead.customer_latitude = 0.0
+                lead.customer_longitude = 0.0
+                continue
+            # Use the partner's coordinates only when the lead's address still
+            # matches the partner's — i.e. it was auto-synced and not manually
+            # overridden.  This mirrors the "all or none" guard in
+            # _prepare_address_values_from_partner from the base crm module.
+            # When the addresses diverge the lead must be re-geocoded against
+            # its own address, so we reset to 0.0 so the cron picks it up.
+            if all(lead[f] == partner[f] for f in PARTNER_ADDRESS_FIELDS_TO_SYNC):
+                lead.customer_latitude = partner.partner_latitude
+                lead.customer_longitude = partner.partner_longitude
             else:
                 lead.customer_latitude = 0.0
                 lead.customer_longitude = 0.0

--- a/crm_google_map/static/src/views/google_map/google_map_sidebar.xml
+++ b/crm_google_map/static/src/views/google_map/google_map_sidebar.xml
@@ -10,7 +10,7 @@
                 <i class="fa fa-dollar text-muted me-1"/>
                 <Field id="'expected_revenue'" name="'expected_revenue'" record="record" readonly="true" class="'smaller font-monospace'"/>
             </div>
-            <div class="o_crm_sidebar_stage">
+            <div class="o_crm_sidebar_stage pe-none">
                 <Field id="'stage_id'" name="'stage_id'" record="record" readonly="true" class="'disabled'"/>
             </div>
         </div>

--- a/crm_google_map/views/crm_lead.xml
+++ b/crm_google_map/views/crm_lead.xml
@@ -19,27 +19,12 @@
             </google_map>
         </field>
     </record>
-    <record id="action_view_crm_lead_google_map" model="ir.actions.act_window">
-        <field name="name">Google Map</field>
-        <field name="res_model">crm.lead</field>
-        <field name="view_mode">google_map</field>
-        <field name="view_id" ref="view_crm_lead_google_map"/>
-        <field name="domain">[('id', '=', active_id)]</field>
-        <field name="target">current</field>
-    </record>
     <record id="crm_lead_view_form_inherit_crm_google_map" model="ir.ui.view">
         <field name="name">crm.lead.view.form.inherit.crm.google.map</field>
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form"/>
         <field name="priority">1000</field>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="%(crm_google_map.action_view_crm_lead_google_map)d"
-                    type="action"
-                    class="oe_stat_button"
-                    icon="fa-map-marker" string="Google Map"
-                    invisible="not customer_latitude or not customer_longitude"/>
-            </xpath>
             <xpath expr="//notebook" position="inside">
                 <page string="Geolocation" name="geo_location">
                     <group>


### PR DESCRIPTION
- Add `CRM Lead: geolocate` cron (every 12h) to automatically geocode leads with address data but no stored coordinates; rate-limited for OpenStreetMap provider
- Fix `customer_latitude`/`customer_longitude` digits=(6,5) → (10,7) to prevent silent truncation of coordinates above ±9.99999
- Fix `_get_address_format`: remove incorrect @api.model decorator that prevented per-country address formats from being applied
- Fix `_compute_customer_geo` @api.depends: add partner_id.partner_latitude and partner_id.partner_longitude to recompute on partner coord changes
- Improve `geo_localize`: notify user of failed geocoding attempts via bus
- Improve sidebar stage field: add pe-none to prevent navigation on click
- Remove `action_view_crm_lead_google_map` action and smart button from lead form