### PR TITLE
[IMP] crm_google_autocomplete: improve manifest, fix dependency, document coordinate guard (v1.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Adds a Google Map view across five CRM menus (All Leads, My Activities, Opportun
 
 Activates click-to-create on the CRM map view. Named place clicks create a pre-filled lead with address, phone, website, coordinates, and an auto-generated opportunity name. Empty map clicks reverse-geocode the coordinate. Duplicate detection uses the Google Place ID.
 
-**[crm_google_autocomplete](crm_google_autocomplete/README.md)** `19.0.1.0.2`
+**[crm_google_autocomplete](crm_google_autocomplete/README.md)** `19.0.1.0.3`
 
 Applies `gplace_autocomplete_el` to the Lead/Opportunity form's company name field (`places` mode) and street field (`address` mode), in both the quick-entry group and the detailed lead tab. Auto-fills address fields and CRM geolocation fields on selection.
 

--- a/crm_google_autocomplete/CHANGELOG.md
+++ b/crm_google_autocomplete/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 19.0.1.0.3
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; fixed declared dependency from `crm` to `crm_google_map`; moved `post_init_hook` key; removed empty `demo` key
+- **README**: Added "Coordinate Preservation" feature; corrected dependency from `crm` to `crm_google_map`
+- **FEATURES.md**: Added "Coordinate Preservation" section documenting the `is_from_google_maps` context flag guard
+
 ## 19.0.1.0.2
 
 ### Added

--- a/crm_google_autocomplete/README.md
+++ b/crm_google_autocomplete/README.md
@@ -15,11 +15,12 @@ Replaces the standard company name and street inputs on the Lead/Opportunity for
 - **Full Address Auto-Fill**: Selecting a suggestion populates street, street2, city, state, zip, and country automatically
 - **Geolocation Auto-Fill**: Lead latitude (`customer_latitude`) and longitude (`customer_longitude`) are stored automatically from the selected place's location data
 - **Company Details Auto-Fill**: Selecting a business from the company name field also fills in phone and website
+- **Coordinate Preservation**: When an address is updated via the Google Maps workflow, the lead's coordinates are not reset — they are kept exactly as returned by the Places API
 - **Auto-Configured on Install**: Field mappings between Google Places data and Odoo Lead fields are created automatically during installation — no manual setup required
 
 ## Dependencies
 
-- `crm`
+- `crm_google_map`
 - `web_widget_google_place_autocomplete`
 
 ## Installation

--- a/crm_google_autocomplete/__manifest__.py
+++ b/crm_google_autocomplete/__manifest__.py
@@ -21,7 +21,7 @@ Provides:
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.2',
+    'version': '1.0.3',
     'depends': ['crm_google_map', 'web_widget_google_place_autocomplete'],
     'data': ['views/crm_lead_views.xml'],
     'post_init_hook': '_post_install_hook_configure_crm_google_place_mapping',

--- a/crm_google_autocomplete/__manifest__.py
+++ b/crm_google_autocomplete/__manifest__.py
@@ -1,12 +1,21 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'CRM Google Places Autocomplete',
-    'summary': '''
-        Add Google Places Autocomplete to Company Name and Street in Lead form
-    ''',
-    'description': '''
-        Add Google Places Autocomplete to Company Name and Street in Lead form
-    ''',
+    'summary': 'Google Places autocomplete for the company name and street fields on the Lead/Opportunity form',
+    'description': """
+CRM Google Places Autocomplete
+================================
+
+Enhances the Lead/Opportunity form with Google Places autocomplete on the company
+name and street fields.
+
+Provides:
+
+- ``gplace_autocomplete_el`` widget on ``partner_name`` (places mode) and ``street`` (address mode) in both the quick-entry group and the detailed lead tab
+- Two mapping modes: ``places`` on the company name field (fetches company name, address, phone, website, and coordinates) and ``address`` on the street field (fetches address components and coordinates, restricted to streets and routes)
+- ``_compute_customer_geo`` override that skips the lead's coordinate reset when the address is being updated from the Google Maps workflow (``is_from_google_maps`` context flag)
+- Post-install hook that automatically creates ``google.places.mapping`` records for ``crm.lead`` — no manual mapping configuration required after installation
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
@@ -15,9 +24,8 @@
     'version': '1.0.2',
     'depends': ['crm_google_map', 'web_widget_google_place_autocomplete'],
     'data': ['views/crm_lead_views.xml'],
-    'demo': [],
+    'post_init_hook': '_post_install_hook_configure_crm_google_place_mapping',
     'installable': True,
     'application': False,
     'auto_install': False,
-    'post_init_hook': '_post_install_hook_configure_crm_google_place_mapping',
 }

--- a/crm_google_autocomplete/docs/FEATURES.md
+++ b/crm_google_autocomplete/docs/FEATURES.md
@@ -49,6 +49,18 @@
 
 ---
 
+## Coordinate Preservation
+
+### Google Maps Coordinate Guard
+
+**What it does**: Prevents the lead's latitude and longitude from being reset when an address is updated through the Google Maps autocomplete workflow.
+
+**Why it matters**: Odoo's CRM lead model resets coordinates to `0.0` when the address diverges from the linked partner. Without this guard, selecting a place from autocomplete would first write the coordinates from the Places API and then immediately clear them.
+
+**How it works**: `_compute_customer_geo` is overridden to skip its logic entirely when the `is_from_google_maps` context flag is set, preserving the coordinates that were already written by the autocomplete widget.
+
+---
+
 ## Installation-Time Configuration
 
 ### Automatic Mapping Setup on Install


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting both widget mapping modes, the _compute_customer_geo override, and the post-install hook
- Fix declared dependency from crm to crm_google_map in both manifest and README
- Move post_init_hook to follow installable entry; remove empty demo: []
- Add "Coordinate Preservation" feature to README and FEATURES.md explaining the is_from_google_maps context flag guard that prevents coordinate reset after a Places API autocomplete selection