### PR TITLE
[IMP] web_view_google_map_drawing: improve manifest, explicit assets, fix author, and regenerate POT (v1.0.21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Root configuration module. Adds a Google Maps section to General Settings for AP
 
 Registers `google_map` as a valid Odoo view type. Provides the full map view stack — controller, model, renderer, sidebar, and search bar — with marker clustering, overlap handling, multi-selection box select, nearby records search, in-map place search, geolocation button, grouped markers, and dark mode support.
 
-**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** `19.0.1.0.20`
+**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** `19.0.1.0.21`
 
 Extends the map view with geographic shape drawing using [Terra Draw](https://terradraw.io/) (Google's recommended replacement for the deprecated Maps Drawing Library) for editing and [Deck.gl](https://deck.gl/) for GPU-accelerated rendering of large datasets. Includes a `google.drawing.shape` mixin and GeoJSON field type with server-side filtering. All libraries bundled locally.
 

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 19.0.1.0.21
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced all wildcard asset globs with explicit ordered file entries; removed empty `data` and `demo` keys
+- **i18n**: Regenerated POT — updated dates; added a large set of new strings covering geometry limit warnings, Terra Draw UI labels (`"Upload GeoJSON"`, `"Download GeoJSON"`, `"Export GeoJSON"`, `"Undo completed"`, `"Redo completed"`), GeoJSON import/export dialogs (`UploadGeoJSONDialog`), Deck.gl renderer labels (`"Area"`, `"Length"`, `"Perimeter"`, `"Total Area"`, `"Points"`), measurement error messages, simplification prompts, and file validation errors; removed stale `"Readonly Mode:"` and `"Features contain polygons with holes…"` strings; updated `"Failed to initialize %s drawing mode"` argument order
+
 ## 19.0.1.0.20
 
 ### Updated Dependencies

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -1,31 +1,66 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Web View Google Map Drawing',
-    'summary': '''
-        Present your geographical data in a new view "Google Maps"
-    ''',
-    'description': '''
-        A view that allows you to add Google Maps in Odoo and gives a
-        possibility to see your geographical data in Google maps without
-        leaving Odoo
-    ''',
+    'summary': 'Extends the Google Map view with Terra Draw shape editing, Deck.gl rendering, and GeoJSON storage',
+    'description': """
+Web View Google Map Drawing
+============================
+
+Adds geographic shape drawing, editing, and storage to the Google Maps view.
+
+Provides:
+
+- ``SearchableJson`` field type extending Odoo's ``fields.Json`` with four JSONB-backed operators: ``json_eq``, ``json_ne``, ``json_contains``, ``json_not_contains``; ``JsonValue`` / ``JsonContainsValue`` wrapper types make values hashable for Odoo's ``OrderedSet`` domain optimizer
+- ``google.drawing.shape`` abstract mixin adding ``gshape_name``, ``gshape_description``, ``gshape_geojson`` (``SearchableJson``), ``gshape_area``, and ``gshape_color`` to any model with a single ``_inherit`` declaration
+- View validation override: ``geojson`` attribute required for ``js_class="google_map_drawing"`` views; warns if ``lat`` / ``lng`` are also set
+- ``google_map_terra_draw`` OWL widget wrapping Terra Draw + Google Maps Adapter with 7 drawing modes: Point, LineString, Polygon, Rectangle, Circle, Freehand, and Select
+- Smart rendering: automatically switches between Terra Draw (editable) and Deck.gl (GPU-accelerated, read-only) based on four thresholds — polygons with interior rings, 3D coordinates, ≥ 3 000 features, or ≥ 5 000 vertices
+- Real-time area and perimeter measurements via Turf.js in metric or imperial units; ``field_area`` widget option writes the value back to a Float field on save
+- GeoJSON import (up to 5 MB) and export; Terra Draw metadata stripped on export for clean standard output
+- Douglas-Peucker geometry simplification (``Ctrl+E``) to bring complex imported shapes within editing limits
+- Full undo/redo session history
+- ``google_map_drawing`` view variant activated via ``js_class="google_map_drawing"`` on a ``<google_map>`` arch element
+- ``google_map_drawing_one2many`` and ``google_map_drawing_many2many`` field widgets for embedding the drawing canvas in form views
+- All three libraries (Terra Draw v1.31.1, Terra Draw Google Maps Adapter v1.6.1, Deck.gl v9.3.4, Turf.js v7.3.5) bundled locally as static assets and loaded on-demand via ``loadJS`` — no external CDN required
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://www.mithnusa.com',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.20',
+    'version': '1.0.21',
     'depends': ['web_view_google_map'],
-    'data': [],
     'assets': {
         'web.assets_backend': [
-            'web_view_google_map_drawing/static/src/utils/**/*',
-            'web_view_google_map_drawing/static/src/views/**/*',
-            'web_view_google_map_drawing/static/src/fields/**/*',
-            'web_view_google_map_drawing/static/src/widget/**/*',
-        ]
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_view.scss',
+            'web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.scss',
+            'web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.scss',
+            'web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.scss',
+            'web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.scss',
+            'web_view_google_map_drawing/static/src/fields/x2many/google_map_drawing_x2many_field.scss',
+            'web_view_google_map_drawing/static/src/utils/geometry_performance_utils.js',
+            'web_view_google_map_drawing/static/src/utils/map_config.js',
+            'web_view_google_map_drawing/static/src/utils/utils.js',
+            'web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js',
+            'web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml',
+            'web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js',
+            'web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.xml',
+            'web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js',
+            'web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml',
+            'web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.js',
+            'web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.xml',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_arch_parser.js',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_model.js',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.js',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_sidebar.xml',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.xml',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_controller.js',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_controller.xml',
+            'web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_view.js',
+            'web_view_google_map_drawing/static/src/fields/x2many/google_map_drawing_x2many_field.js',
+        ],
     },
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/web_view_google_map_drawing/i18n/web_view_google_map_drawing.pot
+++ b/web_view_google_map_drawing/i18n/web_view_google_map_drawing.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-27 10:49+0000\n"
-"PO-Revision-Date: 2025-10-27 10:49+0000\n"
+"POT-Creation-Date: 2026-06-17 11:11+0000\n"
+"PO-Revision-Date: 2026-06-17 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,11 +17,53 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/utils/geometry_performance_utils.js:0
+msgid "%s features exceeds limit of %s"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/utils/geometry_performance_utils.js:0
+msgid "%s points exceeds limit of %s"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/utils/geometry_performance_utils.js:0
+msgid "%s total vertices exceeds limit of %s"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml:0
+msgid ""
+"*Features containing complex geometry (polygon with holes or 3D coordinates)"
+" are not supported for editing."
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
 msgid "All features cleared"
 msgstr ""
 
 #. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.xml:0
+msgid ""
+"Any existing drawn features will be removed when importing a new GeoJSON "
+"file"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.js:0
+msgid "Apply"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
 #: model:ir.model.fields,field_description:web_view_google_map_drawing.field_google_drawing_shape__gshape_area
 msgid "Area"
 msgstr ""
@@ -32,6 +74,12 @@ msgstr ""
 msgid ""
 "Attributes \"lat\" and \"lng\" should not be set when using \"drawing\" "
 "js_class in google_map view"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.xml:0
+msgid "Calculate Area"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -109,8 +157,20 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml:0
+msgid "Download GeoJSON"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
 msgid "Error"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
+msgid "Error calculating measurements"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -129,8 +189,20 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.xml:0
+msgid "Export GeoJSON"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/utils/geometry_performance_utils.js:0
 msgid "Extremely Complex Feature"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+msgid "Failed to calculate area."
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -147,8 +219,9 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
-msgid "Failed to initialize %s drawing mode"
+msgid "Failed to export GeoJSON file."
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -157,6 +230,12 @@ msgstr ""
 msgid ""
 "Failed to initialize Terra Draw. Please check javascript console for more "
 "information"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "Failed to initialize drawing mode %s"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -170,9 +249,7 @@ msgstr ""
 #. module: web_view_google_map_drawing
 #. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
-msgid ""
-"Failed to load Deck.gl assets. Please check javascript console for more "
-"information"
+msgid "Failed to load Deck.gl assets. Please refresh the page and try again."
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -187,6 +264,26 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
 msgid "Failed to load existing features"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "Failed to parse the imported GeoJSON file."
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "Failed to read the imported GeoJSON file."
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.js:0
+msgid "Failed to save area calculation"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -256,19 +353,17 @@ msgid ""
 msgstr ""
 
 #. module: web_view_google_map_drawing
-#. odoo-javascript
-#: code:addons/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml:0
-msgid ""
-"Features contain polygons with holes (interior rings) which are not "
-"supported for editing."
-msgstr ""
-
-#. module: web_view_google_map_drawing
 #. odoo-python
 #: code:addons/web_view_google_map_drawing/models/ir_ui_view.py:0
 msgid ""
 "Field %(name)s assigned to attribute \"geojson\" does not exist. All fields "
 "used in google_map view attribute must be loaded"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.js:0
+msgid "File size exceeds the maximum allowed size of 5MB"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -282,6 +377,20 @@ msgstr ""
 #: code:addons/contacts_area/static/src/views/google_map_drawing_controller.xml:0
 #: code:addons/web_view_google_map_drawing/example/contacts_area/static/src/views/google_map_drawing_controller.xml:0
 msgid "GeoJSON"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "GeoJSON exported successfully."
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "GeoJSON file imported successfully."
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -331,7 +440,14 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/contacts_area/static/src/views/google_map_drawing_controller.js:0
 #: code:addons/web_view_google_map_drawing/example/contacts_area/static/src/views/google_map_drawing_controller.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.xml:0
 msgid "Import GeoJSON"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.js:0
+msgid "Import GeoJSON File"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -357,14 +473,38 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.js:0
+msgid "Invalid file type. Please upload a valid GeoJSON file."
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
 msgid "Last feature deleted"
 msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
+msgid "Length"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml:0
 msgid "Linestring"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.xml:0
+msgid "Maximum file size: 5 MB"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
+msgid "Measurements not available for this geometry type"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -379,6 +519,19 @@ msgid "Name"
 msgstr ""
 
 #. module: web_view_google_map_drawing
+#. odoo-python
+#: code:addons/web_view_google_map_drawing/models/google_drawing_shape.py:0
+msgid "New Shape"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "No data available to export."
+msgstr ""
+
+#. module: web_view_google_map_drawing
 #. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
 msgid "No feature selected for simplification"
@@ -386,8 +539,27 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+msgid "No features available to calculate area."
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
 msgid "No features to delete"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "No file was uploaded."
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+msgid "No polygon features available to calculate area."
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -409,6 +581,12 @@ msgid "Nothing to undo"
 msgstr ""
 
 #. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
+msgid "Perimeter"
+msgstr ""
+
+#. module: web_view_google_map_drawing
 #. odoo-python
 #: code:addons/contacts_area/wizard/geojson_upload_wizard.py:0
 #: code:addons/web_view_google_map_drawing/example/contacts_area/wizard/geojson_upload_wizard.py:0
@@ -417,20 +595,27 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/upload_geojson_dialog/upload_geojson_dialog.js:0
+msgid "Please upload your GeoJSON file"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml:0
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
 msgid "Point"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
+msgid "Points"
 msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml:0
 msgid "Polygon"
-msgstr ""
-
-#. module: web_view_google_map_drawing
-#. odoo-javascript
-#: code:addons/web_view_google_map_drawing/static/src/widget/terra_draw/terra_draw.xml:0
-msgid "Readonly Mode:"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -443,6 +628,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml:0
 msgid "Redo"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "Redo completed"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -542,12 +733,19 @@ msgid ""
 msgstr ""
 
 #. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/deck-gl-editor/deck-gl-editor.js:0
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "The imported file is not a valid GeoJSON."
+msgstr ""
+
+#. module: web_view_google_map_drawing
 #. odoo-python
 #: code:addons/contacts_area/wizard/geojson_upload_wizard.py:0
 #: code:addons/web_view_google_map_drawing/example/contacts_area/wizard/geojson_upload_wizard.py:0
 msgid ""
 "The specified feature name source \"%s\" does not exist in feature "
-"properties."
+"properties. Please close the pop-up window and try again"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -580,8 +778,20 @@ msgstr ""
 
 #. module: web_view_google_map_drawing
 #. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js:0
+msgid "Total Area"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml:0
 msgid "Undo"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
+msgid "Undo completed"
 msgstr ""
 
 #. module: web_view_google_map_drawing
@@ -594,6 +804,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.js:0
 msgid "Unknown Region"
+msgstr ""
+
+#. module: web_view_google_map_drawing
+#. odoo-javascript
+#: code:addons/web_view_google_map_drawing/static/src/views/components/terra-tools-ui/terra-tools-ui.xml:0
+msgid "Upload GeoJSON"
 msgstr ""
 
 #. module: web_view_google_map_drawing

--- a/web_view_google_map_drawing/static/src/utils/utils.js
+++ b/web_view_google_map_drawing/static/src/utils/utils.js
@@ -12,7 +12,7 @@
  * - Area calculation using Turf.js
  * - Measurement formatting
  *
- * @author Yan - https://github.com/yan
+ * @author Yopi Angi - https://github.com/gityopie
  * @version 1.0.0
  */
 


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting SearchableJson field, google.drawing.shape mixin, view validation, the terra_draw widget with 7 drawing modes, smart Terra Draw / Deck.gl switching thresholds, real-time measurements, GeoJSON import/export, Douglas-Peucker simplification, undo/redo, drawing view variant, x2many field widgets, and the fully local-bundled library loading strategy
- Replace all wildcard asset globs with explicit ordered file entries; remove empty data: [] and demo: [] entries
- Regenerate POT: update creation/revision dates; add a large set of new translatable strings covering geometry limit warnings, Terra Draw UI labels, GeoJSON import/export dialogs, Deck.gl renderer labels, measurement units, simplification prompts, and undo/redo notifications