### PR TITLE
[FIX] sale_google_map: update GroupItem XPath selectors for t-att-class change

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Applies `gplace_autocomplete_el` to the Lead/Opportunity form's company name fie
 
 ### Sales
 
-**[sale_google_map](sale_google_map/README.md)** `19.0.1.0.11`
+**[sale_google_map](sale_google_map/README.md)** `19.0.1.0.12`
 
 Adds a Google Map view to Quotations, Orders, Orders to Invoice, Orders to Upsell, and Customers in Sales. Groups records by customer — one marker per customer — showing avatar, name, order count, and aggregated order total. Enforces grouping and auto-loads all groups on open.
 

--- a/sale_google_map/CHANGELOG.md
+++ b/sale_google_map/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!-- markdownlint-disable MD024 -->
 # Change Log
 
+## 19.0.1.0.12
+
+### Fixed
+
+- **`GroupItem` XPath — Collapse Div Selector**: The base template switched the collapsible group div from `t-attf-class="collapse ..."` to `t-att-class="{ 'collapse': true, ... }"` (object binding). The `contains(@t-attf-class, 'collapse')` XPath no longer matched; updated to `contains(@t-attf-id, 'collapseGroup_')` which targets the stable `t-attf-id` attribute
+- **`GroupItem` XPath — Collapse Button Selector**: Similarly, the collapse button's class moved from a `t-attf-class` string interpolation to `t-att-class`; replaced `contains(@t-attf-class, 'collapsed')` with `@data-bs-toggle='collapse'` for a more stable, semantic selector that is unaffected by class binding style
+
 ## 19.0.1.0.11
 
 - [Fixed] **Avatar Wrapper**: Replaced `<div class="d-inline-block position-relative opacity-trigger-hover">` wrapper around the group avatar `<img>` with a plain `<t t-if="avatar_url">` guard, removing the always-present placeholder div when no avatar is available

--- a/sale_google_map/CHANGELOG.md
+++ b/sale_google_map/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Fixed
 
-- **`GroupItem` XPath — Collapse Div Selector**: The base template switched the collapsible group div from `t-attf-class="collapse ..."` to `t-att-class="{ 'collapse': true, ... }"` (object binding). The `contains(@t-attf-class, 'collapse')` XPath no longer matched; updated to `contains(@t-attf-id, 'collapseGroup_')` which targets the stable `t-attf-id` attribute
-- **`GroupItem` XPath — Collapse Button Selector**: Similarly, the collapse button's class moved from a `t-attf-class` string interpolation to `t-att-class`; replaced `contains(@t-attf-class, 'collapsed')` with `@data-bs-toggle='collapse'` for a more stable, semantic selector that is unaffected by class binding style
+- **`GroupItem` XPath — Collapse Div Selector**: Replaced the brittle `contains(@t-attf-class, 'collapse')` XPath with `contains(@t-attf-id, 'collapseGroup_')`, targeting the stable `t-attf-id` used by the collapsible group div instead of relying on class-attribute matching
+- **`GroupItem` XPath — Collapse Button Selector**: Replaced `contains(@t-attf-class, 'collapsed')` with `@data-bs-toggle='collapse'`, using a more stable, semantic selector for the collapse button that does not depend on how classes are constructed
 
 ## 19.0.1.0.11
 

--- a/sale_google_map/__manifest__.py
+++ b/sale_google_map/__manifest__.py
@@ -23,7 +23,7 @@ Requires a Google API Key configured in Settings → General Settings → Google
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/Sales',
-    'version': '1.0.11',
+    'version': '1.0.12',
     'depends': ['sale_management', 'web_view_google_map'],
     'data': ['views/sale_order.xml', 'views/res_partner.xml'],
     'assets': {

--- a/sale_google_map/static/src/views/google_map/google_map_sidebar.xml
+++ b/sale_google_map/static/src/views/google_map/google_map_sidebar.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="sale_google_map.GroupItem" t-inherit="web_view_google_map.GroupItem" t-inherit-mode="primary">
-        <xpath expr="//div[contains(@t-attf-class, 'collapse')]" position="replace"/>
-        <xpath expr="//button[contains(@t-attf-class, 'collapsed')]" position="replace">
+        <xpath expr="//div[contains(@t-attf-id, 'collapseGroup_')]" position="replace"/>
+        <xpath expr="//button[@data-bs-toggle='collapse']" position="replace">
             <div class="ps-1 cursor-pointer o_map_sidebar_group" t-on-click="() => fnPinPointInMap(group.group.id)">
                 <t t-set="title" t-value="(group.group.displayName || 'None') + ' (' + group.group.count + ')' " />
                 <t t-set="totalAmount" t-value="getTotalAmount(group.group)"/>


### PR DESCRIPTION
This pull request updates the `sale_google_map` module to version 19.0.1.0.12 and addresses issues with XPath selectors in the sidebar group items due to changes in the base template's class and attribute bindings. The selectors are now more robust and less dependent on the specific class binding style, improving compatibility and maintainability.

### Version bump and documentation

* Bumped the module version to `1.0.12` in both `__manifest__.py` and `README.md` to reflect the new release. [[1]](diffhunk://#diff-abbbb8c4bfa19129efb2a3398b6c7020c675810b7e8c2ef656be15285bfd5899L26-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R154)
* Added a changelog entry for version `19.0.1.0.12` in `CHANGELOG.md` describing the fixes.

### XPath selector fixes (Sidebar group items)

* Updated the group div XPath in `google_map_sidebar.xml` to use `contains(@t-attf-id, 'collapseGroup_')` instead of the less stable class-based selector, ensuring reliable targeting after the base template's attribute changes.
* Changed the collapse button XPath to select via `@data-bs-toggle='collapse'` instead of a class-based selector, making the selector more semantic and resilient to template changes.