### PR TITLE
[IMP] base_google_map_add_place: improve manifest description and explicit asset entries (v1.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Provides the `google_map` form widget — an embedded Google Maps iframe showing
 
 Provides the `gplace_autocomplete_el` widget and the `google.places.mapping` configuration system. Connects Google Places API (New) to any Odoo Char field. Which fields are populated on selection is fully controlled by mapping records — supporting two autocomplete modes, three component handling modes, configurable separators, relational field auto-resolution, and a live built-in test tool.
 
-**[base_google_map_add_place](base_google_map_add_place/README.md)** `19.0.1.0.2`
+**[base_google_map_add_place](base_google_map_add_place/README.md)** `19.0.1.0.3`
 
 Abstract base for the click-to-create workflow. Provides the `google_map.add_place.mixin` Python mixin and the `InMapClickAddPlace` OWL component with zoom threshold logic and smart zoom shortcut. Application modules extend this instead of re-implementing the pattern.
 

--- a/base_google_map_add_place/CHANGELOG.md
+++ b/base_google_map_add_place/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.0.3
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit file entries; removed empty `data` and `demo` keys
+- **README**: Added `gplace_id` field to the Key Features list
+
 ## 1.0.2
 
 - [Improved] **`is_from_google_maps` Context Flag**: Added `is_from_google_maps=True` to the action context in all three form-open paths in `GoogleMapAddPlaceMixin` — the existing-record open action, `action_in_map_google_place_create`, and `action_in_map_google_place_from_reverse_geocode` — so the quick-create form view and its field handlers can detect that the record was opened from the Google Maps click-to-create workflow

--- a/base_google_map_add_place/README.md
+++ b/base_google_map_add_place/README.md
@@ -13,6 +13,7 @@ This module is a base layer — it does not activate the feature on any model by
 ## Key Features
 
 - **Abstract Model Mixin**: Provides `google_map.add_place.mixin` with all the logic for fetching place details, parsing addresses, and opening quick-create forms
+- **Google Place ID Field**: Adds a `gplace_id` field to any model that inherits the mixin, used to identify and deduplicate records by their Google Place
 - **Places API Integration**: Fetches name, address, phone, website, and coordinates from the Google Places API (New) when clicking a named place
 - **Reverse Geocoding**: Resolves map coordinates to a structured address via the Google Geocoding API when clicking empty map space
 - **Address Mapping**: Maps Google address components to Odoo partner fields (street, city, zip, state, country) with multi-country format support

--- a/base_google_map_add_place/__manifest__.py
+++ b/base_google_map_add_place/__manifest__.py
@@ -1,24 +1,21 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Base - Google Maps: Add Place from Map Click",
-    "summary": """
-        Abstract mixin and UI component for creating Odoo records directly from the Google Maps view by clicking on a place or map location.
-    """,
+    "summary": "Abstract mixin and UI component for creating Odoo records by clicking on a Google Maps view",
     "description": """
-        Provides the reusable foundation for click-to-create workflows on Google Maps views.
+Base - Google Maps: Add Place from Map Click
+============================================
 
-        Includes an abstract model mixin (google_map.add_place.mixin) that application
-        modules inherit to gain click-to-create behaviour. The mixin handles Google Places API
-        detail fetching, reverse geocoding via the Geocoding API, address component mapping to
-        Odoo partner fields, and duplicate detection by Google Place ID.
+Reusable foundation for click-to-create workflows on Google Maps views.
 
-        Also ships the InMapClickAddPlace OWL component: a map overlay that listens for clicks
-        when zoomed in sufficiently (zoom >= 15). Clicking a named Google Place fetches its
-        details (name, address, phone, website, coordinates) and opens a pre-populated
-        quick-create form. Clicking empty map space reverse-geocodes the coordinate and
-        pre-populates the form with the resolved address. A visual indicator in the map corner
-        shows when the feature is active. After saving, the map view reloads automatically.
-    """,
+Provides:
+
+- ``google_map.add_place.mixin`` — abstract model mixin with server-side methods for place detail fetching, address component mapping, reverse geocoding, and duplicate detection
+- ``gplace_id`` Char field added to any inheriting model for Google Place ID storage
+- Address parsing from the adr microformat (Places API New) and plain-text ``formatted_address`` (Geocoding API), with multi-country postal code support
+- ``InMapClickAddPlace`` OWL component — map overlay listening for clicks at zoom ≥ 15, fetching place or reverse-geocoded data, and opening a pre-populated quick-create form
+- Visual indicator injected into the map's top-right corner showing when map-click-to-create is active, with a one-click zoom shortcut
+""",
     "license": "LGPL-3",
     "author": "Yopi Angi",
     "website": "https://github.com/mithnusa",
@@ -28,13 +25,13 @@
     "depends": [
         "web_view_google_map",
     ],
-    "data": [],
     "assets": {
         "web.assets_backend": [
-            "base_google_map_add_place/static/src/components/**/*",
-        ]
+            "base_google_map_add_place/static/src/components/in_map_click_add_place/in_map_click_add_place.js",
+            "base_google_map_add_place/static/src/components/in_map_click_add_place/in_map_click_add_place.xml",
+            "base_google_map_add_place/static/src/components/in_map_click_add_place/in_map_click_add_place.scss",
+        ],
     },
-    "demo": [],
     "installable": True,
     "application": False,
     "auto_install": False,

--- a/base_google_map_add_place/__manifest__.py
+++ b/base_google_map_add_place/__manifest__.py
@@ -21,7 +21,7 @@ Provides:
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Tools",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "depends": [
         "web_view_google_map",
     ],


### PR DESCRIPTION
- Rewrite manifest summary (single-line) and description with structured bullet-point format documenting all provided components: the mixin, gplace_id field, address parsing logic, and InMapClickAddPlace OWL component
- Replace wildcard asset glob with explicit file entries for deterministic load order
- Remove empty data: [] and demo: [] entries from manifest
- Document gplace_id field in README Key Features list