### PR TITLE
[IMP] sale_google_map: improve manifest, explicit assets, update README, and regenerate POT (v1.0.13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Applies `gplace_autocomplete_el` to the Lead/Opportunity form's company name fie
 
 ### Sales
 
-**[sale_google_map](sale_google_map/README.md)** `19.0.1.0.12`
+**[sale_google_map](sale_google_map/README.md)** `19.0.1.0.13`
 
 Adds a Google Map view to Quotations, Orders, Orders to Invoice, Orders to Upsell, and Customers in Sales. Groups records by customer — one marker per customer — showing avatar, name, order count, and aggregated order total. Enforces grouping and auto-loads all groups on open.
 

--- a/sale_google_map/CHANGELOG.md
+++ b/sale_google_map/CHANGELOG.md
@@ -1,6 +1,14 @@
 <!-- markdownlint-disable MD024 -->
 # Change Log
 
+## 19.0.1.0.13
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit ordered file entries; removed empty `demo` key
+- **README**: Clarified that the sidebar arrow button pans to the marker (not opens orders), and that the open action is only on markers
+- **i18n**: Regenerated POT — updated dates; added new strings (`"Avatar"`, `"Customer"`, `"Find nearby records"`, `"Invalid Data"`, `"Logo"`, `"Nearby"`, `"No records available…"`, `"Open"`, no-grouping guidance notification); removed stale `"Complete Address"` field entry
+
 ## 19.0.1.0.12
 
 ### Fixed

--- a/sale_google_map/README.md
+++ b/sale_google_map/README.md
@@ -6,12 +6,12 @@
 
 ## What It Does
 
-Adds a "Map" view button to the Quotations, Orders, Orders to Invoice, Orders to Upsell, and Customers lists. Each customer with geolocated records appears as a single marker on the map. Clicking the marker or the sidebar entry lets you open the related orders or find other nearby customers.
+Adds a "Map" view button to the Quotations, Orders, Orders to Invoice, Orders to Upsell, and Customers lists. Each customer with geolocated records appears as a single marker on the map. Clicking a marker's arrow button opens the related orders for that customer. Clicking a sidebar entry pans the map to that customer's marker; the location-arrow button on markers and sidebar entries finds nearby customers.
 
 ## Key Features
 
 - **Customer-Grouped Markers**: One marker per customer — shows their name, total order value, and avatar
-- **"Open" Action**: Click the arrow button on a marker or sidebar entry to open all orders for that customer
+- **"Open" Action**: Click the arrow button on a marker to open all orders for that customer
 - **"Find Nearby" Action**: Click the location-arrow button on a marker or sidebar to search for nearby customers
 - **Sidebar with Totals**: Left-hand panel lists all customers with their avatar and aggregated order total
 - **Automatic Group Loading**: Groups are expanded automatically when the map loads so all markers appear without manual interaction

--- a/sale_google_map/__manifest__.py
+++ b/sale_google_map/__manifest__.py
@@ -1,37 +1,43 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Sales Google Maps',
-    'summary': 'Visualize sale orders and customers on an interactive Google Maps view',
+    'summary': 'Google Maps view for Sales Orders grouped by customer with totals and nearby search',
     'description': """
 Sales Google Maps
 =================
-Adds a Google Maps view to Sale Orders and Quotations, grouping orders by customer
-and placing each customer as a marker on the map.
 
-Key features:
-- Interactive map view available on Quotations, Orders, Orders to Invoice, and Orders to Upsell
-- Markers show customer name and aggregated order total at a glance
-- Click a marker to open the customer's sale orders in a list
-- "Find Nearby" button on each marker to locate other customers in the area
-- Partner avatar displayed on each marker for quick visual identification
-- Sidebar listing all customers with totals, synced with the map
+Adds a customer-grouped Google Maps view to Quotations, Orders, Orders to Invoice,
+Orders to Upsell, and the Customers list.
 
-Requires a Google API Key configured in Settings → General Settings → Google Maps.
-    """,
+Provides:
+
+- ``partner_latitude`` and ``partner_longitude`` stored related Float fields on ``sale.order``, proxying the customer partner's geolocation so orders can be placed on the map without a separate geocoding step
+- One ``AdvancedMarkerElement`` per customer group showing the customer name, order count, aggregated ``amount_total``, and ``avatar_128``
+- Overlap-offset detection: same-address customers are shifted apart; the shifted marker displays an info indicator with a tooltip explaining the adjustment
+- Marker hover animation (``mouseenter`` / ``touchstart``) that lifts and glows the marker; auto-triggered for 1 s after the map pans to a marker via the sidebar
+- Grouped-only enforcement: if no group-by is active the map renders no markers and a notification guides the user to apply one
+- Automatic group loading via ``openGroupsByDefault`` so all markers are visible on first render without manual group expansion
+- Sidebar listing every customer group with avatar, name, and aggregated total; clicking a row pans and zooms the map to that customer's marker
+- Arrow (→) button on each marker and sidebar entry opens the filtered order list for that customer; location-arrow button triggers nearby-customer search
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/Sales',
-    'version': '1.0.12',
+    'version': '1.0.13',
     'depends': ['sale_management', 'web_view_google_map'],
     'data': ['views/sale_order.xml', 'views/res_partner.xml'],
     'assets': {
         'web.assets_backend': [
-            'sale_google_map/static/src/views/**/*',
-        ]
+            'sale_google_map/static/src/views/google_map/google_map_view.scss',
+            'sale_google_map/static/src/views/google_map/google_map_sidebar.js',
+            'sale_google_map/static/src/views/google_map/google_map_sidebar.xml',
+            'sale_google_map/static/src/views/google_map/google_map_renderer.js',
+            'sale_google_map/static/src/views/google_map/google_map_controller.js',
+            'sale_google_map/static/src/views/google_map/google_map_view.js',
+        ],
     },
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/sale_google_map/i18n/sale_google_map.pot
+++ b/sale_google_map/i18n/sale_google_map.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-27 10:48+0000\n"
-"PO-Revision-Date: 2025-10-27 10:48+0000\n"
+"POT-Creation-Date: 2026-06-17 11:09+0000\n"
+"PO-Revision-Date: 2026-06-17 11:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,15 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_google_map
-#: model:ir.model.fields,field_description:sale_google_map.field_sale_order__partner_contact_address
-msgid "Complete Address"
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_sidebar.xml:0
+msgid "Avatar"
+msgstr ""
+
+#. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid "Customer"
 msgstr ""
 
 #. module: sale_google_map
