### PR TITLE
[FIX] project_google_map: update button selectors from id to data-role

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Adds a Google Map view across Deliveries, Ready to Transfer, Waiting Transfer, L
 
 ### Project
 
-**[project_google_map](project_google_map/README.md)** `19.0.1.0.2`
+**[project_google_map](project_google_map/README.md)** `19.0.1.0.3`
 
 Adds a Google Map view for Projects and Tasks. Project markers show task counts and completion statistics; a satellite site map is embedded on the project form. Task maps are scoped per project. Status color-coding (on track, at risk, off track, on hold, done) is configurable per project.
 

--- a/project_google_map/CHANGELOG.md
+++ b/project_google_map/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixed
 
-- **`MarkerInfoWindow` XPath — Button Selector**: Updated XPath from `//button[@id='btn-open_form']` to `//button[@data-role='btn-open_form']` tracking the ID → `data-role` change in `web_view_google_map` v1.0.24
-- **"View Tasks" Button — `id` → `data-role`**: Replaced `id="btn-view_tasks"` with `data-role="btn-view_tasks"` on the button element, avoiding duplicate-ID issues when multiple info windows are open
-- **`_createInfoWindowContent` — Button Selector**: Updated `content.querySelector('#btn-view_tasks')` to `content.querySelector('[data-role="btn-view_tasks"]')` to match the new attribute
+- **`MarkerInfoWindow` XPath — Button Selector**: Updated XPath from `//button[@id='btn-open_form']` to `//button[@data-role='btn-open_form']` to align with the upstream ID → `data-role` selector change adopted by `web_view_google_map`
+- **"View Tasks" Button — `id` → `data-role`**: Replaced `id="btn-view_tasks"` with `data-role="btn-view_tasks"` on the button element for consistency with the updated selector convention
+- **`_createInfoWindowContent` — Button Selector**: Updated `content.querySelector('#btn-view_tasks')` to `content.querySelector('[data-role="btn-view_tasks"]')` to match the button attribute change
 
 ## 1.0.2
 

--- a/project_google_map/CHANGELOG.md
+++ b/project_google_map/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.0.3
+
+### Fixed
+
+- **`MarkerInfoWindow` XPath — Button Selector**: Updated XPath from `//button[@id='btn-open_form']` to `//button[@data-role='btn-open_form']` tracking the ID → `data-role` change in `web_view_google_map` v1.0.24
+- **"View Tasks" Button — `id` → `data-role`**: Replaced `id="btn-view_tasks"` with `data-role="btn-view_tasks"` on the button element, avoiding duplicate-ID issues when multiple info windows are open
+- **`_createInfoWindowContent` — Button Selector**: Updated `content.querySelector('#btn-view_tasks')` to `content.querySelector('[data-role="btn-view_tasks"]')` to match the new attribute
+
 ## 1.0.2
 
 - [Improved] **Sidebar Actions Hook Migration**: Replaced `RecordItem` primary template inheritance (xpath before the marker span) with the new `recordActionsTemplate` slot from `web_view_google_map` v1.0.22; `GoogleMapSidebarProject` now sets `static recordActionsTemplate = 'project_google_map.RecordActionsTemplate'` instead of overriding `recordItemTemplate`

--- a/project_google_map/__manifest__.py
+++ b/project_google_map/__manifest__.py
@@ -14,7 +14,7 @@
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Project',
-    'version': '1.0.2',
+    'version': '1.0.3',
     'depends': [
         'project',
         'web_view_google_map',

--- a/project_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/project_google_map/static/src/views/google_map/google_map_renderer.js
@@ -17,7 +17,7 @@ export class GoogleMapRendererProject extends GoogleMapRenderer {
     _createInfoWindowContent(record, isShifted = false) {
         const content = super._createInfoWindowContent(record, isShifted);
         if (content) {
-            const viewTaskButton = content.querySelector('#btn-view_tasks');
+            const viewTaskButton = content.querySelector('[data-role="btn-view_tasks"]');
             if (viewTaskButton && Number.isFinite(record.resId)) {
                 const eventHandler = this._actionViewTasks.bind(this, record);
                 viewTaskButton.addEventListener('click', eventHandler);

--- a/project_google_map/static/src/views/google_map/google_map_renderer.xml
+++ b/project_google_map/static/src/views/google_map/google_map_renderer.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="project_google_map.MarkerInfoWindow" t-inherit="web_view_google_map.MarkerInfoWindow" t-inherit-mode="primary">
-        <xpath expr="//button[@id='btn-open_form']" position="after">
-            <button type="button" class="btn btn-sm btn-outline-dark" id="btn-view_tasks" data-tooltip="View Tasks">
+        <xpath expr="//button[@data-role='btn-open_form']" position="after">
+            <button type="button" class="btn btn-sm btn-outline-dark" data-role="btn-view_tasks" data-tooltip="View Tasks">
                 <i class="fa fa-fw fa-list-ul"/>
             </button>
         </xpath>


### PR DESCRIPTION
This pull request updates the `project_google_map` module to version 1.0.3, focusing on fixing selector issues related to Google Map marker info window buttons. The changes ensure compatibility with updates in the dependent `web_view_google_map` module and resolve potential issues with duplicate IDs when multiple info windows are open.

**Marker Info Window Button Selector Updates:**

- Changed the XPath in the marker info window template to select buttons using `data-role='btn-open_form'` instead of `id='btn-open_form'` to track upstream changes in `web_view_google_map` v1.0.24.
- Updated the "View Tasks" button in the marker info window to use `data-role="btn-view_tasks"` instead of `id="btn-view_tasks"`, preventing duplicate ID issues when multiple info windows are present.

**JavaScript Selector Adjustments:**

- Modified the selector in `_createInfoWindowContent` within `google_map_renderer.js` to use `[data-role="btn-view_tasks"]` instead of `#btn-view_tasks`, matching the updated attribute.

**Documentation and Versioning:**

- Updated the module version to `1.0.3` in both `README.md` and `__manifest__.py` to reflect these fixes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R170) [[2]](diffhunk://#diff-5c22d634cd4626f6d8f1b4c5666c2903a93cbbc82797fbce489f62558ebd5e79L17-R17)
- Added a changelog entry detailing the selector updates and the rationale behind them.