### PR TITLE
[IMP] contacts_google_autocomplete: improve manifest, fix module name, update docs (v1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Adds a Google Map view to the Contacts application with color-coded partner mark
 
 Activates click-to-create on the Contacts map view. Clicking a named Google Place or empty map location opens a pre-populated partner creation form. Duplicate detection prevents creating a second record for the same Google Place ID.
 
-**[contacts_google_autocomplete](contacts_google_autocomplete/README.md)** `19.0.1.0.1`
+**[contacts_google_autocomplete](contacts_google_autocomplete/README.md)** `19.0.1.0.2`
 
 Applies `gplace_autocomplete_el` to the Contact form's name field (`places` mode) and street field (`address` mode). Populates address fields and coordinates on selection. Mapping configurations for `res.partner` are created automatically on installation.
 

--- a/contacts_google_autocomplete/CHANGELOG.md
+++ b/contacts_google_autocomplete/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 19.0.1.0.2
+
+### Improved
+
+- **`__manifest__.py` — Name**: Corrected module name from `'Contact Google Autocomplete'` to `'Contacts Google Autocomplete'` for consistency with the module directory name
+- **`__manifest__.py` — Summary & Description**: Rewrote the summary and description to accurately document the two widget mapping modes (`places` on name fields, `address` on street field) and the child-contacts inline sub-form coverage
+- **`__manifest__.py` — `post_init_hook` Placement**: Moved `post_init_hook` key to follow `data` and `installable` entries for manifest key ordering consistency; removed the empty `demo: []` entry
+- **`README.md` — Basic Usage**: Extended the usage note to mention that the same autocomplete applies inside the child-contacts inline sub-form when adding contacts linked to a company
+
 ## 19.0.1.0.1
 ### Improved
 - **Performance Optimization**: Changed from `search()` to `search_count()` for existence checks in post-install hook

--- a/contacts_google_autocomplete/README.md
+++ b/contacts_google_autocomplete/README.md
@@ -31,7 +31,7 @@ Replaces the standard name and street inputs on the Contact form with Google Pla
 
 ## Basic Usage
 
-Open any Contact form. The name and street fields now have Google autocomplete — start typing to see suggestions. Select a suggestion to auto-fill the address and other available details.
+Open any Contact form. The name and street fields now have Google autocomplete — start typing to see suggestions. Select a suggestion to auto-fill the address and other available details. The same autocomplete applies inside the child-contacts sub-form when adding contacts linked to a company.
 
 ## Related Modules
 

--- a/contacts_google_autocomplete/__manifest__.py
+++ b/contacts_google_autocomplete/__manifest__.py
@@ -1,25 +1,29 @@
 # -*- coding: utf-8 -*-
 {
-    'name': 'Contact Google Autocomplete',
-    'summary': '''
-        Adds Google Places autocomplete functionality to the Contact form.
-        It enhances the name and street fields with Google Places autocomplete,
-        allowing users to quickly fill in contact information by selecting from Google Places suggestions
-    ''',
-    'description': '''
-        Adds Google Autocomplete to name and street in Contact form
-    ''',
+    'name': 'Contacts Google Autocomplete',
+    'summary': 'Google Places autocomplete for the name and street fields on the Contact form',
+    'description': """
+Contacts Google Autocomplete
+=============================
+
+Enhances the Odoo Contact form with Google Places autocomplete on the name and street fields.
+
+Provides:
+
+- ``gplace_autocomplete_el`` widget on the name and street fields in the Contact form and inside the child-contacts inline sub-form
+- Two mapping modes: ``places`` on the name fields (fetches name, address, phone, website, and coordinates) and ``address`` on the street field (fetches address components and coordinates, restricted to streets and routes)
+- Post-install hook that automatically creates ``google.places.mapping`` records for ``res.partner`` — no manual mapping configuration required after installation
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.1',
+    'version': '1.0.2',
     'depends': ['contacts', 'web_widget_google_place_autocomplete'],
     'data': ['views/res_partner_views.xml'],
-    'demo': [],
+    'post_init_hook': '_post_install_hook_configure_contact_google_place_mapping',
     'installable': True,
     'application': False,
     'auto_install': False,
-    'post_init_hook': '_post_install_hook_configure_contact_google_place_mapping',
 }


### PR DESCRIPTION
- Fix module name from 'Contact Google Autocomplete' to 'Contacts Google Autocomplete' for consistency with the module directory name
- Rewrite manifest summary and description with structured bullet-point format documenting both widget mapping modes (places on name, address on street) and the child-contacts inline sub-form coverage
- Move post_init_hook to follow data/installable entries; remove empty demo: []
- Extend README Basic Usage to mention autocomplete in child-contacts sub-form