### PR TITLE
[IMP] project_google_map: improve manifest, explicit assets, and regenerate POT (v1.0.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Adds a Google Map view across Deliveries, Ready to Transfer, Waiting Transfer, L
 
 ### Project
 
-**[project_google_map](project_google_map/README.md)** `19.0.1.0.3`
+**[project_google_map](project_google_map/README.md)** `19.0.1.0.4`
 
 Adds a Google Map view for Projects and Tasks. Project markers show task counts and completion statistics; a satellite site map is embedded on the project form. Task maps are scoped per project. Status color-coding (on track, at risk, off track, on hold, done) is configurable per project.
 

--- a/project_google_map/CHANGELOG.md
+++ b/project_google_map/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.0.4
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit ordered file entries; removed empty `demo` key
+- **i18n**: Regenerated POT — updated dates; removed stale `"Create a Customer"` and `"Create a Task"` website form label entries; added task quick-entry keyword help text string
+
 ## 1.0.3
 
 ### Fixed

--- a/project_google_map/__manifest__.py
+++ b/project_google_map/__manifest__.py
@@ -1,20 +1,29 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Project Google Maps',
-    'summary': 'Display and navigate projects on an interactive Google Maps view',
-    'description': '''
-        Adds a Google Maps view to the Project module, allowing you to
-        visualize project locations on an interactive map. Each project
-        is shown as a marker based on its site coordinates. A sidebar
-        lists all projects alongside the map, and a "View Tasks" button
-        on each project opens the related task list directly from the map.
-    ''',
+    'summary': 'Google Maps views for Projects and Tasks with site addresses and status-colored markers',
+    'description': """
+Project Google Maps
+===================
+
+Adds Google Maps views to both the Project and Task lists in Odoo's Project
+application.
+
+Provides:
+
+- ``partner_site_id`` (Many2one to ``res.partner``), ``site_latitude``, and ``site_longitude`` fields on both ``project.project`` and ``project.task``
+- ``marker_color`` computed on ``project.project`` — derives a hex color from ``last_update_status``: green (on track), orange (at risk), red (off track), cyan (on hold), purple (done), gray (no status)
+- ``marker_color`` Integer field on ``project.task`` with a color picker widget for per-task marker customization
+- New ``site`` partner type on ``res.partner`` with a dedicated site icon as the avatar placeholder, keeping site addresses separate from contacts
+- ``post_init_hook``: adds the ``google_map`` view mode to 4 project actions (All Projects, All Projects by Stage, Configuration, Configuration by Stage) and 1 task action; ``uninstall_hook`` removes them cleanly on uninstall
+- Sidebar listing projects or tasks alongside the map; a "View Tasks" button in each project marker opens the filtered task list directly from the map
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Project',
-    'version': '1.0.3',
+    'version': '1.0.4',
     'depends': [
         'project',
         'web_view_google_map',
@@ -26,10 +35,13 @@
     ],
     'assets': {
         'web.assets_backend': [
-            'project_google_map/static/src/views/**/*',
+            'project_google_map/static/src/views/google_map/google_map_sidebar.js',
+            'project_google_map/static/src/views/google_map/google_map_sidebar.xml',
+            'project_google_map/static/src/views/google_map/google_map_renderer.js',
+            'project_google_map/static/src/views/google_map/google_map_renderer.xml',
+            'project_google_map/static/src/views/google_map/google_map_view.js',
         ],
     },
-    'demo': [],
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'installable': True,

--- a/project_google_map/i18n/project_google_map.pot
+++ b/project_google_map/i18n/project_google_map.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-07 14:47+0000\n"
-"PO-Revision-Date: 2026-04-07 14:47+0000\n"
+"POT-Creation-Date: 2026-06-17 11:08+0000\n"
+"PO-Revision-Date: 2026-06-17 11:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -30,16 +30,6 @@ msgstr ""
 #. module: project_google_map
 #: model:ir.model,name:project_google_map.model_res_partner
 msgid "Contact"
-msgstr ""
-
-#. module: project_google_map
-#: model:ir.model,website_form_label:project_google_map.model_res_partner
-msgid "Create a Customer"
-msgstr ""
-
-#. module: project_google_map
-#: model:ir.model,website_form_label:project_google_map.model_project_task
-msgid "Create a Task"
 msgstr ""
 
 #. module: project_google_map
@@ -127,6 +117,20 @@ msgstr ""
 #. module: project_google_map
 #: model_terms:ir.ui.view,arch_db:project_google_map.view_project_task_google_map
 msgid "Task Sites"
+msgstr ""
+
+#. module: project_google_map
+#: model:ir.model.fields,help:project_google_map.field_project_task__display_name
+msgid ""
+"Use these keywords in the title to set new tasks:\n"
+"\n"
+"            #tags Set tags on the task\n"
+"            @user Assign the task to a user\n"
+"            ! Set the task a medium priority\n"
+"            !! Set the task a high priority\n"
+"            !!! Set the task a urgent priority\n"
+"\n"
+"            Make sure to use the right format and order e.g. Improve the configuration screen #feature #v16 @Mitchell !"
 msgstr ""
 
 #. module: project_google_map


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting the site partner fields, marker_color computed on project status, per-task color picker, new "site" partner type, post/uninstall hooks for view mode injection, and the "View Tasks" button in project markers
- Replace wildcard asset glob with explicit ordered file entries; remove empty demo: []
- Regenerate POT: update creation/revision dates; remove stale website_form_label entries for "Create a Customer" and "Create a Task"; add new display_name help text string for task quick-entry keywords