### PR TITLE
[ADD] CI: add Python test coverage workflow and codecov badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,69 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: ["19.0", "19.0-*"]
+  pull_request:
+    branches: ["19.0"]
+
+permissions:
+  contents: read
+  code-quality: write
+
+jobs:
+  coverage:
+    name: Python Test Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libldap2-dev libsasl2-dev libssl-dev
+
+      - name: Clone Odoo 19
+        run: |
+          git clone --depth=1 --branch=19.0 \
+            https://github.com/odoo/odoo.git /opt/odoo
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-odoo19-${{ hashFiles('/opt/odoo/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-odoo19-
+
+      - name: Install Odoo and test dependencies
+        run: |
+          pip install -r /opt/odoo/requirements.txt
+          pip install -e /opt/odoo
+          pip install coverage
+
+      - name: Run tests with coverage
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          ln -sfn "$GITHUB_WORKSPACE/web_view_google_map_drawing" /opt/odoo/odoo/addons/web_view_google_map_drawing
+          python -m coverage run \
+            --source=. \
+            -m unittest \
+            odoo.addons.web_view_google_map_drawing.tests.test_field_json_searchable
+          python -m coverage xml -o coverage.xml
+
+      - name: Upload coverage report
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/19.0'
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage.xml
+          language: python
+          label: Python

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Odoo 19.0](https://img.shields.io/badge/Odoo-19.0-875A7B?logo=odoo&logoColor=white)](https://www.odoo.com/)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/mithnusa/odoo-google-maps/19.0.svg)](https://results.pre-commit.ci/latest/github/mithnusa/odoo-google-maps/19.0)
+[![codecov](https://codecov.io/gh/mithnusa/odoo-google-maps/branch/19.0/graph/badge.svg)](https://codecov.io/gh/mithnusa/odoo-google-maps)
 [![Google Maps JS API](https://img.shields.io/badge/Google_Maps_JS_API-latest-4285F4?logo=googlemaps&logoColor=white)](https://developers.google.com/maps/documentation/javascript)
 [![License: LGPL-3](https://img.shields.io/badge/License-LGPL_3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 


### PR DESCRIPTION
- Add `.github/workflows/coverage.yml`: clones Odoo 19, installs dependencies, runs `coverage` against `web_view_google_map_drawing` tests, uploads the XML report via `actions/upload-code-coverage@v1`; triggers on push to `19.0`/`19.0-*` and PRs to `19.0`
- Add codecov badge to README pointing to the `19.0` branch coverage report