### PR TITLE
[IMP] contacts_google_map_add_place: improve manifest, explicit assets, clean up POT (v1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Abstract base for the click-to-create workflow. Provides the `google_map.add_pla
 
 Adds a Google Map view to the Contacts application with color-coded partner markers. Adds a Geolocation tab to the partner form with an embedded map, geocode button, marker color picker, nearby search, and an optional background geocoding cron job.
 
-**[contacts_google_map_add_place](contacts_google_map_add_place/README.md)** `19.0.1.0.1`
+**[contacts_google_map_add_place](contacts_google_map_add_place/README.md)** `19.0.1.0.2`
 
 Activates click-to-create on the Contacts map view. Clicking a named Google Place or empty map location opens a pre-populated partner creation form. Duplicate detection prevents creating a second record for the same Google Place ID.
 

--- a/contacts_google_map_add_place/CHANGELOG.md
+++ b/contacts_google_map_add_place/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.0.2
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit file entries; removed empty `data` and `demo` keys
+- **i18n**: Regenerated POT — updated dates; removed stale JS strings moved upstream to `base_google_map_add_place`
+
 ## 1.0.1
 
 - [Refactor] **Mixin Extraction**: Moved `google_map.add_place.mixin` and the `InMapClickAddPlace` OWL component to the new `base_google_map_add_place` module; `contacts_google_map_add_place` now delegates all click-to-create logic to that base layer

--- a/contacts_google_map_add_place/__manifest__.py
+++ b/contacts_google_map_add_place/__manifest__.py
@@ -22,7 +22,7 @@ Provides:
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Tools",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "depends": [
         "web_view_google_map",
         "base_google_map_add_place",

--- a/contacts_google_map_add_place/__manifest__.py
+++ b/contacts_google_map_add_place/__manifest__.py
@@ -1,18 +1,22 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Contacts - Google Maps: Click to Add Place",
-    "summary": """
-        Create new contacts directly from the Google Maps view by clicking on any place or map location.
-    """,
+    "summary": "Create contacts directly from the Google Maps view by clicking on any place or location",
     "description": """
-        Extends the Google Maps view for Contacts with a click-to-create workflow.
-        When zoomed in sufficiently, clicking a named Google Place fetches its details
-        (name, address, phone, website) via the Places API and pre-populates a quick-create
-        form. Clicking on empty map space performs a reverse geocode and pre-populates the
-        form with the resolved address. A visual indicator in the map corner signals when
-        the feature is active. After saving, the map view reloads automatically to reflect
-        the new or updated contact.
-    """,
+Contacts - Google Maps: Click to Add Place
+==========================================
+
+Extends the Contacts Google Maps view with a click-to-create workflow.
+
+Provides:
+
+- ``res.partner`` inherits ``google_map.add_place.mixin``, activating the click-to-create server-side methods for the Contact model
+- Patches the Contacts map renderer to include the ``InMapClickAddPlace`` component: clicking a named Google Place fetches name, address, phone, and website via the Places API (New) and opens a pre-populated quick-create form; clicking empty map space reverse-geocodes the coordinate and pre-fills the form with the resolved address
+- Duplicate detection: if a contact with the same Google Place ID already exists, that record opens instead of creating a new one
+- ``gplace_id`` stored on each contact created from a named Google Place
+- Visual indicator in the map's top-right corner with one-click zoom shortcut
+- Map view reloads automatically after save with a notification linking to the new contact
+""",
     "license": "LGPL-3",
     "author": "Yopi Angi",
     "website": "https://github.com/mithnusa",
@@ -24,13 +28,12 @@
         "base_google_map_add_place",
         "contacts_google_map",
     ],
-    "data": [],
     "assets": {
         "web.assets_backend": [
-            "contacts_google_map_add_place/static/src/views/**/*",
-        ]
+            "contacts_google_map_add_place/static/src/views/google_map/google_map_renderer.js",
+            "contacts_google_map_add_place/static/src/views/google_map/google_map_renderer.xml",
+        ],
     },
-    "demo": [],
     "installable": True,
     "application": False,
     "auto_install": False,

--- a/contacts_google_map_add_place/i18n/contacts_google_map_add_place.pot
+++ b/contacts_google_map_add_place/i18n/contacts_google_map_add_place.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-28 04:42+0000\n"
-"PO-Revision-Date: 2026-03-28 04:42+0000\n"
+"POT-Creation-Date: 2026-06-17 11:05+0000\n"
+"PO-Revision-Date: 2026-06-17 11:05+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,37 +21,8 @@ msgid "Contact"
 msgstr ""
 
 #. module: contacts_google_map_add_place
-#. odoo-javascript
-#: code:addons/contacts_google_map_add_place/static/src/views/component/in_map_click_add_place/in_map_click_add_place.js:0
-msgid "Contact is updated successfully"
-msgstr ""
-
-#. module: contacts_google_map_add_place
-#: model:ir.model,website_form_label:contacts_google_map_add_place.model_res_partner
-msgid "Create a Customer"
-msgstr ""
-
-#. module: contacts_google_map_add_place
 #: model:ir.model.fields,field_description:contacts_google_map_add_place.field_res_partner__display_name
 msgid "Display Name"
-msgstr ""
-
-#. module: contacts_google_map_add_place
-#. odoo-javascript
-#: code:addons/contacts_google_map_add_place/static/src/views/component/in_map_click_add_place/in_map_click_add_place.js:0
-msgid "Failed to open the quick create form."
-msgstr ""
-
-#. module: contacts_google_map_add_place
-#. odoo-javascript
-#: code:addons/contacts_google_map_add_place/static/src/views/component/in_map_click_add_place/in_map_click_add_place.js:0
-msgid "Failed to retrieve place details."
-msgstr ""
-
-#. module: contacts_google_map_add_place
-#. odoo-javascript
-#: code:addons/contacts_google_map_add_place/static/src/views/component/in_map_click_add_place/in_map_click_add_place.js:0
-msgid "Failed to retrieve place information."
 msgstr ""
 
 #. module: contacts_google_map_add_place
@@ -65,28 +36,8 @@ msgid "ID"
 msgstr ""
 
 #. module: contacts_google_map_add_place
-#. odoo-javascript
-#: code:addons/contacts_google_map_add_place/static/src/views/component/in_map_click_add_place/in_map_click_add_place.js:0
-msgid "New contact is created successfully"
-msgstr ""
-
-#. module: contacts_google_map_add_place
-#. odoo-javascript
-#: code:addons/contacts_google_map_add_place/static/src/views/component/in_map_click_add_place/in_map_click_add_place.js:0
-msgid "Open"
-msgstr ""
-
-#. module: contacts_google_map_add_place
 #: model:ir.model.fields,help:contacts_google_map_add_place.field_res_partner__gplace_id
 msgid ""
 "The unique identifier for the place in Google Maps. This is used to link the"
 " record to a specific location on the map."
-msgstr ""
-
-#. module: contacts_google_map_add_place
-#. odoo-javascript
-#: code:addons/contacts_google_map_add_place/static/src/views/component/in_map_click_add_place/in_map_click_add_place.xml:0
-msgid ""
-"Zoom in on the map until this control turns green. Then click anywhere on "
-"the map to open a quick-create form with pre-filled location details"
 msgstr ""


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting the res.partner mixin inheritance, InMapClickAddPlace component patch, duplicate detection, gplace_id storage, visual indicator, and post-save reload notification
- Replace wildcard asset glob with explicit file entries; remove empty data: [] and demo: [] entries
- Regenerate POT: update creation/revision dates; remove stale JS translatable strings that were moved upstream to base_google_map_add_place