### PR TITLE
[IMP] web_widget_google_place_autocomplete: improve manifest, explicit assets, fix field labels (v1.0.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Extends the map view with geographic shape drawing using [Terra Draw](https://te
 
 Provides the `google_map` form widget — an embedded Google Maps iframe showing a record's coordinates, with an edit dialog containing a draggable marker and place search for visually updating the location without leaving the form.
 
-**[web_widget_google_place_autocomplete](web_widget_google_place_autocomplete/README.md)** `19.0.1.0.7`
+**[web_widget_google_place_autocomplete](web_widget_google_place_autocomplete/README.md)** `19.0.1.0.8`
 
 Provides the `gplace_autocomplete_el` widget and the `google.places.mapping` configuration system. Connects Google Places API (New) to any Odoo Char field. Which fields are populated on selection is fully controlled by mapping records — supporting two autocomplete modes, three component handling modes, configurable separators, relational field auto-resolution, and a live built-in test tool.
 

--- a/web_widget_google_place_autocomplete/CHANGELOG.md
+++ b/web_widget_google_place_autocomplete/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 19.0.1.0.8
+
+### Improved
+
+- **Manifest**: Rewrote summary and description; replaced wildcard asset globs with explicit ordered file entries; removed empty `demo` key
+- **`google.places.mapping` — Field Labels**: Renamed both ambiguous `'Fetch Fields'` string labels to `'Google Fields for Place Mode'` and `'Google Fields for Address Mode'` to clearly distinguish the two fetch-field Text fields
+
 ## 19.0.1.0.7
 
 - [Improved] **Google Maps Context Flag**: `record.update()` in `_handlePlaceSelect` is now wrapped with `record.context.is_from_google_maps = true` set before the call and cleaned up in a `finally` block after; downstream field handlers and computed triggers can use this flag to detect that the update originated from a Google Places selection

--- a/web_widget_google_place_autocomplete/__manifest__.py
+++ b/web_widget_google_place_autocomplete/__manifest__.py
@@ -1,24 +1,45 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Web widget Google Place Autocomplete',
-    'summary': '''
-        New widget of Google Place Autcomplete using the NEW Place API
-    ''',
-    'description': '''
-        Implementation of Google Places Autocomplete Element through widget
-    ''',
+    'summary': 'Configurable Google Places autocomplete widget and field mapping system for any Odoo model',
+    'description': """
+Web Widget Google Place Autocomplete
+=====================================
+
+Provides the ``gplace_autocomplete_el`` widget and the ``google.places.mapping``
+configuration system for connecting the Google Places API (New) to any Odoo field.
+
+Provides:
+
+- ``google.places.mapping`` model: unique ``code`` (SQL-unique), ``model_id``, ``mode`` (``places`` / ``address``), optional ``PlaceAutocompleteElement`` options (``gplace_options``), fetch-field lists, ``latitude`` / ``longitude`` Many2one fields pointing to ``ir.model.fields``, ``active``, ``sequence``; ``unlink`` override prevents deletion while the mapping is referenced in views
+- ``google.places.mapping.address.line``: maps a Google address component list to an Odoo field with ``text_option`` (``shortText`` / ``longText``), ``handling_mode`` (``direct`` / ``fallback`` / ``concat``), and ``separator`` (space, comma, hyphen, underscore, slash, new line); SQL-unique per mapping
+- ``google.places.mapping.other.line``: maps a single Google Places property key (e.g. ``displayName``, ``internationalPhoneNumber``) to any stored Odoo field; SQL-unique per mapping
+- ``google_street_format`` selection field on ``res.country`` (``route_street_number`` / ``street_number_route``); used in ``parse_place`` to assemble the street string in the correct order for each country
+- ``parse_place()`` server-side method: resolves address components in country → state → other-relational → text priority order, assembles concatenated / fallback / direct text fields, resolves ``Many2one`` country and state records by name or code, returns a structured dict with ``address``, ``geolocation``, and ``other`` keys ready for ``record.update()``
+- ``get_widget_mapping_by_code()`` and ``get_widget_mapping_by_mode()``: serve the mapping configuration to the frontend, validated against the calling record's model
+- ``useGooglePlaceAutocompleteMapping`` OWL hook: fetches the mapping config from the backend at panel-open time and exposes a shared widget-ID generator
+- ``GooglePlaceAutocompleteElement`` OWL component: wraps Google's ``PlaceAutocompleteElement`` (Places API New) and calls ``parse_place`` on selection, returning structured data to the parent widget
+- ``gplace_autocomplete_el`` widget: extends ``CharField``; accepts ``mapping_code`` (priority) or ``mapping_mode`` as options; ``no_manual_edit`` option makes the input read-only; validates and fetches mapping on panel open; writes all mapped values in a single atomic ``record.update()``
+- ``GooglePlaceMappingTestField`` widget: embeds a live autocomplete test inside the mapping configuration form, showing parsed address, other, geolocation, and raw API JSON for any selected place
+""",
     'license': 'LGPL-3',
     'author': 'Yopi Angi',
     'website': 'https://github.com/mithnusa',
     'support': 'yopiangi@gmail.com',
     'category': 'Extra Tools',
-    'version': '1.0.7',
+    'version': '1.0.8',
     'depends': ['base_google_map'],
     'assets': {
         'web.assets_backend': [
-            'web_widget_google_place_autocomplete/static/src/hooks/*',
-            'web_widget_google_place_autocomplete/static/src/widgets/**/*',
-            'web_widget_google_place_autocomplete/static/src/component/*',
+            'web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.scss',
+            'web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceMappingTest/google_place_mapping_test.scss',
+            'web_widget_google_place_autocomplete/static/src/hooks/use_google_place_autocomplete_mapping.js',
+            'web_widget_google_place_autocomplete/static/src/component/google_place_autocomplete.js',
+            'web_widget_google_place_autocomplete/static/src/component/google_place_autocomplete.xml',
+            'web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.js',
+            'web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceAutocompleteElement/google_place_autocomplete_element.xml',
+            'web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceMappingTest/google_place_mapping_test.js',
+            'web_widget_google_place_autocomplete/static/src/widgets/GooglePlaceMappingTest/google_place_mapping_test.xml',
         ],
     },
     'data': [
@@ -26,7 +47,6 @@
         'views/res_country.xml',
         'views/google_places_mapping_views.xml',
     ],
-    'demo': [],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/web_widget_google_place_autocomplete/models/google_places_mapping.py
+++ b/web_widget_google_place_autocomplete/models/google_places_mapping.py
@@ -134,11 +134,11 @@ class GooglePlacesMapping(models.Model):
         help='PlaceAutocompleteElement options',
     )
     gplace_place_fetch_fields = fields.Text(
-        string='Fetch Fields',
+        string='Google Fields for Place Mode',
         help='PlaceAutocompleteElement options "fields" parameter.',
     )
     gplace_address_fetch_fields = fields.Text(
-        string='Fetch Fields',
+        string='Google Fields for Address Mode',
         help='PlaceAutocompleteElement options "fields" parameter.',
         default="['addressComponents', 'location']",
     )


### PR DESCRIPTION
- Rewrite manifest summary and description with structured bullet-point format documenting all provided components: google.places.mapping and its two child line models, google_street_format country field, parse_place() server method, backend RPC helpers, useGooglePlaceAutocompleteMapping hook, GooglePlaceAutocompleteElement component, gplace_autocomplete_el widget, and the live mapping test widget
- Replace wildcard asset globs with explicit ordered file entries; remove empty demo: []
- Fix ambiguous field labels: rename both 'Fetch Fields' strings to 'Google Fields for Place Mode' and 'Google Fields for Address Mode' to distinguish the two fetch-field Text fields on google.places.mapping