### PR TITLE
[IMP] web_view_google_map_drawing: refactor SearchableJson field and fix NULL handling (v1.0.19)

### DIFF
--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## 19.0.1.0.19
+
+### Refactored
+
+- **`SearchableJson` / `JsonValue` / `JsonContainsValue` — Base Class Introduced**: Extracted shared `__init__`, `__hash__`, `__eq__`, and `__repr__` into a new `_JsonWrappedValue` base class, eliminating ~40 lines of duplicated code between `JsonValue` and `JsonContainsValue`
+- **`_condition_to_sql` Split into Four Methods**: The monolithic method is now `_build_json_in_sql` (loop + SQL joining), `_single_value_to_sql` (type dispatch), `_equality_sql` (exact JSONB equality), and `_containment_sql` (JSONB @> containment) — each independently testable
+- **Type Dispatch via `isinstance` (re-introduced)**: `_single_value_to_sql` now uses `isinstance(v, JsonContainsValue)` / `isinstance(v, JsonValue)` instead of `getattr` marker attribute duck-typing, enabled by the base class consolidation. See 19.0.1.0.17 for the dual-import context; this assumes a single import path for the module
+- **`type(self) is type(other)` in `__eq__`**: Replaced `isinstance(other, JsonValue)` with an exact type check so `JsonValue(x)` is never equal to `JsonContainsValue(x)` even when wrapping the same payload — prevents silent `OrderedSet` deduplication across operator classes
+
+### Fixed
+
+- **`False`/`None` Handled as SQL NULL**: Plain `False` or `None` values in `not in` now generate `IS NULL` / `IS NOT NULL` SQL directly, instead of routing through `json.dumps` which produces the JSON literals `false`/`null` and misses actual SQL NULL rows
+- **Explicit `::jsonb` Casts on Both Sides of Equality**: `_equality_sql` now generates `%s::jsonb = %s::jsonb` instead of bare `%s = %s`, removing the dependency on PostgreSQL's implicit text→jsonb coercion
+
+### Tests Added
+
+- **NULL Operator Coverage (Integration)**: Four new integration tests verify correct SQL NULL semantics end-to-end against a real JSONB column: `test_eq_false_finds_null_records`, `test_ne_false_excludes_null_records`, `test_json_ne_includes_null_records`, `test_json_not_contains_includes_null_records`
+- **IS NULL Guard Assertions**: `test_json_ne_sql_generation_with_wrapped_value` and `test_json_not_contains_sql_generation` now assert `IS NULL` is present in the generated SQL — previously these tests could pass even with broken NULL handling
+- **`test_regular_value_not_in_includes_null_check`**: Verifies that plain (non-wrapped) values in a `not in` operator also generate the IS NULL guard
+- **`test_misapplied_custom_operator_raises_error`**: Verifies all four custom operators (`json_eq`, `json_ne`, `json_contains`, `json_not_contains`) raise `ValueError` when they bypass domain optimization
+
+### Improved
+
+- **Test Isolation in Integration Tests**: All integration test searches are now scoped via a `_search(ids, ...)` helper that prepends `('id', 'in', ids)` — prevents flaky results caused by pre-existing `res.partner.area` rows in the test database
+- **GeoJSON Fixtures as Module-Level Constants**: `POINT`, `POINT_OTHER`, `POLYGON`, `FEATURE_COLLECTION_EMPTY`, `FEATURE_COLLECTION_POINT` are module-level constants shared across all integration tests, replacing repeated inline dicts
+
 ## 19.0.1.0.18
 
 ### Fixed

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -11,10 +11,10 @@
     ''',
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
-    'website': 'https://github.com/mithnusa',
+    'website': 'https://www.mithnusa.com',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.18',
+    'version': '1.0.19',
     'depends': ['web_view_google_map'],
     'data': ['data/gmap_libraries.xml'],
     'assets': {

--- a/web_view_google_map_drawing/docs/FEATURES.md
+++ b/web_view_google_map_drawing/docs/FEATURES.md
@@ -28,6 +28,15 @@ Keyboard shortcuts are available for switching modes (keys `1`–`7`), saving (`
 
 **How it works**: The module provides a `SearchableJson` field type that extends Odoo's standard JSON field with four additional search operators: `json_eq`, `json_ne`, `json_contains`, and `json_not_contains`. These map to PostgreSQL JSONB operators, allowing domain filters like "find all records whose shape is a polygon" directly from the Odoo ORM.
 
+| Operator | Description |
+| --- | --- |
+| `json_eq` | Exact match — returns records whose GeoJSON is structurally identical to the given value |
+| `json_ne` | Not equal — returns records with a different value, including records with no GeoJSON at all |
+| `json_contains` | Containment — returns records whose GeoJSON contains the given sub-object (PostgreSQL `@>` operator) |
+| `json_not_contains` | Not contains — returns records that do not contain the sub-object, including records with no GeoJSON |
+
+Records with no GeoJSON stored (NULL) are correctly included in `json_ne` and `json_not_contains` results. Standard Odoo `= False` and `!= False` operators also work correctly on the field for explicit NULL checks.
+
 ---
 
 ## Google Drawing Shape Mixin

--- a/web_view_google_map_drawing/example/contacts_area/tests/test_searchable_json_integration.py
+++ b/web_view_google_map_drawing/example/contacts_area/tests/test_searchable_json_integration.py
@@ -2,15 +2,33 @@
 """
 Integration tests for SearchableJson field using res.partner.area.
 
-These tests require the contacts_area module to be installed (which provides
-res.partner.area, a concrete model inheriting google.drawing.shape). They
+These tests require the contacts_area module to be installed. They
 verify that the custom JSON operators (json_eq, json_ne, json_contains,
-json_not_contains) execute correct SQL against a real PostgreSQL JSONB column.
+json_not_contains) and standard Odoo operators (=, !=) execute correct SQL
+against a real PostgreSQL JSONB column.
 
 Unit tests for the field class, wrapper classes, and domain optimization live in:
   web_view_google_map_drawing/tests/test_field_json_searchable.py
 """
 from odoo.tests.common import TransactionCase
+
+POINT = {"type": "Point", "coordinates": [106.45, -6.36]}
+POINT_OTHER = {"type": "Point", "coordinates": [1.0, 1.0]}
+POLYGON = {
+    "type": "Polygon",
+    "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+}
+FEATURE_COLLECTION_EMPTY = {"type": "FeatureCollection", "features": []}
+FEATURE_COLLECTION_POINT = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": POINT,
+            "properties": {},
+        }
+    ],
+}
 
 
 class TestSearchableJsonIntegration(TransactionCase):
@@ -19,197 +37,157 @@ class TestSearchableJsonIntegration(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.test_model = cls.env['res.partner.area']
+        cls.Model = cls.env['res.partner.area']
 
-    def test_create_and_search_feature_collection(self):
-        """Test creating a record with FeatureCollection and searching for it."""
-        feature_collection = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {
-                        "type": "Point",
-                        "coordinates": [106.45, -6.36]
-                    },
-                    "properties": {}
-                }
-            ]
-        }
+    def _create(self, name, geojson):
+        return self.Model.create({'gshape_name': name, 'gshape_geojson': geojson})
 
-        record = self.test_model.create({
-            'gshape_name': 'Test FeatureCollection',
-            'gshape_geojson': feature_collection,
-        })
+    def _search(self, extra_ids, *domain_parts):
+        """Search restricted to the given record IDs to avoid pre-existing data."""
+        return self.Model.search([('id', 'in', extra_ids)] + list(domain_parts))
 
-        results = self.test_model.search([
-            ('gshape_geojson', 'json_contains', {'type': 'FeatureCollection'})
-        ])
+    # -------------------------------------------------------------------------
+    # Standard Odoo operators: = False / != False (NULL handling)
+    # -------------------------------------------------------------------------
 
-        self.assertIn(record, results)
+    def test_eq_false_finds_null_records(self):
+        """('gshape_geojson', '=', False) must return records where geojson IS NULL."""
+        null_rec = self._create('Null GeoJSON', False)
+        has_value = self._create('Has GeoJSON', POINT)
+        ids = [null_rec.id, has_value.id]
 
-    def test_search_exact_match(self):
-        """Test exact match search with json_eq operator."""
-        simple_geojson = {
-            "type": "Point",
-            "coordinates": [106.45, -6.36]
-        }
+        results = self._search(ids, ('gshape_geojson', '=', False))
 
-        record = self.test_model.create({
-            'gshape_name': 'Test Point',
-            'gshape_geojson': simple_geojson,
-        })
+        self.assertIn(null_rec, results)
+        self.assertNotIn(has_value, results)
 
-        results = self.test_model.search([
-            ('gshape_geojson', 'json_eq', simple_geojson)
-        ])
+    def test_ne_false_excludes_null_records(self):
+        """('gshape_geojson', '!=', False) must exclude records where geojson IS NULL."""
+        null_rec = self._create('Null GeoJSON', False)
+        has_value = self._create('Has GeoJSON', POINT)
+        ids = [null_rec.id, has_value.id]
 
-        self.assertIn(record, results)
+        results = self._search(ids, ('gshape_geojson', '!=', False))
 
-    def test_search_not_contains(self):
-        """Test json_not_contains operator."""
-        polygon_collection = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {
-                        "type": "Polygon",
-                        "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]
-                    },
-                    "properties": {}
-                }
-            ]
-        }
+        self.assertNotIn(null_rec, results)
+        self.assertIn(has_value, results)
 
-        record = self.test_model.create({
-            'gshape_name': 'Test Polygon',
-            'gshape_geojson': polygon_collection,
-        })
+    # -------------------------------------------------------------------------
+    # json_eq / json_ne
+    # -------------------------------------------------------------------------
 
-        # Polygon record has no top-level type: Point, so it should be returned
-        results = self.test_model.search([
-            ('gshape_geojson', 'json_not_contains', {'type': 'Point'})
-        ])
+    def test_json_eq_finds_exact_match(self):
+        """json_eq returns only records whose geojson equals the given value."""
+        rec = self._create('Point A', POINT)
+        other = self._create('Point B', POINT_OTHER)
+        ids = [rec.id, other.id]
 
-        self.assertIn(record, results)
+        results = self._search(ids, ('gshape_geojson', 'json_eq', POINT))
 
-    def test_complex_feature_collection_search(self):
-        """Test searching within FeatureCollection with multiple features."""
-        multi_feature = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [106.45, -6.36]},
-                    "properties": {"name": "Point 1"}
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [106.46, -6.37]},
-                    "properties": {"name": "Point 2"}
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {
-                        "type": "LineString",
-                        "coordinates": [[106.45, -6.36], [106.46, -6.37]]
-                    },
-                    "properties": {"name": "Line 1"}
-                }
-            ]
-        }
+        self.assertIn(rec, results)
+        self.assertNotIn(other, results)
 
-        record = self.test_model.create({
-            'gshape_name': 'Multi-Feature Collection',
-            'gshape_geojson': multi_feature,
-        })
+    def test_json_ne_excludes_matching_record(self):
+        """json_ne excludes the exact match but includes different values."""
+        rec = self._create('Point A', POINT)
+        other = self._create('Point B', POINT_OTHER)
+        ids = [rec.id, other.id]
 
-        results = self.test_model.search([
-            ('gshape_geojson', 'json_contains', {'type': 'FeatureCollection'})
-        ])
+        results = self._search(ids, ('gshape_geojson', 'json_ne', POINT))
 
-        self.assertIn(record, results)
+        self.assertNotIn(rec, results)
+        self.assertIn(other, results)
 
-    def test_multiple_records_filtering(self):
-        """Test filtering across multiple records with different GeoJSON types."""
-        point_record = self.test_model.create({
-            'gshape_name': 'Simple Point',
-            'gshape_geojson': {"type": "Point", "coordinates": [0, 0]},
-        })
+    def test_json_ne_includes_null_records(self):
+        """json_ne must include records with NULL geojson.
 
-        polygon_record = self.test_model.create({
-            'gshape_name': 'Simple Polygon',
-            'gshape_geojson': {
-                "type": "Polygon",
-                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]
-            },
-        })
+        PostgreSQL evaluates NULL != value as NULL (not TRUE), so without an
+        explicit IS NULL guard these rows would be silently excluded.
+        """
+        null_rec = self._create('No GeoJSON', False)
+        ids = [null_rec.id]
 
-        collection_record = self.test_model.create({
-            'gshape_name': 'Feature Collection',
-            'gshape_geojson': {"type": "FeatureCollection", "features": []},
-        })
+        results = self._search(ids, ('gshape_geojson', 'json_ne', POINT))
 
-        point_results = self.test_model.search([
-            ('gshape_geojson', 'json_contains', {'type': 'Point'})
-        ])
-        self.assertIn(point_record, point_results)
-        self.assertNotIn(collection_record, point_results)
+        self.assertIn(null_rec, results)
 
-        polygon_results = self.test_model.search([
-            ('gshape_geojson', 'json_contains', {'type': 'Polygon'})
-        ])
-        self.assertIn(polygon_record, polygon_results)
-        self.assertNotIn(point_record, polygon_results)
+    # -------------------------------------------------------------------------
+    # json_contains / json_not_contains
+    # -------------------------------------------------------------------------
 
-        collection_results = self.test_model.search([
-            ('gshape_geojson', 'json_contains', {'type': 'FeatureCollection'})
-        ])
-        self.assertIn(collection_record, collection_results)
-        self.assertNotIn(point_record, collection_results)
+    def test_json_contains_finds_matching_record(self):
+        """json_contains returns records where the field contains the sub-object."""
+        rec = self._create('Feature Collection', FEATURE_COLLECTION_POINT)
+        other = self._create('Polygon', POLYGON)
+        ids = [rec.id, other.id]
 
-    def test_nested_structure_containment(self):
-        """Test containment check with nested structures."""
-        nested_geojson = {
+        results = self._search(ids, ('gshape_geojson', 'json_contains', {'type': 'FeatureCollection'}))
+
+        self.assertIn(rec, results)
+        self.assertNotIn(other, results)
+
+    def test_json_not_contains_excludes_matching_record(self):
+        """json_not_contains excludes records that do contain the sub-object."""
+        rec = self._create('Feature Collection', FEATURE_COLLECTION_POINT)
+        other = self._create('Polygon', POLYGON)
+        ids = [rec.id, other.id]
+
+        results = self._search(ids, ('gshape_geojson', 'json_not_contains', {'type': 'FeatureCollection'}))
+
+        self.assertNotIn(rec, results)
+        self.assertIn(other, results)
+
+    def test_json_not_contains_includes_null_records(self):
+        """json_not_contains must include records with NULL geojson.
+
+        PostgreSQL evaluates NULL @> value as NULL (not FALSE), so without an
+        explicit IS NULL guard these rows would be silently excluded.
+        """
+        null_rec = self._create('No GeoJSON', False)
+        ids = [null_rec.id]
+
+        results = self._search(ids, ('gshape_geojson', 'json_not_contains', {'type': 'Point'}))
+
+        self.assertIn(null_rec, results)
+
+    def test_json_contains_nested_structure(self):
+        """json_contains works for nested JSON sub-objects."""
+        nested = {
             "type": "FeatureCollection",
             "features": [
                 {
                     "type": "Feature",
                     "geometry": {"type": "Point", "coordinates": [106.45, -6.36]},
-                    "properties": {"category": "landmark"}
+                    "properties": {"category": "landmark"},
                 }
-            ]
+            ],
         }
+        rec = self._create('Nested', nested)
+        ids = [rec.id]
 
-        record = self.test_model.create({
-            'gshape_name': 'Nested Structure',
-            'gshape_geojson': nested_geojson,
-        })
+        results = self._search(
+            ids,
+            ('gshape_geojson', 'json_contains', {'features': [{'properties': {'category': 'landmark'}}]}),
+        )
 
-        results = self.test_model.search([
-            ('gshape_geojson', 'json_contains', {
-                'features': [{'properties': {'category': 'landmark'}}]
-            })
-        ])
+        self.assertIn(rec, results)
 
-        self.assertIn(record, results)
+    # -------------------------------------------------------------------------
+    # Multi-record filtering
+    # -------------------------------------------------------------------------
 
-    def test_json_ne_operator(self):
-        """Test json_ne (not equal) operator."""
-        point1 = self.test_model.create({
-            'gshape_name': 'Point 1',
-            'gshape_geojson': {"type": "Point", "coordinates": [0, 0]},
-        })
+    def test_multiple_records_filtered_by_type(self):
+        """Each json_contains query returns only the records with the matching type."""
+        point_rec = self._create('Point', POINT)
+        polygon_rec = self._create('Polygon', POLYGON)
+        collection_rec = self._create('Collection', FEATURE_COLLECTION_EMPTY)
+        ids = [point_rec.id, polygon_rec.id, collection_rec.id]
 
-        point2 = self.test_model.create({
-            'gshape_name': 'Point 2',
-            'gshape_geojson': {"type": "Point", "coordinates": [1, 1]},
-        })
+        point_results = self._search(ids, ('gshape_geojson', 'json_contains', {'type': 'Point'}))
+        self.assertEqual(point_results, point_rec)
 
-        results = self.test_model.search([
-            ('gshape_geojson', 'json_ne', {"type": "Point", "coordinates": [0, 0]})
-        ])
+        polygon_results = self._search(ids, ('gshape_geojson', 'json_contains', {'type': 'Polygon'}))
+        self.assertEqual(polygon_results, polygon_rec)
 
-        self.assertNotIn(point1, results)
-        self.assertIn(point2, results)
+        collection_results = self._search(ids, ('gshape_geojson', 'json_contains', {'type': 'FeatureCollection'}))
+        self.assertEqual(collection_results, collection_rec)

--- a/web_view_google_map_drawing/models/fields.py
+++ b/web_view_google_map_drawing/models/fields.py
@@ -1,271 +1,158 @@
 """
-Custom JSON field with advanced search capabilities for Google Map Drawing module.
+Custom JSON field with advanced search capabilities for Mapbox GL Drawing module.
 
-This module extends Odoo's standard JSON field to support GeoJSON-specific
-search operations using PostgreSQL's JSONB operators. It provides custom
-domain operators for efficient JSON field querying in the web_view_google_map_drawing module.
+Extends Odoo's standard JSON field with GeoJSON-specific domain operators backed
+by PostgreSQL JSONB operators. NULL handling: Python False/None maps to SQL NULL.
+
+Supported operators:
+    json_eq / json_ne           -- exact JSONB equality / inequality
+    json_contains               -- field @> value  (field contains sub-object)
+    json_not_contains           -- NOT (field @> value)
 """
 import json
 
-from odoo import _, fields
+from odoo import fields
 from odoo.tools import SQL
 from odoo.orm.domains import CONDITION_OPERATORS, operator_optimization, DomainCondition
 from odoo.tools.misc import OrderedSet
 
-# Register new operators for JSON field searching
 CONDITION_OPERATORS.update(['json_eq', 'json_ne', 'json_contains', 'json_not_contains'])
 
 
+# ---------------------------------------------------------------------------
+# Wrapper types — make JSON values hashable for Odoo's OrderedSet optimizer
+# ---------------------------------------------------------------------------
+
+class _JsonWrappedValue:
+    """Base for JSON value wrappers that need to participate in domain optimization."""
+
+    __slots__ = ('value', '_hash')
+
+    def __init__(self, value):
+        self.value = value
+        try:
+            self._hash = hash(json.dumps(value, sort_keys=True, separators=(',', ':')))
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"Cannot create {type(self).__name__} from non-serializable value: {e}"
+            ) from e
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.value == other.value
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.value!r})"
+
+
+class JsonValue(_JsonWrappedValue):
+    """Wraps a value for json_eq / json_ne (exact JSONB equality)."""
+    __slots__ = ()
+
+
+class JsonContainsValue(_JsonWrappedValue):
+    """Wraps a value for json_contains / json_not_contains (JSONB @> operator)."""
+    __slots__ = ()
+
+
+# ---------------------------------------------------------------------------
+# Field
+# ---------------------------------------------------------------------------
+
 class SearchableJson(fields.Json):
     """
-    Extended JSON Field with advanced search capabilities for GeoJSON data.
+    JSON field that supports custom GeoJSON domain operators.
 
-    This field extends Odoo's standard JSON field to support custom operators
-    optimized for PostgreSQL JSONB columns, enabling efficient querying of
-    complex JSON structures like GeoJSON geometries.
-
-    Supported custom operators:
-        - json_eq: Exact JSON equality comparison (converted to 'in' operator)
-        - json_ne: JSON inequality comparison (converted to 'not in' operator)
-        - json_contains: Check if JSON field contains a sub-object (uses PostgreSQL @>)
-        - json_not_contains: Check if JSON field does NOT contain a sub-object
-
-    These operators are automatically optimized through Odoo's domain optimization
-    system, allowing multiple conditions to be combined efficiently.
-
-    Example usage in domain:
-        [('geojson', 'json_eq', {'type': 'Point'})]
-        [('geojson', 'json_contains', {'geometry': {'type': 'Polygon'}})]
+    See module docstring for supported operators and NULL handling.
     """
 
-    def _condition_to_sql(self, field_expr: str, operator: str, value, model, alias: str, query) -> SQL:
-        """Convert domain conditions to SQL for JSON fields"""
+    def _condition_to_sql(
+        self, field_expr: str, operator: str, value, model, alias: str, query
+    ) -> SQL:
         sql_field = model._field_to_sql(alias, field_expr, query)
 
-        # Handle the 'in'/'not in' operators that come from optimization
         if operator in ('in', 'not in'):
-            conditions = []
-            for v in value:
-                if getattr(v, '_json_contains_marker', False):
-                    # This is a containment check - use PostgreSQL @> operator
-                    original_value = v.value
-                    try:
-                        json_value = json.dumps(original_value)
-                    except (TypeError, ValueError) as e:
-                        raise ValueError(
-                            _("Cannot serialize JSON value for containment check: %s") % e
-                        ) from e
+            return self._build_json_in_sql(sql_field, operator, value)
 
-                    if operator == 'in':
-                        # json_contains: field contains the value
-                        conditions.append(SQL("%s @> %s::jsonb", sql_field, json_value))
-                    else:
-                        # json_not_contains: include NULL rows (NULL @> value = NULL, not FALSE)
-                        conditions.append(SQL("(%s IS NULL OR NOT (%s @> %s::jsonb))", sql_field, sql_field, json_value))
-                elif getattr(v, '_json_marker', False):
-                    # This is a JSON equality check
-                    original_value = v.value
-                    # Use compact JSON with sorted keys for consistent comparison
-                    # separators=(',', ':') removes whitespace for stable string matching
-                    try:
-                        json_value = json.dumps(original_value, sort_keys=True, separators=(',', ':'))
-                    except (TypeError, ValueError) as e:
-                        raise ValueError(
-                            _("Cannot serialize JSON value for comparison: %s") % e
-                        ) from e
-
-                    if operator == 'in':
-                        conditions.append(SQL("%s = %s", sql_field, json_value))
-                    else:
-                        # Use OR with IS NULL to handle null fields correctly
-                        conditions.append(SQL("(%s IS NULL OR %s != %s)", sql_field, sql_field, json_value))
-                else:
-                    # Regular value (not wrapped)
-                    try:
-                        json_str = json.dumps(v)
-                    except (TypeError, ValueError) as e:
-                        raise ValueError(
-                            _("Cannot serialize value for comparison: %s") % e
-                        ) from e
-
-                    if operator == 'in':
-                        conditions.append(SQL("%s = %s", sql_field, json_str))
-                    else:
-                        # Use IS NULL to include NULL fields in 'not equal' results
-                        conditions.append(SQL("(%s IS NULL OR %s != %s)", sql_field, sql_field, json_str))
-
-            if not conditions:
-                return SQL("FALSE") if operator == 'in' else SQL("TRUE")
-
-            if operator == 'in':
-                return SQL("(%s)", SQL(" OR ".join(["%s"] * len(conditions)), *conditions))
-            else:
-                return SQL("(%s)", SQL(" AND ".join(["%s"] * len(conditions)), *conditions))
-
-        # Guard: custom operators must always be optimized to 'in'/'not in' before reaching
-        # this method. If one arrives here it means it was applied to a non-SearchableJson field.
+        # Custom operators must be optimized to in/not in before reaching here.
         if operator in ('json_eq', 'json_ne', 'json_contains', 'json_not_contains'):
             raise ValueError(
-                _("Operator '%s' is only supported on SearchableJson fields.") % operator
+                f"Operator '{operator}' is only supported on SearchableJson fields."
             )
+
         return super()._condition_to_sql(field_expr, operator, value, model, alias, query)
 
+    def _build_json_in_sql(self, sql_field: SQL, operator: str, values) -> SQL:
+        conditions = [self._single_value_to_sql(sql_field, operator, v) for v in values]
 
-# Wrapper class for JSON values to make them hashable
-class JsonValue:
-    """
-    Wrapper class to make JSON values hashable for domain optimization.
+        if not conditions:
+            return SQL("FALSE") if operator == 'in' else SQL("TRUE")
 
-    Odoo's domain optimization uses sets (OrderedSet) to collect values for 'in'/'not in'
-    operators. Since JSON objects (dicts/lists) are not hashable in Python, this wrapper
-    provides the necessary __hash__ and __eq__ methods to enable set operations.
+        joiner = " OR " if operator == 'in' else " AND "
+        return SQL("(%s)", SQL(joiner.join(["%s"] * len(conditions)), *conditions))
 
-    The hash is computed from a stable JSON string representation with sorted keys
-    and compact formatting to ensure that structurally identical JSON values produce
-    the same hash, regardless of key ordering or whitespace.
+    def _single_value_to_sql(self, sql_field: SQL, operator: str, v) -> SQL:
+        if isinstance(v, JsonContainsValue):
+            return self._containment_sql(sql_field, operator, v.value)
+        if isinstance(v, JsonValue):
+            return self._equality_sql(sql_field, operator, v.value)
 
-    Attributes:
-        value: The original JSON-serializable Python value (dict, list, etc.)
-        _json_marker (bool): Marker attribute to identify wrapped values in SQL generation
-        _hash (int): Pre-computed hash value for performance
+        # Plain value from standard Odoo operators (e.g. != False → not in [False])
+        if v is False or v is None:
+            return (
+                SQL("%s IS NULL", sql_field)
+                if operator == 'in'
+                else SQL("%s IS NOT NULL", sql_field)
+            )
 
-    Example:
-        >>> v1 = JsonValue({"type": "Point", "coordinates": [0, 0]})
-        >>> v2 = JsonValue({"coordinates": [0, 0], "type": "Point"})
-        >>> v1 == v2  # True - same structure despite different key order
-        >>> hash(v1) == hash(v2)  # True - same hash
-        >>> {v1, v2}  # {JsonValue(...)} - only one element in set
-    """
-    def __init__(self, value):
-        self.value = value
-        self._json_marker = True
-        # Use compact JSON representation with sorted keys for stable hashing
+        return self._equality_sql(sql_field, operator, v)
+
+    def _equality_sql(self, sql_field: SQL, operator: str, value) -> SQL:
+        """Generate SQL for exact JSONB equality using ::jsonb cast on both sides."""
         try:
-            self._hash = hash(json.dumps(value, sort_keys=True, separators=(',', ':')))
+            json_str = json.dumps(value, sort_keys=True, separators=(',', ':'))
         except (TypeError, ValueError) as e:
             raise ValueError(
-                _("Cannot create JsonValue from non-serializable value: %s") % e
+                f"Cannot serialize JSON value for comparison: {e}"
             ) from e
 
-    def __hash__(self):
-        return self._hash
+        if operator == 'in':
+            return SQL("%s::jsonb = %s::jsonb", sql_field, json_str)
+        # Include NULL rows in != results (NULL != anything is NULL, not TRUE)
+        return SQL("(%s IS NULL OR %s::jsonb != %s::jsonb)", sql_field, sql_field, json_str)
 
-    def __eq__(self, other):
-        if not isinstance(other, JsonValue):
-            return False
-        return self.value == other.value
-
-    def __repr__(self):
-        return f"JsonValue({self.value!r})"
-
-
-class JsonContainsValue:
-    """
-    Wrapper class for JSON containment check values.
-
-    This wrapper marks values that should be used with PostgreSQL's @> (contains)
-    operator instead of exact equality. It's used to pass containment check values
-    through the domain optimization system.
-
-    Attributes:
-        value: The JSON value to check for containment
-        _json_contains_marker (bool): Marker to identify this as a containment check
-        _hash (int): Pre-computed hash value for performance
-    """
-    def __init__(self, value):
-        self.value = value
-        self._json_contains_marker = True
+    def _containment_sql(self, sql_field: SQL, operator: str, value) -> SQL:
+        """Generate SQL for JSONB @> containment check."""
         try:
-            self._hash = hash(json.dumps(value, sort_keys=True, separators=(',', ':')))
+            json_str = json.dumps(value)
         except (TypeError, ValueError) as e:
             raise ValueError(
-                _("Cannot create JsonContainsValue from non-serializable value: %s") % e
+                f"Cannot serialize JSON value for containment check: {e}"
             ) from e
 
-    def __hash__(self):
-        return self._hash
-
-    def __eq__(self, other):
-        if not isinstance(other, JsonContainsValue):
-            return False
-        return self.value == other.value
-
-    def __repr__(self):
-        return f"JsonContainsValue({self.value!r})"
+        if operator == 'in':
+            return SQL("%s @> %s::jsonb", sql_field, json_str)
+        # NULL @> value = NULL (not FALSE) — include NULL rows in NOT-contains results
+        return SQL("(%s IS NULL OR NOT (%s @> %s::jsonb))", sql_field, sql_field, json_str)
 
 
-# Convert our custom operators to standard 'in'/'not in' with wrapped values
+# ---------------------------------------------------------------------------
+# Domain optimizations — rewrite custom operators to in/not in with wrapped values
+# ---------------------------------------------------------------------------
+
 @operator_optimization(['json_eq', 'json_ne'])
 def _json_equal_optimization(condition, model):
-    """
-    Optimize json_eq/json_ne operators to standard in/not in operators.
+    operator = 'in' if condition.operator == 'json_eq' else 'not in'
+    return DomainCondition(
+        condition.field_expr, operator, OrderedSet([JsonValue(condition.value)])
+    )
 
-    This optimization function is called by Odoo's domain optimizer to transform
-    custom JSON equality operators into standard 'in'/'not in' operators. This
-    allows multiple json_eq conditions to be combined into a single SQL IN clause.
-
-    The transformation wraps JSON values in JsonValue objects to make them hashable,
-    enabling Odoo's optimizer to collect multiple values into OrderedSets for
-    efficient SQL generation.
-
-    Transformations:
-        [('geojson', 'json_eq', {...})]  ->  [('geojson', 'in', [JsonValue({...})])]
-        [('geojson', 'json_ne', {...})]  ->  [('geojson', 'not in', [JsonValue({...})])]
-
-    Multiple conditions are automatically combined by Odoo:
-        [('geojson', 'json_eq', val1), ('geojson', 'json_eq', val2)]
-        -> [('geojson', 'in', [JsonValue(val1), JsonValue(val2)])]
-
-    Args:
-        condition (DomainCondition): Domain condition with json_eq or json_ne operator
-        model: Odoo model class (unused but required by decorator signature)
-
-    Returns:
-        DomainCondition: New condition with 'in' or 'not in' operator and wrapped value
-    """
-    if condition.operator == 'json_eq':
-        operator = 'in'
-    else:  # json_ne
-        operator = 'not in'
-
-    # Wrap the value to make it hashable for OrderedSet operations
-    wrapped_value = JsonValue(condition.value)
-    value = OrderedSet([wrapped_value])
-
-    return DomainCondition(condition.field_expr, operator, value)
 
 @operator_optimization(['json_contains', 'json_not_contains'])
 def _json_contains_optimization(condition, model):
-    """
-    Optimize json_contains/json_not_contains to standard in/not in operators.
-
-    This optimization function transforms JSON containment operators into standard
-    'in'/'not in' operators with wrapped values. The wrapping allows _condition_to_sql
-    to detect containment checks and generate the appropriate PostgreSQL @> operator.
-
-    Transformations:
-        [('geojson', 'json_contains', {'type': 'Point'})]
-        -> [('geojson', 'in', [JsonContainsValue({'type': 'Point'})])]
-        -> SQL: geojson @> '{"type":"Point"}'::jsonb
-
-        [('geojson', 'json_not_contains', {'type': 'Point'})]
-        -> [('geojson', 'not in', [JsonContainsValue({'type': 'Point'})])]
-        -> SQL: NOT (geojson @> '{"type":"Point"}'::jsonb)
-
-    Args:
-        condition (DomainCondition): Domain condition with json_contains or json_not_contains
-        model: Odoo model class (unused but required by decorator signature)
-
-    Returns:
-        DomainCondition: Condition with 'in' or 'not in' operator and wrapped value
-    """
-    if condition.operator == 'json_contains':
-        operator = 'in'
-    else:  # json_not_contains
-        operator = 'not in'
-
-    # Wrap the value to mark it as a containment check
-    wrapped_value = JsonContainsValue(condition.value)
-    value = OrderedSet([wrapped_value])
-
-    return DomainCondition(condition.field_expr, operator, value)
+    operator = 'in' if condition.operator == 'json_contains' else 'not in'
+    return DomainCondition(
+        condition.field_expr, operator, OrderedSet([JsonContainsValue(condition.value)])
+    )

--- a/web_view_google_map_drawing/models/fields.py
+++ b/web_view_google_map_drawing/models/fields.py
@@ -1,5 +1,5 @@
 """
-Custom JSON field with advanced search capabilities for Mapbox GL Drawing module.
+Custom JSON field with advanced search capabilities for Google Maps Drawing module.
 
 Extends Odoo's standard JSON field with GeoJSON-specific domain operators backed
 by PostgreSQL JSONB operators. NULL handling: Python False/None maps to SQL NULL.

--- a/web_view_google_map_drawing/tests/test_field_json_searchable.py
+++ b/web_view_google_map_drawing/tests/test_field_json_searchable.py
@@ -40,7 +40,7 @@ class TestJsonValue(TransactionCase):
         json_val = JsonValue(value)
 
         self.assertEqual(json_val.value, value)
-        self.assertTrue(json_val._json_marker)
+        self.assertIsInstance(json_val, JsonValue)
         self.assertIsInstance(json_val._hash, int)
 
     def test_json_value_hash_consistency(self):
@@ -127,7 +127,7 @@ class TestJsonContainsValue(TransactionCase):
         json_val = JsonContainsValue(value)
 
         self.assertEqual(json_val.value, value)
-        self.assertTrue(json_val._json_contains_marker)
+        self.assertIsInstance(json_val, JsonContainsValue)
         self.assertIsInstance(json_val._hash, int)
 
     def test_json_contains_value_hash_consistency(self):
@@ -254,8 +254,9 @@ class TestSearchableJsonField(TransactionCase):
 
         self.assertIsInstance(result, SQL)
         sql_str = str(result)
-        # Should include IS NULL check for 'not in'
         self.assertIn('test_table.geojson', sql_str)
+        # NULL rows must be included in negation results (NULL != value = NULL, not TRUE)
+        self.assertIn('IS NULL', sql_str)
 
     def test_json_contains_sql_generation(self):
         """Test SQL generation for 'in' operator with JsonContainsValue wrapper."""
@@ -285,6 +286,21 @@ class TestSearchableJsonField(TransactionCase):
         self.assertIn('NOT', sql_str)
         self.assertIn('@>', sql_str)
         self.assertIn('::jsonb', sql_str)
+        # NULL rows must be included: NULL @> value = NULL, not FALSE
+        self.assertIn('IS NULL', sql_str)
+
+    def test_regular_value_not_in_includes_null_check(self):
+        """Test that 'not in' with a plain (non-wrapped) value generates an IS NULL guard."""
+        values = OrderedSet(['test_string'])
+
+        result = self.field._condition_to_sql(
+            'geojson', 'not in', values, self.mock_model, 'test_table', self.mock_query
+        )
+
+        self.assertIsInstance(result, SQL)
+        sql_str = str(result)
+        # NULL rows must be included: NULL != value = NULL, not TRUE
+        self.assertIn('IS NULL', sql_str)
 
     def test_empty_in_operator_returns_false(self):
         """Test that empty 'in' operator returns SQL FALSE."""
@@ -427,3 +443,20 @@ class TestEdgeCases(TransactionCase):
 
         json_val = JsonValue(bool_data)
         self.assertEqual(json_val.value, bool_data)
+
+    def test_misapplied_custom_operator_raises_error(self):
+        """Test that custom operators raise ValueError when they bypass optimization."""
+        field = SearchableJson()
+        mock_model = Mock()
+        mock_model._field_to_sql = Mock(return_value=SQL("test_table.geojson"))
+        mock_query = Mock()
+
+        for operator in ('json_eq', 'json_ne', 'json_contains', 'json_not_contains'):
+            with self.assertRaises(ValueError) as context:
+                field._condition_to_sql(
+                    'geojson', operator, 'value', mock_model, 'test_table', mock_query
+                )
+            self.assertIn(
+                'only supported on SearchableJson fields',
+                str(context.exception),
+            )


### PR DESCRIPTION
- Introduce _JsonWrappedValue base class shared by JsonValue and JsonContainsValue, removing ~40 lines of duplicated code
- Split _condition_to_sql into four focused methods: _build_json_in_sql, _single_value_to_sql, _equality_sql, and _containment_sql
- Fix False/None in not in to emit IS NULL/IS NOT NULL directly instead of json.dumps, which produced JSON literals and missed actual SQL NULL rows
- Fix _equality_sql to cast both sides to ::jsonb instead of bare equality
- Re-introduce isinstance dispatch over getattr marker duck-typing
- Rewrite integration tests with _search(ids) helper to scope queries to test-created records and prevent flaky results from pre-existing rows
- Add NULL operator coverage in both unit and integration test suites