### PR TITLE
[IMP] partner_autocomplete_with_google_autocomplete: improve manifest, explicit assets, clean up POT (v1.0.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Activates click-to-create on the Contacts map view. Clicking a named Google Plac
 
 Applies `gplace_autocomplete_el` to the Contact form's name field (`places` mode) and street field (`address` mode). Populates address fields and coordinates on selection. Mapping configurations for `res.partner` are created automatically on installation.
 
-**[partner_autocomplete_with_google_autocomplete](partner_autocomplete_with_google_autocomplete/README.md)** `19.0.1.0.4`
+**[partner_autocomplete_with_google_autocomplete](partner_autocomplete_with_google_autocomplete/README.md)** `19.0.1.0.5`
 
 Combines Odoo's built-in partner autocomplete with a Google Places toggle panel on the Contact name field, applied to all `res.partner` form views automatically via `_get_view()` — no XML changes required. The Odoo partner autocomplete remains available on the same input.
 

--- a/partner_autocomplete_with_google_autocomplete/CHANGELOG.md
+++ b/partner_autocomplete_with_google_autocomplete/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 19.0.1.0.5
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit ordered file entries; removed empty `data` and `demo` keys
+- **i18n**: Regenerated POT — updated dates; removed stale `"Create a Customer"` website form label entry
+
 ## 19.0.1.0.4
 
 - [Improved] **Google Maps Context Flag**: `record.update()` in `_handlePlaceSelect` is now wrapped with `record.context.is_from_google_maps = true` set before the call and cleaned up in a `finally` block after; downstream field handlers and computed triggers can use this flag to detect that the update originated from a Google Places selection

--- a/partner_autocomplete_with_google_autocomplete/__manifest__.py
+++ b/partner_autocomplete_with_google_autocomplete/__manifest__.py
@@ -1,26 +1,36 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Partner Autocomplete with Google Autocomplete',
-    'summary': '''
-        Add Google Place Autocomplete to partner form
-    ''',
-    'description': '''
-        Implementation of Google Autocomplete Element through widget
-    ''',
+    'summary': 'Combines Odoo partner autocomplete with a Google Places panel on the Contact name field',
+    'description': """
+Partner Autocomplete with Google Autocomplete
+=============================================
+
+Extends Odoo's built-in partner autocomplete on ``res.partner`` with a
+side-by-side Google Places autocomplete panel.
+
+Provides:
+
+- ``_get_view()`` override on ``res.partner`` that automatically applies the combined widget to every ``name`` field on all partner form views — no per-module view XML changes required
+- ``field_partner_autocomplete_with_google_place`` field widget extending ``PartnerAutoCompleteCharField`` with a collapsible Google Places panel triggered by a toggle button; mapping config is fetched lazily on first open
+- Atomic ``record.update()`` combining address components, place details (phone, website — places mode only), and geolocation in a single write
+- ``no_manual_edit`` widget option that sets the name input to read-only, enforcing selection via autocomplete rather than free-text entry
+- Mapping configuration validation on panel open with user-visible warnings when the config is missing or the mapping mode is invalid
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.4',
+    'version': '1.0.5',
     'depends': ['partner_autocomplete', 'contacts_google_autocomplete'],
     'assets': {
         'web.assets_backend': [
-            'partner_autocomplete_with_google_autocomplete/static/src/js/*',
+            'partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.scss',
+            'partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.js',
+            'partner_autocomplete_with_google_autocomplete/static/src/js/partner_autocomplete_with_google_place.xml',
         ],
     },
-    'data': [],
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/partner_autocomplete_with_google_autocomplete/i18n/partner_autocomplete_with_google_autocomplete.pot
+++ b/partner_autocomplete_with_google_autocomplete/i18n/partner_autocomplete_with_google_autocomplete.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-04 09:24+0000\n"
-"PO-Revision-Date: 2026-03-04 09:24+0000\n"
+"POT-Creation-Date: 2026-06-17 11:07+0000\n"
+"PO-Revision-Date: 2026-06-17 11:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,11 +18,6 @@ msgstr ""
 #. module: partner_autocomplete_with_google_autocomplete
 #: model:ir.model,name:partner_autocomplete_with_google_autocomplete.model_res_partner
 msgid "Contact"
-msgstr ""
-
-#. module: partner_autocomplete_with_google_autocomplete
-#: model:ir.model,website_form_label:partner_autocomplete_with_google_autocomplete.model_res_partner
-msgid "Create a Customer"
 msgstr ""
 
 #. module: partner_autocomplete_with_google_autocomplete


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting the _get_view() override, the combined widget with collapsible Google Places panel, atomic record.update() write, no_manual_edit option, and mapping config validation with user warnings
- Replace wildcard asset glob with explicit ordered file entries; remove empty data: [] and demo: [] entries
- Regenerate POT: update creation/revision dates; remove stale "Create a Customer" website_form_label entry