### PR TITLE
[IMP] stock_google_map: improve manifest description, fix category, and bump version (v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Adds a Google Map view to Quotations, Orders, Orders to Invoice, Orders to Upsel
 
 ### Inventory
 
-**[stock_google_map](stock_google_map/README.md)** `19.0.1.0.0`
+**[stock_google_map](stock_google_map/README.md)** `19.0.1.0.1`
 
 Adds a Google Map view across Deliveries, Ready to Transfer, Waiting Transfer, Late Transfers, Backorders, and All Operations in Inventory. Each picking appears as a teal marker at the delivery partner's address, with coordinates sourced automatically from the linked partner.
 

--- a/stock_google_map/CHANGELOG.md
+++ b/stock_google_map/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change Log
 
+## 19.0.1.0.1
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; fixed module category from `'Hidden'` to `'Inventory'`; removed empty `demo` key
+
 ## 19.0.1.0.0
 Migration to version 19.0

--- a/stock_google_map/__manifest__.py
+++ b/stock_google_map/__manifest__.py
@@ -1,17 +1,28 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Delivery Google Maps',
-    'summary': 'Show your Delivery on Google Maps',
-    'description': '',
+    'summary': 'Google Maps view for Delivery Orders and stock pickings plotted by delivery address',
+    'description': """
+Delivery Google Maps
+====================
+
+Adds a Google Maps view to Delivery Orders and other stock picking lists
+in Odoo's Inventory application.
+
+Provides:
+
+- ``partner_latitude``, ``partner_longitude``, and ``partner_contact_address`` related fields on ``stock.picking``, proxying the delivery partner's geolocation and formatted address
+- ``google_map`` view for ``stock.picking`` with teal markers, sidebar title set to picking reference (``name``), and sidebar subtitle set to the delivery contact address (``partner_contact_address``)
+- Map view added to 6 Inventory actions: Deliveries, Ready to Transfer, All Operations, Waiting Transfer, Late Transfers, and Backorders
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
-    'category': 'Hidden',
-    'version': '1.0.0',
+    'category': 'Inventory',
+    'version': '1.0.1',
     'depends': ['sale_stock', 'stock_delivery', 'web_view_google_map'],
     'data': ['views/stock_picking.xml'],
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting the related geolocation fields on stock.picking, the teal marker configuration, and the 6 Inventory actions that receive the map view
- Fix module category from 'Hidden' to 'Inventory'
- Remove empty demo: [] entry