### PR TITLE
[IMP] crm_google_map_add_place: use Odoo 19 translation convention, reformat Python and XML, and clean up manifest (v19.0.1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Enhances the Contact name field with a Google Places panel alongside Odoo's buil
 
 Adds a Google Map view to the CRM application, available in All Leads, My Activities, Opportunities, Pipeline, and Forecast. Each lead appears as a color-coded marker showing stage, address, company, contact, phone, salesperson, expected revenue, win probability, and closing date. Activity scheduling is available directly from each marker's info window. The lead form gains a Geolocation tab with an embedded map preview, a geocode button, and a marker color picker.
 
-**[crm_google_map_add_place](crm_google_map_add_place/README.md)** `19.0.1.0.1`
+**[crm_google_map_add_place](crm_google_map_add_place/README.md)** `19.0.1.0.2`
 
 Enables click-to-create on the CRM map. Clicking a named Google Place opens a new lead form pre-filled with the business name, address, phone, website, and an auto-generated opportunity name. Clicking an empty location reverse-geocodes the coordinate and fills in the address. Duplicate detection prevents creating two leads for the same Google Place.
 

--- a/crm_google_map_add_place/CHANGELOG.md
+++ b/crm_google_map_add_place/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 19.0.1.0.2
+
+### Improved
+
+- **Python — Odoo 19 translations** (`models/crm_lead.py`): Replaced module-level `_()` import with `self.env._()` calls; removed `_` from the `odoo` import.
+- **Python — Black format** (`models/crm_lead.py`): Reformatted long `if` conditions to multi-line style.
+- **XML format** (`google_map_renderer.xml`): Multi-line attribute layout for `<t t-name=...>`; self-closing `<InMapClickAddPlace />`; XML declaration spacing.
+- **Manifest**: Version normalized to `19.0.1.0.2`; removed `installable`, `application`, `auto_install` keys.
+
 ## 1.0.1
 
 ### Improved

--- a/crm_google_map_add_place/__manifest__.py
+++ b/crm_google_map_add_place/__manifest__.py
@@ -24,7 +24,7 @@ Provides:
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Tools",
-    "version": "1.0.1",
+    "version": "19.0.1.0.2",
     "depends": [
         "web_view_google_map",
         "base_google_map_add_place",
@@ -36,7 +36,4 @@ Provides:
             "crm_google_map_add_place/static/src/views/google_map/google_map_renderer.xml",
         ],
     },
-    "installable": True,
-    "application": False,
-    "auto_install": False,
 }

--- a/crm_google_map_add_place/models/crm_lead.py
+++ b/crm_google_map_add_place/models/crm_lead.py
@@ -1,4 +1,5 @@
-from odoo import _, api, models
+from odoo import api, models
+
 
 class CrmLead(models.Model):
     _name = "crm.lead"
@@ -40,11 +41,17 @@ class CrmLead(models.Model):
     def action_in_map_google_place_create(self, place):
         action = super().action_in_map_google_place_create(place)
         # For lead creation, set the opportunity name to "<Place Name>'s opportunity" by default
-        if not action.get("res_id") and action.get("context", {}).get("default_gplace_id"):
+        if not action.get("res_id") and action.get("context", {}).get(
+            "default_gplace_id"
+        ):
             #  Set default name
             place_display_name = place.get("displayName")
             field_name = self._get_mapping_odoo_fields().get("name")
-            if place_display_name and action["context"].get(f"default_{field_name}"):
+            if place_display_name and action["context"].get(
+                f"default_{field_name}"
+            ):
                 name_value = action["context"][f"default_{field_name}"]
-                action["context"]["default_name"] = _("%s's opportunity", name_value)
+                action["context"]["default_name"] = self.env._(
+                    "%s's opportunity", name_value
+                )
         return action

--- a/crm_google_map_add_place/static/src/views/google_map/google_map_renderer.xml
+++ b/crm_google_map_add_place/static/src/views/google_map/google_map_renderer.xml
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-    <t t-name="crm_google_map_add_place.GoogleMapRenderer" t-inherit="web_view_google_map.GoogleMapRenderer" t-inherit-mode="primary">
+    <t
+        t-name="crm_google_map_add_place.GoogleMapRenderer"
+        t-inherit="web_view_google_map.GoogleMapRenderer"
+        t-inherit-mode="primary"
+    >
         <xpath expr="//InMapSearchPlaces" position="after">
-            <InMapClickAddPlace googleMap="googleMap" t-if="state.isMapReady"/>
+            <InMapClickAddPlace googleMap="googleMap" t-if="state.isMapReady" />
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
- Replace module-level `_()` with `self.env._()` in `crm_lead.py`; remove unused `_` from the `odoo` import
- Reformat `crm_lead.py` with Black: expand long `if` conditions and `self.env._()` call to multi-line style; add missing blank lines after imports
- Reformat `google_map_renderer.xml` with Prettier: multi-line `<t t-name=...>` attributes, self-closing `<InMapClickAddPlace />`, space before `?>`
- Remove redundant `installable`, `application`, and `auto_install` keys from `__manifest__.py`