### PR TITLE
[IMP] crm_google_map_add_place: improve manifest, explicit assets, and clean up POT (v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Combines Odoo's built-in partner autocomplete with a Google Places toggle panel 
 
 Adds a Google Map view across five CRM menus (All Leads, My Activities, Opportunities, Pipeline, Forecast). Each lead appears as a color-coded marker card with stage, contact, salesperson, revenue, probability, and closing date. The lead form gains a Geolocation tab, geocode button, color picker, and an embedded map preview.
 
-**[crm_google_map_add_place](crm_google_map_add_place/README.md)** `19.0.1.0.0`
+**[crm_google_map_add_place](crm_google_map_add_place/README.md)** `19.0.1.0.1`
 
 Activates click-to-create on the CRM map view. Named place clicks create a pre-filled lead with address, phone, website, coordinates, and an auto-generated opportunity name. Empty map clicks reverse-geocode the coordinate. Duplicate detection uses the Google Place ID.
 

--- a/crm_google_map_add_place/CHANGELOG.md
+++ b/crm_google_map_add_place/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.0.1
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit file entries; removed empty `data` and `demo` keys
+- **i18n**: Regenerated POT — updated dates; removed stale `"Create an Opportunity"` website form label entry
+
 ## 1.0.0 - Initial Release
 
 - **CRM Lead Mixin**: Extended `crm.lead` with `google_map.add_place.mixin` to gain `gplace_id` field and click-to-create methods

--- a/crm_google_map_add_place/__manifest__.py
+++ b/crm_google_map_add_place/__manifest__.py
@@ -1,43 +1,41 @@
 # -*- coding: utf-8 -*-
 {
     "name": "CRM - Google Maps: Add Lead from Map Click",
-    "summary": """
-        Create new CRM leads directly from the Google Maps view by clicking on any place or map location.
-    """,
+    "summary": "Create CRM leads directly from the Google Maps view by clicking on any place or location",
     "description": """
-        Activates the click-to-create workflow on the CRM Google Maps view by inheriting
-        the google_map.add_place.mixin into crm.lead.
+CRM - Google Maps: Add Lead from Map Click
+==========================================
 
-        When zoomed in sufficiently (zoom >= 15), clicking a named Google Place fetches its
-        details (place name, address, phone, website, coordinates) via the Places API and
-        opens a pre-populated quick-create form for a new lead. The place display name is
-        automatically used to set the opportunity name (e.g. "Acme Corp's opportunity").
-        Clicking empty map space performs a reverse geocode and pre-populates the form with
-        the resolved address and coordinates.
+Extends the CRM Google Maps view with a click-to-create workflow for leads.
 
-        Field mapping is adapted for crm.lead: place name populates contact_name,
-        coordinates map to customer_latitude/customer_longitude, and all standard address
-        fields (street, city, zip, state, country) are pre-filled. Duplicate detection
-        by Google Place ID is inherited from the base mixin.
-    """,
+Provides:
+
+- ``crm.lead`` inherits ``google_map.add_place.mixin``, activating the click-to-create server-side methods for the CRM Lead model
+- CRM-specific field mapping: place name → ``contact_name``, coordinates → ``customer_latitude`` / ``customer_longitude``, all address fields pre-filled
+- ``action_in_map_google_place_create`` override that automatically sets the lead ``name`` to "<Place Name>'s opportunity" when creating from a named place
+- Patches the CRM map renderer to include the ``InMapClickAddPlace`` component: clicking a named Google Place opens a pre-populated lead form; clicking empty map space reverse-geocodes the coordinate and pre-fills the form with the address
+- Duplicate detection: if a lead with the same Google Place ID already exists, that record opens instead of creating a new one
+- ``gplace_id`` stored on each lead created from a named Google Place
+- Visual indicator in the map's top-right corner with one-click zoom shortcut
+- Map view reloads automatically after save with a notification linking to the new lead
+""",
     "license": "LGPL-3",
     "author": "Yopi Angi",
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Tools",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "depends": [
         "web_view_google_map",
         "base_google_map_add_place",
         "crm_google_map",
     ],
-    "data": [],
     "assets": {
         "web.assets_backend": [
-            "crm_google_map_add_place/static/src/views/**/*",
-        ]
+            "crm_google_map_add_place/static/src/views/google_map/google_map_renderer.js",
+            "crm_google_map_add_place/static/src/views/google_map/google_map_renderer.xml",
+        ],
     },
-    "demo": [],
     "installable": True,
     "application": False,
     "auto_install": False,

--- a/crm_google_map_add_place/i18n/crm_google_map_add_place.pot
+++ b/crm_google_map_add_place/i18n/crm_google_map_add_place.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-28 04:42+0000\n"
-"PO-Revision-Date: 2026-03-28 04:42+0000\n"
+"POT-Creation-Date: 2026-06-17 11:06+0000\n"
+"PO-Revision-Date: 2026-06-17 11:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,11 +19,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/crm_google_map_add_place/models/crm_lead.py:0
 msgid "%s's opportunity"
-msgstr ""
-
-#. module: crm_google_map_add_place
-#: model:ir.model,website_form_label:crm_google_map_add_place.model_crm_lead
-msgid "Create an Opportunity"
 msgstr ""
 
 #. module: crm_google_map_add_place


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting the crm.lead mixin inheritance, CRM-specific field mapping, auto-generated opportunity name override, InMapClickAddPlace component patch, duplicate detection, gplace_id storage, visual indicator, and post-save reload
- Replace wildcard asset glob with explicit file entries; remove empty data: [] and demo: [] entries
- Regenerate POT: update creation/revision dates; remove stale "Create an Opportunity" website_form_label entry