### PR TITLE
[IMP] project_google_map: replace post_init_hook with declarative XML data file for view mode injection (v19.0.1.0.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ graph LR
     web_view_google_map --> stock_google_map
     web_view_google_map --> project_google_map
 
-    web_widget_google_map --> contacts_google_map
-
     web_widget_google_place_autocomplete --> contacts_google_autocomplete
     web_widget_google_place_autocomplete --> crm_google_autocomplete
 
@@ -170,7 +168,7 @@ Adds a Google Map view to the Inventory application, covering Deliveries, Ready 
 
 ### Project
 
-**[project_google_map](project_google_map/README.md)** [`19.0.1.0.5`](project_google_map/CHANGELOG.md)
+**[project_google_map](project_google_map/README.md)** [`19.0.1.0.6`](project_google_map/CHANGELOG.md)
 
 Adds Google Map views for Projects and Tasks. Project markers are automatically color-coded by health status — on track, at risk, off track, on hold, and done — and include a "View Tasks" shortcut to jump directly to that project's tasks. The project form gains an embedded satellite map. Task markers can be individually color-coded using a color picker.
 

--- a/contacts_google_map/__manifest__.py
+++ b/contacts_google_map/__manifest__.py
@@ -28,7 +28,6 @@ Provides:
         'base_geolocalize',
         'contacts',
         'web_view_google_map',
-        'web_widget_google_map',
     ],
     'data': [
         'data/cron_contact_geolocalize.xml',

--- a/project_google_map/CHANGELOG.md
+++ b/project_google_map/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 19.0.1.0.6
+
+### Changed
+
+- **`post_init_hook` → XML Data File**: Replaced the Python `post_init_hook` that imperatively appended `google_map` to action `view_mode` strings with a declarative `data/ir_actions_act_window.xml` file. The XML approach re-applies the view mode on every module update, surviving upgrades of the `project` module that would otherwise reset `view_mode` to its default.
+- **Removed `post_init_hook`**: `post_init_hook` function and its manifest entry removed; view mode injection is now handled entirely by the data file.
+
+### Improved
+
+- **`uninstall_hook` — Extended Coverage**: Added cleanup for 2 additional task actions (`project.action_view_all_task`, `project.action_view_my_task`) that were previously missing from the uninstall cleanup.
+
 ## 19.0.1.0.5
 
 ### Changed

--- a/project_google_map/__init__.py
+++ b/project_google_map/__init__.py
@@ -1,57 +1,6 @@
 from . import models
 
 
-def post_init_hook(env):
-    # Project actions
-    action_project1 = env.ref(
-        'project.open_view_project_all', raise_if_not_found=False
-    )
-    if action_project1:
-        view_mode = action_project1.view_mode.split(',')
-        if 'google_map' not in view_mode:
-            view_mode.append('google_map')
-            action_project1.view_mode = ','.join(view_mode)
-
-    action_project2 = env.ref(
-        'project.open_view_project_all_group_stage', raise_if_not_found=False
-    )
-    if action_project2:
-        view_mode = action_project2.view_mode.split(',')
-        if 'google_map' not in view_mode:
-            view_mode.append('google_map')
-            action_project2.view_mode = ','.join(view_mode)
-
-    action_project3 = env.ref(
-        'project.open_view_project_all_config', raise_if_not_found=False
-    )
-    if action_project3:
-        view_mode = action_project3.view_mode.split(',')
-        if 'google_map' not in view_mode:
-            view_mode.append('google_map')
-            action_project3.view_mode = ','.join(view_mode)
-
-    action_project4 = env.ref(
-        'project.open_view_project_all_config_group_stage',
-        raise_if_not_found=False,
-    )
-    if action_project4:
-        view_mode = action_project4.view_mode.split(',')
-        if 'google_map' not in view_mode:
-            view_mode.append('google_map')
-            action_project4.view_mode = ','.join(view_mode)
-
-    # Task actions
-    action_task1 = env.ref(
-        'project.act_project_project_2_project_task_all',
-        raise_if_not_found=False,
-    )
-    if action_task1:
-        view_mode = action_task1.view_mode.split(',')
-        if 'google_map' not in view_mode:
-            view_mode.append('google_map')
-            action_task1.view_mode = ','.join(view_mode)
-
-
 def uninstall_hook(env):
     # Remove google_map view from project actions
     action_project1 = env.ref(
@@ -104,5 +53,25 @@ def uninstall_hook(env):
         view_mode = action_task1.view_mode.split(',')
         if 'google_map' in view_mode:
             action_task1.view_mode = ','.join(
+                [mode for mode in view_mode if mode != 'google_map']
+            )
+
+    action_task2 = env.ref(
+        'project.action_view_all_task', raise_if_not_found=False
+    )
+    if action_task2 and action_task2.view_mode:
+        view_mode = action_task2.view_mode.split(',')
+        if 'google_map' in view_mode:
+            action_task2.view_mode = ','.join(
+                [mode for mode in view_mode if mode != 'google_map']
+            )
+
+    action_task3 = env.ref(
+        'project.action_view_my_task', raise_if_not_found=False
+    )
+    if action_task3 and action_task3.view_mode:
+        view_mode = action_task3.view_mode.split(',')
+        if 'google_map' in view_mode:
+            action_task3.view_mode = ','.join(
                 [mode for mode in view_mode if mode != 'google_map']
             )

--- a/project_google_map/__manifest__.py
+++ b/project_google_map/__manifest__.py
@@ -23,12 +23,13 @@ Provides:
     'website': 'https://www.mithnusa.com',
     'support': 'yopiangi@gmail.com',
     'category': 'Project',
-    'version': '19.0.1.0.5',
+    'version': '19.0.1.0.6',
     'depends': [
         'project',
         'web_view_google_map',
     ],
     'data': [
+        'data/ir_actions_act_window.xml',
         'views/project_project.xml',
         'views/project_task.xml',
     ],
@@ -41,6 +42,5 @@ Provides:
             'project_google_map/static/src/views/google_map/google_map_view.js',
         ],
     },
