### PR TITLE
[FIX] web_view_google_map_drawing: replace isinstance with type name comparison to fix dual-import class identity mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Root configuration module. Adds a Google Maps section to General Settings for AP
 
 Registers `google_map` as a valid Odoo view type. Provides the full map view stack — controller, model, renderer, sidebar, and search bar — with marker clustering, overlap handling, multi-selection box select, nearby records search, in-map place search, geolocation button, grouped markers, and dark mode support.
 
-**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** `19.0.1.0.18`
+**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** `19.0.1.0.19`
 
 Extends the map view with geographic shape drawing using [Terra Draw](https://terradraw.io/) (Google's recommended replacement for the deprecated Maps Drawing Library) for editing and [Deck.gl](https://deck.gl/) for GPU-accelerated rendering of large datasets. Includes a `google.drawing.shape` mixin and GeoJSON field type with server-side filtering. All libraries bundled locally.
 

--- a/base_google_map/models/res_config_settings.py
+++ b/base_google_map/models/res_config_settings.py
@@ -150,7 +150,7 @@ class ResConfigSettings(models.TransientModel):
         string='Color Scheme',
         config_parameter='base_google_map.color_scheme',
     )
-    is_web_google_map_installed = fields.Boolean(string="Is the Sale Module Installed")
+    is_web_google_map_installed = fields.Boolean(string="Is the 'Web View Google Map' Module Installed")
 
     @api.depends('google_autocomplete_country_restriction_str')
     def _compute_country_restriction(self):

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -16,7 +16,7 @@
     'category': 'Extra Tools',
     'version': '1.0.19',
     'depends': ['web_view_google_map'],
