### PR TITLE
[IMP] web_widget_google_map: improve manifest, explicit assets, and regenerate POT (v1.0.5)

### DIFF
--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 19.0.1.0.5
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset glob with explicit ordered file entries; removed empty `data` and `demo` keys
+- **i18n**: Regenerated POT — updated dates; replaced stale `ir.ui.view` model field entries with actual JS translatable strings (`"Drag the marker to update the location"`, `"Failed to initialize Google Map.\n%s"`, `"Failed to load Google Maps API.\n%s"`, `"Save"`)
+
 ## 19.0.1.0.4
 
 ### Improved

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -1,26 +1,36 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Web widget Google Maps',
-    'summary': '''
-        A new widget for Google Maps integration
-    ''',
-    'description': '''
-        A widget that allows you to display Google Maps in form view and be able to edit the geolocation (lat & lng)
-    ''',
+    'summary': 'Google Maps embed widget for form views with an interactive coordinate-edit dialog',
+    'description': """
+Web Widget Google Maps
+======================
+
+Provides a ``google_map`` form widget that embeds a Google Maps preview and
+an interactive coordinate-edit dialog in any Odoo form view.
+
+Provides:
+
+- ``GoogleMapWidget`` registered in the ``view_widgets`` registry as ``google_map``; renders a Google Maps Embed API ``<iframe>`` at the record's current coordinates with configurable ``zoom`` (default 14), ``maptype`` (``roadmap`` / ``satellite``), ``width`` (default 400 px), and ``height`` (default 200 px) XML attributes; falls back to world-level zoom when coordinates are ``(0, 0)``
+- ``GeolocationEditDialog`` extending ``ConfirmationDialog``; initializes a full Google Maps JavaScript API instance via ``useGoogleMapsAPILoader`` and places an ``AdvancedMarkerElement`` with ``gmpDraggable: true`` at the current coordinates; drag-end position is stored locally and written to the record via ``record.update()`` on Save
+- ``GoogleMapSearchPlaces`` component from ``web_view_google_map`` reused inside the dialog for place-autocomplete navigation before marker placement
+- Read-only mode: edit button hidden, dialog marker non-draggable
+- ``lat`` and ``lng`` XML attributes required; validated at component init with a clear error if the referenced fields are missing from the view
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.4',
+    'version': '1.0.5',
     'depends': ['base_google_map', 'web_view_google_map'],
     'assets': {
         'web.assets_backend': [
-            'web_widget_google_map/static/src/widgets/**/*',
+            'web_widget_google_map/static/src/widgets/GoogleMap/google_map.scss',
+            'web_widget_google_map/static/src/widgets/GoogleMap/google_map.js',
+            'web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml',
         ],
     },
-    'data': [],
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/web_widget_google_map/i18n/web_widget_google_map.pot
+++ b/web_widget_google_map/i18n/web_widget_google_map.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-27 10:50+0000\n"
-"PO-Revision-Date: 2025-10-27 10:50+0000\n"
+"POT-Creation-Date: 2026-06-17 11:11+0000\n"
+"PO-Revision-Date: 2026-06-17 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,9 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: web_widget_google_map
-#: model:ir.model.fields,field_description:web_widget_google_map.field_ir_ui_view__display_name
-msgid "Display Name"
+#. odoo-javascript
+#: code:addons/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml:0
+msgid "Drag the marker to update the location"
 msgstr ""
 
 #. module: web_widget_google_map
@@ -33,11 +34,23 @@ msgid "Edit Geolocation"
 msgstr ""
 
 #. module: web_widget_google_map
-#: model:ir.model.fields,field_description:web_widget_google_map.field_ir_ui_view__id
-msgid "ID"
+#. odoo-javascript
+#: code:addons/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js:0
+msgid ""
+"Failed to initialize Google Map.\n"
+"%s"
 msgstr ""
 
 #. module: web_widget_google_map
-#: model:ir.model,name:web_widget_google_map.model_ir_ui_view
-msgid "View"
+#. odoo-javascript
+#: code:addons/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js:0
+msgid ""
+"Failed to load Google Maps API.\n"
+"%s"
+msgstr ""
+
+#. module: web_widget_google_map
+#. odoo-javascript
+#: code:addons/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js:0
+msgid "Save"
 msgstr ""


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting GoogleMapWidget iframe attributes and fallback behavior, GeolocationEditDialog with draggable AdvancedMarkerElement, GoogleMapSearchPlaces reuse inside the dialog, read-only mode handling, and lat/lng field validation
- Replace wildcard asset glob with explicit ordered file entries; remove empty data: [] and demo: [] entries
- Regenerate POT: update creation/revision dates; replace stale ir.ui.view model entries with actual JS translatable strings: "Drag the marker to update the location", "Failed to initialize Google Map.\n%s", "Failed to load Google Maps API.\n%s", and "Save"