-    'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
 }

--- a/project_google_map/data/ir_actions_act_window.xml
+++ b/project_google_map/data/ir_actions_act_window.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Appends the "google_map" view mode to standard Project and Task window
+    actions. Declared in a data file (not a post_init_hook) so that it is
+    re-applied on every module update, surviving project module upgrades.
+-->
+<odoo>
+    <!-- Project actions -->
+    <record id="project.open_view_project_all" model="ir.actions.act_window">
+        <field name="view_mode">kanban,list,form,google_map</field>
+    </record>
+
+    <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
+        <field name="view_mode">kanban,list,form,calendar,activity,google_map</field>
+    </record>
+
+    <record id="project.open_view_project_all_config" model="ir.actions.act_window">
+        <field name="view_mode">list,kanban,form,google_map</field>
+    </record>
+
+    <record id="project.open_view_project_all_config_group_stage" model="ir.actions.act_window">
+        <field name="view_mode">list,kanban,form,calendar,activity,google_map</field>
+    </record>
+
+    <!-- Task actions -->
+    <record id="project.act_project_project_2_project_task_all" model="ir.actions.act_window">
+        <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity,google_map</field>
+    </record>
+
+    <record id="project.action_view_all_task" model="ir.actions.act_window">
+        <field name="view_mode">list,kanban,form,calendar,activity,pivot,graph,google_map</field>
+    </record>
+
+    <record id="project.action_view_my_task" model="ir.actions.act_window">
+        <field name="view_mode">kanban,list,form,calendar,activity,pivot,graph,google_map</field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Replace imperative `post_init_hook` (Python) with `data/ir_actions_act_window.xml` that sets `view_mode` on all 7 project and task actions declaratively — survives `project` module upgrades that would otherwise reset `view_mode` to its default
- Remove `post_init_hook` from `__init__.py` and `__manifest__.py`; keep `uninstall_hook`
- Extend `uninstall_hook` to also clean up `project.action_view_all_task` and `project.action_view_my_task`, which were previously missing from the removal logic
- Drop `web_widget_google_map` from `contacts_google_map` depends (not required by that module)
- Remove `web_widget_google_map → contacts_google_map` edge from README dependency graph; bump version badge to `19.0.1.0.6`