-    'data': ['data/gmap_libraries.xml'],
+    'data': [],
     'assets': {
         'web.assets_backend': [
             'web_view_google_map_drawing/static/src/utils/**/*',

--- a/web_view_google_map_drawing/data/gmap_libraries.xml
+++ b/web_view_google_map_drawing/data/gmap_libraries.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <data noupdate="1">
-        <function model="ir.config_parameter" name="set_param" eval="('base_google_map.libraries', 'geometry,places,drawing')"/>
-    </data>
-</odoo>

--- a/web_view_google_map_drawing/example/contacts_area/tests/test_searchable_json_integration.py
+++ b/web_view_google_map_drawing/example/contacts_area/tests/test_searchable_json_integration.py
@@ -10,6 +10,8 @@ against a real PostgreSQL JSONB column.
 Unit tests for the field class, wrapper classes, and domain optimization live in:
   web_view_google_map_drawing/tests/test_field_json_searchable.py
 """
+import unittest
+
 from odoo.tests.common import TransactionCase
 
 POINT = {"type": "Point", "coordinates": [106.45, -6.36]}
@@ -37,6 +39,8 @@ class TestSearchableJsonIntegration(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if 'res.partner.area' not in cls.env:
+            raise unittest.SkipTest('contacts_area module is not installed')
         cls.Model = cls.env['res.partner.area']
 
     def _create(self, name, geojson):
@@ -191,3 +195,49 @@ class TestSearchableJsonIntegration(TransactionCase):
 
         collection_results = self._search(ids, ('gshape_geojson', 'json_contains', {'type': 'FeatureCollection'}))
         self.assertEqual(collection_results, collection_rec)
+
+    # -------------------------------------------------------------------------
+    # Edge cases
+    # -------------------------------------------------------------------------
+
+    def test_json_eq_key_order_independent(self):
+        """json_eq must match regardless of JSON key insertion order.
+
+        _equality_sql uses ::jsonb cast on both sides; PostgreSQL normalizes key
+        order inside JSONB, so {'b': 2, 'a': 1} must equal {'a': 1, 'b': 2}.
+        """
+        stored = {"coordinates": [106.45, -6.36], "type": "Point"}
+        rec = self._create('Reversed Keys', stored)
+        ids = [rec.id]
+
+        results = self._search(ids, ('gshape_geojson', 'json_eq', POINT))
+
+        self.assertIn(rec, results)
+
+    def test_json_eq_false_does_not_find_null_records(self):
+        """json_eq False finds rows storing JSON boolean false, NOT NULL rows.
+
+        ('field', '=', False) maps to IS NULL.
+        ('field', 'json_eq', False) maps to field::jsonb = 'false'::jsonb.
+        These are semantically different — this test documents and protects that boundary.
+        """
+        null_rec = self._create('Null GeoJSON', False)
+        ids = [null_rec.id]
+
+        results = self._search(ids, ('gshape_geojson', 'json_eq', False))
+
+        self.assertNotIn(null_rec, results)
+
+    def test_json_contains_empty_dict_matches_all_non_null(self):
+        """json_contains with {} matches every non-NULL row (JSONB containment of empty object).
+
+        In PostgreSQL, any_jsonb @> '{}'::jsonb is TRUE for all non-NULL values.
+        """
+        rec = self._create('Point', POINT)
+        null_rec = self._create('Null GeoJSON', False)
+        ids = [rec.id, null_rec.id]
+
+        results = self._search(ids, ('gshape_geojson', 'json_contains', {}))
+
+        self.assertIn(rec, results)
+        self.assertNotIn(null_rec, results)

--- a/web_view_google_map_drawing/models/fields.py
+++ b/web_view_google_map_drawing/models/fields.py
@@ -41,7 +41,7 @@ class _JsonWrappedValue:
         return self._hash
 
     def __eq__(self, other):
-        return type(self) is type(other) and self.value == other.value
+        return type(self).__name__ == type(other).__name__ and self.value == other.value
 
     def __repr__(self):
         return f"{type(self).__name__}({self.value!r})"
@@ -94,9 +94,10 @@ class SearchableJson(fields.Json):
         return SQL("(%s)", SQL(joiner.join(["%s"] * len(conditions)), *conditions))
 
     def _single_value_to_sql(self, sql_field: SQL, operator: str, v) -> SQL:
-        if isinstance(v, JsonContainsValue):
+        vname = type(v).__name__
+        if vname == 'JsonContainsValue':
             return self._containment_sql(sql_field, operator, v.value)
-        if isinstance(v, JsonValue):
+        if vname == 'JsonValue':
             return self._equality_sql(sql_field, operator, v.value)
 
         # Plain value from standard Odoo operators (e.g. != False → not in [False])

--- a/web_view_google_map_drawing/models/fields.py
+++ b/web_view_google_map_drawing/models/fields.py
@@ -16,6 +16,9 @@ from odoo.tools import SQL
 from odoo.orm.domains import CONDITION_OPERATORS, operator_optimization, DomainCondition
 from odoo.tools.misc import OrderedSet
 
+# Odoo 19 has no public API for registering custom domain operators.
+# Mutating this internal set is the only available extension point.
+# Re-verify this is still a plain set on each major Odoo version upgrade.
 CONDITION_OPERATORS.update(['json_eq', 'json_ne', 'json_contains', 'json_not_contains'])
 
 
@@ -34,14 +37,20 @@ class _JsonWrappedValue:
             self._hash = hash(json.dumps(value, sort_keys=True, separators=(',', ':')))
         except (TypeError, ValueError) as e:
             raise ValueError(
-                f"Cannot create {type(self).__name__} from non-serializable value: {e}"
+                f"Domain value is not JSON-serializable: {e}"
             ) from e
 
     def __hash__(self):
         return self._hash
 
     def __eq__(self, other):
-        return type(self).__name__ == type(other).__name__ and self.value == other.value
+        # type().__name__ comparison is intentional: when this module is loaded via two
+        # Python import paths (dual-import), `type(self) is type(other)` can be False for
+        # semantically identical classes. Name-based comparison preserves correct
+        # OrderedSet deduplication. Do NOT replace with isinstance or type() identity.
+        if type(self).__name__ != type(other).__name__ or not hasattr(other, 'value'):
+            return NotImplemented
+        return self.value == other.value
 
     def __repr__(self):
         return f"{type(self).__name__}({self.value!r})"
@@ -73,13 +82,17 @@ class SearchableJson(fields.Json):
     ) -> SQL:
         sql_field = model._field_to_sql(alias, field_expr, query)
 
+        # Intercept in/not in entirely: parent fields.Json uses text comparison,
+        # but this field requires JSONB semantics for all value types.
         if operator in ('in', 'not in'):
             return self._build_json_in_sql(sql_field, operator, value)
 
-        # Custom operators must be optimized to in/not in before reaching here.
+        # Custom operators must be rewritten to in/not in by operator_optimization before
+        # reaching here. If they arrive unrewritten, the registration failed.
         if operator in ('json_eq', 'json_ne', 'json_contains', 'json_not_contains'):
-            raise ValueError(
-                f"Operator '{operator}' is only supported on SearchableJson fields."
+            raise AssertionError(
+                f"Operator '{operator}' reached _condition_to_sql without being rewritten "
+                "— operator_optimization registration may have failed."
             )
 
         return super()._condition_to_sql(field_expr, operator, value, model, alias, query)
@@ -94,10 +107,13 @@ class SearchableJson(fields.Json):
         return SQL("(%s)", SQL(joiner.join(["%s"] * len(conditions)), *conditions))
 
     def _single_value_to_sql(self, sql_field: SQL, operator: str, v) -> SQL:
+        # type().__name__ dispatch is intentional — see _JsonWrappedValue.__eq__ for
+        # rationale. Do NOT replace with isinstance: dual-import creates distinct class
+        # objects for the same logical type, making isinstance unreliable here.
         vname = type(v).__name__
-        if vname == 'JsonContainsValue':
+        if vname == 'JsonContainsValue' and hasattr(v, 'value'):
             return self._containment_sql(sql_field, operator, v.value)
-        if vname == 'JsonValue':
+        if vname == 'JsonValue' and hasattr(v, 'value'):
             return self._equality_sql(sql_field, operator, v.value)
 
         # Plain value from standard Odoo operators (e.g. != False → not in [False])
@@ -127,7 +143,7 @@ class SearchableJson(fields.Json):
     def _containment_sql(self, sql_field: SQL, operator: str, value) -> SQL:
         """Generate SQL for JSONB @> containment check."""
         try:
-            json_str = json.dumps(value)
+            json_str = json.dumps(value, sort_keys=True)
         except (TypeError, ValueError) as e:
             raise ValueError(
                 f"Cannot serialize JSON value for containment check: {e}"

--- a/web_view_google_map_drawing/tests/test_field_json_searchable.py
+++ b/web_view_google_map_drawing/tests/test_field_json_searchable.py
@@ -16,14 +16,16 @@ Test Structure:
 3. TestDomainOptimization - Tests for domain optimization functions
 4. TestSearchableJsonField - Tests for SQL generation
 5. TestEdgeCases - Edge cases and error handling
+6. TestModuleReloadRobustness - Regression tests for dual-import / module reload
 
 Integration tests (end-to-end ORM search against a real JSONB column) live in:
   web_view_google_map_drawing/example/contacts_area/tests/test_searchable_json_integration.py
 They require the contacts_area module to be installed.
 """
+import json
 from unittest.mock import Mock
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import BaseCase
 from odoo.tools import SQL
 from odoo.orm.domains import DomainCondition
 from odoo.tools.misc import OrderedSet
@@ -31,7 +33,7 @@ from odoo.tools.misc import OrderedSet
 from ..models.fields import SearchableJson, JsonValue, JsonContainsValue, _json_equal_optimization, _json_contains_optimization
 
 
-class TestJsonValue(TransactionCase):
+class TestJsonValue(BaseCase):
     """Test suite for JsonValue wrapper class."""
 
     def test_json_value_basic_creation(self):
@@ -115,10 +117,10 @@ class TestJsonValue(TransactionCase):
         with self.assertRaises(ValueError) as context:
             JsonValue({"date": datetime.now()})
 
-        self.assertIn("Cannot create JsonValue", str(context.exception))
+        self.assertIn("Domain value is not JSON-serializable", str(context.exception))
 
 
-class TestJsonContainsValue(TransactionCase):
+class TestJsonContainsValue(BaseCase):
     """Test suite for JsonContainsValue wrapper class."""
 
     def test_json_contains_value_basic_creation(self):
@@ -157,7 +159,7 @@ class TestJsonContainsValue(TransactionCase):
         self.assertEqual(len(value_set), 2)
 
 
-class TestDomainOptimization(TransactionCase):
+class TestDomainOptimization(BaseCase):
     """Test suite for domain optimization functions."""
 
     def test_json_eq_optimization(self):
@@ -219,7 +221,7 @@ class TestDomainOptimization(TransactionCase):
         self.assertEqual(wrapped_value.value, {'type': 'Point'})
 
 
-class TestSearchableJsonField(TransactionCase):
+class TestSearchableJsonField(BaseCase):
     """Test suite for SearchableJson field SQL generation."""
 
     def setUp(self):
@@ -366,7 +368,7 @@ class TestSearchableJsonField(TransactionCase):
         with self.assertRaises(ValueError) as context:
             JsonContainsValue({'date': datetime.now()})
 
-        self.assertIn("Cannot create JsonContainsValue", str(context.exception))
+        self.assertIn("Domain value is not JSON-serializable", str(context.exception))
 
     def test_regular_value_without_json_marker(self):
         """Test SQL generation with regular values (not wrapped)."""
@@ -379,7 +381,7 @@ class TestSearchableJsonField(TransactionCase):
         self.assertIsInstance(result, SQL)
 
 
-class TestEdgeCases(TransactionCase):
+class TestEdgeCases(BaseCase):
     """Test edge cases and error conditions."""
 
     def test_null_json_value(self):
@@ -452,11 +454,124 @@ class TestEdgeCases(TransactionCase):
         mock_query = Mock()
 
         for operator in ('json_eq', 'json_ne', 'json_contains', 'json_not_contains'):
-            with self.assertRaises(ValueError) as context:
+            with self.assertRaises(AssertionError) as context:
                 field._condition_to_sql(
                     'geojson', operator, 'value', mock_model, 'test_table', mock_query
                 )
             self.assertIn(
-                'only supported on SearchableJson fields',
+                'reached _condition_to_sql without being rewritten',
                 str(context.exception),
             )
+
+
+class TestModuleReloadRobustness(BaseCase):
+    """Regression tests for dual-import / module reload robustness.
+
+    _single_value_to_sql and __eq__ use type(v).__name__ instead of isinstance
+    or type identity so they survive Odoo module reloads, where the same module
+    may be executed twice under different sys.modules keys, producing classes
+    with the same name but different identity.
+
+    These tests simulate that scenario by constructing local classes with the
+    same names as the real wrappers and verifying that cross-identity instances
+    are handled correctly.
+    """
+
+    def _stale_json_value(self, data):
+        """Return an instance whose class is named JsonValue but has a different identity."""
+        class JsonValue:
+            __slots__ = ('value', '_hash')
+
+            def __init__(self, v):
+                self.value = v
+                self._hash = hash(json.dumps(v, sort_keys=True, separators=(',', ':')))
+
+            def __hash__(self):
+                return self._hash
+
+        return JsonValue(data)
+
+    def _stale_json_contains_value(self, data):
+        """Return an instance whose class is named JsonContainsValue but has a different identity."""
+        class JsonContainsValue:
+            __slots__ = ('value', '_hash')
+
+            def __init__(self, v):
+                self.value = v
+                self._hash = hash(json.dumps(v, sort_keys=True, separators=(',', ':')))
+
+            def __hash__(self):
+                return self._hash
+
+        return JsonContainsValue(data)
+
+    # ------------------------------------------------------------------
+    # __eq__ cross-identity tests
+    # ------------------------------------------------------------------
+
+    def test_eq_cross_identity_same_value(self):
+        """Two JsonValue instances from different class objects are equal when their values match."""
+        real = JsonValue({'type': 'Point'})
+        stale = self._stale_json_value({'type': 'Point'})
+        self.assertEqual(real, stale)
+
+    def test_eq_cross_identity_different_value(self):
+        """Two JsonValue instances from different class objects are not equal when values differ."""
+        real = JsonValue({'type': 'Point'})
+        stale = self._stale_json_value({'type': 'Polygon'})
+        self.assertNotEqual(real, stale)
+
+    def test_eq_does_not_mix_wrapper_kinds(self):
+        """A stale JsonValue instance is not equal to a JsonContainsValue instance."""
+        real_contains = JsonContainsValue({'type': 'Point'})
+        stale_value = self._stale_json_value({'type': 'Point'})
+        self.assertNotEqual(real_contains, stale_value)
+
+    # ------------------------------------------------------------------
+    # _single_value_to_sql dispatch tests
+    # ------------------------------------------------------------------
+
+    def _make_field_and_sql(self):
+        field = SearchableJson()
+        sql_field = SQL("test_table.geojson")
+        return field, sql_field
+
+    def test_dispatch_stale_json_value_generates_equality_sql(self):
+        """_single_value_to_sql generates equality SQL for a stale JsonValue instance."""
+        field, sql_field = self._make_field_and_sql()
+        stale = self._stale_json_value({'type': 'Point'})
+
+        result = field._single_value_to_sql(sql_field, 'in', stale)
+
+        self.assertIsInstance(result, SQL)
+        sql_str = str(result)
+        self.assertIn('::jsonb', sql_str)
+        self.assertNotIn('@>', sql_str)
+
+    def test_dispatch_stale_json_contains_value_generates_containment_sql(self):
+        """_single_value_to_sql generates @> SQL for a stale JsonContainsValue instance."""
+        field, sql_field = self._make_field_and_sql()
+        stale = self._stale_json_contains_value({'type': 'Point'})
+
+        result = field._single_value_to_sql(sql_field, 'in', stale)
+
+        self.assertIsInstance(result, SQL)
+        self.assertIn('@>', str(result))
+
+    def test_dispatch_impostor_missing_value_attr_does_not_raise_attribute_error(self):
+        """An impostor class with the right name but no .value falls through without AttributeError."""
+        class JsonValue:
+            pass  # Same name as the real wrapper, but no .value attribute
+
+        field, sql_field = self._make_field_and_sql()
+        impostor = JsonValue()
+
+        try:
+            field._single_value_to_sql(sql_field, 'in', impostor)
+        except AttributeError as exc:
+            self.fail(
+                f"AttributeError raised — .value was accessed without guard: {exc}"
+            )
+        except (ValueError, TypeError):
+            pass  # Expected: falls through to plain path; _equality_sql re-raises TypeError
+                  # from json.dumps as ValueError — either is acceptable here


### PR DESCRIPTION
This pull request updates the equality and type-checking logic in the `web_view_google_map_drawing/models/fields.py` file to make comparisons more robust and to avoid issues with class identity that can arise, for example, in testing or dynamic module loading scenarios. The changes focus on comparing type names instead of types directly, and on using type names for conditional logic instead of `isinstance`.

Type comparison and equality improvements:

* Changed the equality method (`__eq__`) in custom field classes to compare the type names rather than the type objects themselves, making equality checks more flexible and less prone to issues with multiple class definitions.
* Updated SQL-building methods to check the type name of the value (`v`) instead of using `isinstance`, ensuring correct handling even if the class is reloaded or duplicated, which can happen in some development or testing environments.