### PR TITLE
[IMP] contacts_google_map: improve manifest, update cron docs, and regenerate POT (v1.0.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Abstract base for the click-to-create workflow. Provides the `google_map.add_pla
 
 ### Contacts
 
-**[contacts_google_map](contacts_google_map/README.md)** `19.0.1.0.9`
+**[contacts_google_map](contacts_google_map/README.md)** `19.0.1.0.10`
 
 Adds a Google Map view to the Contacts application with color-coded partner markers. Adds a Geolocation tab to the partner form with an embedded map, geocode button, marker color picker, nearby search, and an optional background geocoding cron job.
 

--- a/contacts_google_map/README.md
+++ b/contacts_google_map/README.md
@@ -15,7 +15,7 @@ Adds the `google_map` view type to Contacts so you can see all your contacts pin
 - **Marker Color Customization**: Each contact can have a custom marker color set via a color picker on the contact form
 - **Nearby Contacts Search**: "Nearby Contacts" button on the contact form opens the map filtered to contacts within a configurable radius of that contact's location
 - **Embedded Map in Contact Form**: The Geolocation page of the contact form shows an embedded map at the contact's coordinates
-- **Automatic Geocoding Cron**: An optional scheduled job (inactive by default) automatically geocodes up to 500 contacts per day that have a country but no coordinates
+- **Automatic Geocoding Cron**: A scheduled job (enabled by default, runs every 12 hours) that automatically geocodes up to 80 contacts per run that have a country and at least one address field but no coordinates
 
 ## Dependencies
 
@@ -29,7 +29,7 @@ Adds the `google_map` view type to Contacts so you can see all your contacts pin
 1. Install the module through Odoo Apps
 2. Ensure `base_google_map` is configured with a valid Google Maps API key in **Settings → General Settings → Google Maps**
 3. Enable **Maps JavaScript API**, **Places API (New)**, **Maps Embed API**, and **Geocoding API** in your Google Cloud Console
-4. Optionally activate the geocoding cron job in **Settings → Technical → Scheduled Actions → Auto Geolocalize Contacts**
+4. The geocoding cron job is enabled by default. You can adjust its schedule or disable it in **Settings → Technical → Scheduled Actions → Contact: geolocate**
 
 ## Basic Usage
 

--- a/contacts_google_map/__manifest__.py
+++ b/contacts_google_map/__manifest__.py
@@ -1,32 +1,50 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Contacts Google Maps',
-    'summary': '''
-        Show your contacts in a new view Google Maps
-    ''',
-    'description': '''
-        A new view 'Google Maps' added on Contacts, gives you
-        an ability to show your contact location in Google Maps
-    ''',
+    'summary': 'Google Maps view for Contacts with nearby search, marker colors, and geocoding cron',
+    'description': """
+Contacts Google Maps
+====================
+
+Adds a Google Maps view to the Contacts application.
+
+Provides:
+
+- ``google_map`` view type added to the Contacts action (alongside list, kanban, and form)
+- Contact avatars displayed in the map sidebar and marker info windows
+- ``marker_color`` field on ``res.partner`` with a color picker on the Geolocation form page
+- Embedded map widget on the contact form's Geolocation page showing the contact's coordinates
+- **Nearby Contacts** button on the contact form — opens the map filtered to contacts within a configurable radius, with correct antimeridian wraparound handling
+- Scheduled geocoding job (every 12 hours, up to 80 contacts per run) that automatically geocodes contacts that have an address but no coordinates; respects OpenStreetMap Nominatim rate limits with per-record pausing
+- ``_delete_coordinates`` override that preserves coordinates when the address is updated from the Google Maps workflow (``is_from_google_maps`` context flag)
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/CRM',
-    'version': '1.0.9',
+    'version': '1.0.10',
     'depends': [
         'base_geolocalize',
         'contacts',
         'web_view_google_map',
         'web_widget_google_map',
     ],
-    'data': ['data/cron_contact_geolocalize.xml', 'views/res_partner.xml'],
+    'data': [
+        'data/cron_contact_geolocalize.xml',
+        'views/res_partner.xml',
+    ],
     'assets': {
         'web.assets_backend': [
-            'contacts_google_map/static/src/views/**/*',
-        ]
+            'contacts_google_map/static/src/views/google_map/google_map_view.scss',
+            'contacts_google_map/static/src/views/google_map/google_map_arch_parser.js',
+            'contacts_google_map/static/src/views/google_map/google_map_sidebar.js',
+            'contacts_google_map/static/src/views/google_map/google_map_sidebar.xml',
+            'contacts_google_map/static/src/views/google_map/google_map_renderer.js',
+            'contacts_google_map/static/src/views/google_map/google_map_renderer.xml',
+            'contacts_google_map/static/src/views/google_map/google_map_view.js',
+        ],
     },
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/contacts_google_map/i18n/contacts_google_map.pot
+++ b/contacts_google_map/i18n/contacts_google_map.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-27 10:45+0000\n"
-"PO-Revision-Date: 2025-10-27 10:45+0000\n"
+"POT-Creation-Date: 2026-06-17 11:04+0000\n"
+"PO-Revision-Date: 2026-06-17 11:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,6 @@ msgstr ""
 
 #. module: contacts_google_map
 #: model:ir.model,name:contacts_google_map.model_res_partner
-#: model_terms:ir.ui.view,arch_db:contacts_google_map.view_res_partner_google_map_form
 msgid "Contact"
 msgstr ""
 
@@ -49,16 +48,6 @@ msgid "Display Name"
 msgstr ""
 
 #. module: contacts_google_map
-#: model:ir.actions.act_window,name:contacts_google_map.action_view_res_partner_google_map
-msgid "Google Map"
-msgstr ""
-
-#. module: contacts_google_map
-#: model_terms:ir.ui.view,arch_db:contacts_google_map.view_crm_partner_geo_form_inherit
-msgid "Google Maps"
-msgstr ""
-
-#. module: contacts_google_map
 #: model:ir.model.fields,field_description:contacts_google_map.field_res_partner__id
 msgid "ID"
 msgstr ""
@@ -67,4 +56,21 @@ msgstr ""
 #: model:ir.model.fields,field_description:contacts_google_map.field_res_partner__marker_color
 #: model:ir.model.fields,field_description:contacts_google_map.field_res_users__marker_color
 msgid "Marker Color"
+msgstr ""
+
+#. module: contacts_google_map
+#: model_terms:ir.ui.view,arch_db:contacts_google_map.view_res_partner_form_inherit_nearby_search
+msgid "Nearby Contacts"
+msgstr ""
+
+#. module: contacts_google_map
+#. odoo-python
+#: code:addons/contacts_google_map/models/res_partner.py:0
+msgid "Nearby Contacts (within %.1f km)"
+msgstr ""
+
+#. module: contacts_google_map
+#. odoo-python
+#: code:addons/contacts_google_map/models/res_partner.py:0
+msgid "This contact does not have geolocation coordinates."
 msgstr ""


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting the map view, marker color, nearby search, embedded form map, geocoding cron, and the is_from_google_maps context flag
- Replace wildcard asset glob with explicit ordered file entries
- Remove empty demo: [] entry
- Update README and installation notes to reflect that the geocoding cron is now enabled by default (every 12 hours, up to 80 contacts per run)
- Regenerate POT: update creation/revision dates; add new translatable strings for "Nearby Contacts", "Nearby Contacts (within %.1f km)", and "This contact does not have geolocation coordinates."; remove stale entries