### PR TITLE
[IMP] crm_google_map: improve manifest, explicit assets, and regenerate POT (v1.0.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Combines Odoo's built-in partner autocomplete with a Google Places toggle panel 
 
 ### CRM
 
-**[crm_google_map](crm_google_map/README.md)** `19.0.1.0.9`
+**[crm_google_map](crm_google_map/README.md)** `19.0.1.0.10`
 
 Adds a Google Map view across five CRM menus (All Leads, My Activities, Opportunities, Pipeline, Forecast). Each lead appears as a color-coded marker card with stage, contact, salesperson, revenue, probability, and closing date. The lead form gains a Geolocation tab, geocode button, color picker, and an embedded map preview.
 

--- a/crm_google_map/CHANGELOG.md
+++ b/crm_google_map/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!-- markdownlint-disable MD024 -->
 # Change Log
 
+## 19.0.1.0.10
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit ordered file entries; removed empty `demo` key
+- **i18n**: Regenerated POT — updated dates; added new strings (`"CRM Lead: geolocate"`, `"Invalid Data"`, `"No match found for %(lead_names)s address(es)."`, `"Open"`, overlap-offset tooltip, `"Warning"`); renamed `"Customer"` → `"Contact"`; removed stale sidebar-sourced duplicates for `"Expected Closing"`, `"Expected Revenue"`, `"Probability"`, `"Salesperson"`
+
 ## 19.0.1.0.9
 
 ### Added

--- a/crm_google_map/__manifest__.py
+++ b/crm_google_map/__manifest__.py
@@ -1,19 +1,32 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'CRM Google Maps',
-    'summary': '''
-        Show leads or opportunities in Google Maps view
-    ''',
-    'description': '''
-        A new view 'Google Maps' added on leads or opportunities, gives you
-        an ability to show the location in Google Maps
-    ''',
+    'summary': 'Google Maps view for CRM Leads and Opportunities with geolocation and marker colors',
+    'description': """
+CRM Google Maps
+===============
+
+Adds a Google Maps view to the CRM application for Leads and Opportunities.
+
+Provides:
+
+- ``customer_latitude``, ``customer_longitude``, ``customer_address``, and ``marker_color`` fields on ``crm.lead``
+- ``_compute_customer_geo``: mirrors the linked partner's coordinates when the lead address is in sync; resets to ``(0, 0)`` when they diverge so the cron re-geocodes
+- ``_compute_customer_address``: computed formatted address using the country's address format
+- ``geo_localize()``: manual geocoding from the lead's address fields with a user notification when no result is found
+- Scheduled geocoding job (every 12 hours, up to 80 leads per run) with OpenStreetMap rate-limit handling
+- ``google_map`` view type added to the Leads, Opportunities, My Activities, Pipeline, and Forecast CRM actions
+- CRM-specific marker cards showing deal name, stage, contact, salesperson, expected revenue, probability, and closing date
+- Overlap-offset rendering so stacked markers remain individually clickable
+- Sidebar listing leads with expected revenue and stage
+- Geolocation tab on the lead form with coordinate display, geocode buttons, marker color picker, and an embedded map preview
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/CRM',
-    'version': '1.0.9',
+    'version': '1.0.10',
     'depends': [
         'crm',
         'web_view_google_map',
@@ -25,10 +38,16 @@
     ],
     'assets': {
         'web.assets_backend': [
-            'crm_google_map/static/src/views/**/*',
-        ]
+            'crm_google_map/static/src/views/google_map/google_map_view.scss',
+            'crm_google_map/static/src/views/google_map/google_map_sidebar.scss',
+            'crm_google_map/static/src/views/google_map/google_map_sidebar.js',
+            'crm_google_map/static/src/views/google_map/google_map_sidebar.xml',
+            'crm_google_map/static/src/views/google_map/google_map_renderer.js',
+            'crm_google_map/static/src/views/google_map/google_map_renderer.xml',
+            'crm_google_map/static/src/views/google_map/google_map_controller.js',
+            'crm_google_map/static/src/views/google_map/google_map_view.js',
+        ],
     },
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/crm_google_map/i18n/crm_google_map.pot
+++ b/crm_google_map/i18n/crm_google_map.pot
@@ -6,14 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-27 10:47+0000\n"
-"PO-Revision-Date: 2025-10-27 10:47+0000\n"
+"POT-Creation-Date: 2026-06-17 11:06+0000\n"
+"PO-Revision-Date: 2026-06-17 11:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: crm_google_map
+#: model:ir.actions.server,name:crm_google_map.ir_cron_data_crm_lead_geolocate_ir_actions_server
+msgid "CRM Lead: geolocate"
+msgstr ""
 
 #. module: crm_google_map
 #: model:ir.model.fields,field_description:crm_google_map.field_crm_lead__customer_address
@@ -32,8 +37,8 @@ msgstr ""
 
 #. module: crm_google_map
 #. odoo-javascript
-#: code:addons/crm_google_map/static/src/views/google_map/google_map_sidebar.xml:0
-msgid "Customer"
+#: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.xml:0
+msgid "Contact"
 msgstr ""
 
 #. module: crm_google_map
@@ -54,14 +59,12 @@ msgstr ""
 #. module: crm_google_map
 #. odoo-javascript
 #: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.xml:0
-#: code:addons/crm_google_map/static/src/views/google_map/google_map_sidebar.xml:0
 msgid "Expected Closing"
 msgstr ""
 
 #. module: crm_google_map
 #. odoo-javascript
 #: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.xml:0
-#: code:addons/crm_google_map/static/src/views/google_map/google_map_sidebar.xml:0
 msgid "Expected Revenue"
 msgstr ""
 
@@ -76,14 +79,14 @@ msgid "Geolocation"
 msgstr ""
 
 #. module: crm_google_map
-#: model:ir.actions.act_window,name:crm_google_map.action_view_crm_lead_google_map
-#: model_terms:ir.ui.view,arch_db:crm_google_map.crm_lead_view_form_inherit_crm_google_map
-msgid "Google Map"
+#: model:ir.model.fields,field_description:crm_google_map.field_crm_lead__id
+msgid "ID"
 msgstr ""
 
 #. module: crm_google_map
-#: model:ir.model.fields,field_description:crm_google_map.field_crm_lead__id
-msgid "ID"
+#. odoo-javascript
+#: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid "Invalid Data"
 msgstr ""
 
 #. module: crm_google_map
@@ -92,8 +95,9 @@ msgid "Lat :"
 msgstr ""
 
 #. module: crm_google_map
+#. odoo-javascript
+#: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.js:0
 #: model:ir.model,name:crm_google_map.model_crm_lead
-#: model_terms:ir.ui.view,arch_db:crm_google_map.view_crm_lead_google_map_form
 msgid "Lead"
 msgstr ""
 
@@ -113,9 +117,20 @@ msgid "Marker color"
 msgstr ""
 
 #. module: crm_google_map
+#. odoo-python
+#: code:addons/crm_google_map/models/crm_lead.py:0
+msgid "No match found for %(lead_names)s address(es)."
+msgstr ""
+
+#. module: crm_google_map
 #. odoo-javascript
 #: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.xml:0
-#: code:addons/crm_google_map/static/src/views/google_map/google_map_sidebar.xml:0
+msgid "Open"
+msgstr ""
+
+#. module: crm_google_map
+#. odoo-javascript
+#: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.xml:0
 msgid "Probability"
 msgstr ""
 
@@ -131,6 +146,20 @@ msgstr ""
 
 #. module: crm_google_map
 #. odoo-javascript
-#: code:addons/crm_google_map/static/src/views/google_map/google_map_sidebar.xml:0
+#: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.xml:0
 msgid "Salesperson"
+msgstr ""
+
+#. module: crm_google_map
+#. odoo-javascript
+#: code:addons/crm_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid ""
+"This marker has been adjusted slightly so it doesn't overlap with others. "
+"The line points to its original location."
+msgstr ""
+
+#. module: crm_google_map
+#. odoo-python
+#: code:addons/crm_google_map/models/crm_lead.py:0
+msgid "Warning"
 msgstr ""


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting all added fields, computed methods, geocoding cron, view registrations, marker card contents, overlap-offset rendering, sidebar, and the Geolocation form tab
- Replace wildcard asset glob with explicit ordered file entries; remove empty demo: []
- Regenerate POT: update creation/revision dates; add new translatable strings for "CRM Lead: geolocate", "Invalid Data", "No match found for %(lead_names)s address(es).", "Open", overlap-offset tooltip, and "Warning"; remove stale sidebar-sourced duplicates; rename "Customer" to "Contact"