@@ -26,8 +33,20 @@ msgid "Display Name"
 msgstr ""
 
 #. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid "Find nearby records"
+msgstr ""
+
+#. module: sale_google_map
 #: model:ir.model.fields,field_description:sale_google_map.field_sale_order__id
 msgid "ID"
+msgstr ""
+
+#. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid "Invalid Data"
 msgstr ""
 
 #. module: sale_google_map
@@ -36,8 +55,32 @@ msgid "Latitude"
 msgstr ""
 
 #. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid "Logo"
+msgstr ""
+
+#. module: sale_google_map
 #: model:ir.model.fields,field_description:sale_google_map.field_sale_order__partner_longitude
 msgid "Longitude"
+msgstr ""
+
+#. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_sidebar.xml:0
+msgid "Nearby"
+msgstr ""
+
+#. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid "No records available in this group to find nearby records."
+msgstr ""
+
+#. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid "Open"
 msgstr ""
 
 #. module: sale_google_map
@@ -53,6 +96,14 @@ msgstr ""
 #. module: sale_google_map
 #: model_terms:ir.ui.view,arch_db:sale_google_map.view_sale_order_upselling_google_map
 msgid "Orders to Upsell"
+msgstr ""
+
+#. module: sale_google_map
+#. odoo-javascript
+#: code:addons/sale_google_map/static/src/views/google_map/google_map_renderer.js:0
+msgid ""
+"Please group the records to display markers on the map. The Google Maps view"
+" is designed to load grouped data"
 msgstr ""
 
 #. module: sale_google_map


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting the related partner geolocation fields, per-customer marker with overlap-offset detection, hover animation, grouped-only enforcement, automatic group loading, sidebar pan-on-click behavior, and open/nearby actions
- Replace wildcard asset glob with explicit ordered file entries; remove empty demo: []
- Update README to clarify that the sidebar arrow button pans to a marker and the open action is only on markers (not sidebar entries)
- Regenerate POT: update creation/revision dates; add new translatable strings for "Avatar", "Customer", "Find nearby records", "Invalid Data", "Logo", "Nearby", "No records available…", "Open", and the no-grouping guidance notification; remove stale "Complete Address" field entry