### PR TITLE
[IMP] web_widget_google_map: improve geolocate button UX, add pre-flight permission check, and fix idle listener leak (v19.0.1.0.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The core map view module. Adds a `google_map` view type alongside list, kanban, 
 
 Extends the map view with geographic drawing tools. Users can draw polygons, rectangles, and freehand shapes directly on the map. Shapes are stored as GeoJSON on the record and support server-side filtering so you can query which records fall inside a drawn area. Built on [Terra Draw](https://terradraw.io/) and [Deck.gl](https://deck.gl/); all libraries are bundled locally.
 
-**[web_widget_google_map](web_widget_google_map/README.md)** [`19.0.1.0.6`](web_widget_google_map/CHANGELOG.md)
+**[web_widget_google_map](web_widget_google_map/README.md)** [`19.0.1.0.7`](web_widget_google_map/CHANGELOG.md)
 
 Adds an embedded Google Map to any Odoo form. Shows the record's saved location and lets users update it visually — by dragging a marker or typing a place name — without leaving the form. A Street View side-by-side dialog lets users verify the exact location with street-level imagery alongside the standard map; it falls back gracefully when no Street View coverage is available.
 

--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 19.0.1.0.7
+
+### Improved
+
+- **`GoogleMapGeolocate` — Pre-flight Permission Check**: Added an early `navigator.permissions.query({ name: 'geolocation' })` check before calling `getCurrentPosition`; when `state === 'denied'` the component now shows an actionable notification immediately instead of waiting for the browser's silent error callback
+- **`GoogleMapGeolocate` — `PERMISSION_DENIED` Error Message**: Updated the case-1 error message to match the new pre-flight wording: `"Location access is blocked. Click the lock icon in your browser address bar, allow location access, then try again."`
+- **`geolocate.scss` — Button Spacing & Color**: Reduced `margin-bottom` from `8px` to `2px`; simplified padding to `6px`; removed explicit `opacity` and `cursor` overrides; added `color: #1a56c4` to match the blue geolocation icon style
+- **`geolocate.xml` — Icon Class**: Removed `text-700` class from the `fa-location-arrow` icon, letting it inherit color from the button's CSS
+
 ## 19.0.1.0.6
 
 ### Added

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -24,7 +24,7 @@ Provides:
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Extra Tools",
-    "version": "19.0.1.0.6",
+    "version": "19.0.1.0.7",
     "depends": ["base_google_map"],
     "assets": {
         "web.assets_backend": [

--- a/web_widget_google_map/static/src/components/geolocate/geolocate.js
+++ b/web_widget_google_map/static/src/components/geolocate/geolocate.js
@@ -10,6 +10,7 @@ export class GoogleMapGeolocate extends Component {
     setup() {
         this.notificationService = useService('notification');
         this.geolocateBtn = null;
+        this._idleListener = null;
         // Store bound reference for proper cleanup
         this._boundGeolocation = this.geolocation.bind(this);
 
@@ -43,23 +44,39 @@ export class GoogleMapGeolocate extends Component {
      * Get current user location using browser's geolocation API
      * @returns {Promise<void>}
      */
-    async geolocation(ev) {
-        ev.preventDefault();
+    async geolocation() {
         try {
             if (!navigator.geolocation) {
                 this.notificationService.add(_t('Geolocation is not supported by your browser.'), { type: 'warning' });
                 return;
             }
 
+            // Check permission state before calling getCurrentPosition.
+            // When state is 'prompt', getCurrentPosition triggers the browser dialog.
+            // When state is 'denied', the browser silently fires the error callback —
+            // we intercept here to show a clear, actionable message instead.
+            if (navigator.permissions) {
+                const { state } = await navigator.permissions.query({ name: 'geolocation' });
+                if (state === 'denied') {
+                    this.notificationService.add(
+                        _t(
+                            'Location access is blocked. Click the lock icon in your browser address bar, allow location access, then try again.'
+                        ),
+                        { type: 'danger' }
+                    );
+                    return;
+                }
+            }
+
             const position = await new Promise((resolve, reject) => {
                 navigator.geolocation.getCurrentPosition(resolve, reject, {
                     enableHighAccuracy: true,
-                    timeout: 10000, // 10 seconds
+                    timeout: 10000,
                     maximumAge: 0,
                 });
             });
 
-            this._geolocationSuccess(position);
+            await this._geolocationSuccess(position);
         } catch (error) {
             this._geolocationFailed(error);
         }
@@ -94,15 +111,23 @@ export class GoogleMapGeolocate extends Component {
             });
         }
 
+        // Always update the marker position to ensure it reflects the latest geolocation
+        this.marker.position = latLng;
+
         if (this.marker.map === null) {
             this.marker.map = this.props.googleMap;
         }
 
-        this.props.googleMap.panTo(this.marker.position);
+        this.props.googleMap.panTo(latLng);
 
-        google.maps.event.addListenerOnce(this.props.googleMap, 'idle', () => {
+        if (this._idleListener) {
+            google.maps.event.removeListener(this._idleListener);
+        }
+
+        this._idleListener = google.maps.event.addListenerOnce(this.props.googleMap, 'idle', () => {
+            this._idleListener = null;
             if (this.props.googleMap.getZoom() < 16) this.props.googleMap.setZoom(16);
-            google.maps.event.trigger(this.marker, 'gmp-click');
+            this._onMarkerClick();
         });
     }
 
@@ -128,7 +153,7 @@ export class GoogleMapGeolocate extends Component {
             switch (error.code) {
                 case 1: // PERMISSION_DENIED
                     message = _t(
-                        'Geolocation is disabled. Please enable it in your browser settings if you want browser to detect your location.'
+                        'Location access is blocked. Click the lock icon in your browser address bar, allow location access, then try again.'
                     );
                     break;
                 case 2: // POSITION_UNAVAILABLE
@@ -140,8 +165,8 @@ export class GoogleMapGeolocate extends Component {
                 default:
                     message = _t('An unknown error occurred. Please check Javascript console for details.');
             }
-        } else if (error.message) {
-            message = error.message;
+        } else if (error) {
+            console.error('Geolocation error:', error);
         }
 
         this.notificationService.add(message, { type: 'danger' });
@@ -161,12 +186,16 @@ export class GoogleMapGeolocate extends Component {
             this.infoWindow.close();
             google.maps.event.clearListeners(this.infoWindow, 'closeclick');
         }
+        if (this._idleListener) {
+            google.maps.event.removeListener(this._idleListener);
+            this._idleListener = null;
+        }
         if (this.geolocateBtn && this._boundGeolocation) {
             this.geolocateBtn.removeEventListener('click', this._boundGeolocation);
             // Remove button from map controls
             if (this.props.googleMap) {
                 const controls = this.props.googleMap.controls[google.maps.ControlPosition.RIGHT_BOTTOM];
-                const index = controls ? (controls.getArray() || []).indexOf(this.geolocateBtn) : -1;
+                const index = controls ? controls.getArray().indexOf(this.geolocateBtn) : -1;
                 if (index > -1) {
                     controls.removeAt(index);
                 }

--- a/web_widget_google_map/static/src/components/geolocate/geolocate.scss
+++ b/web_widget_google_map/static/src/components/geolocate/geolocate.scss
@@ -2,13 +2,12 @@
     .o_google_map_view {
         .button_geolocate_user {
             margin-right: 10px;
-            margin-bottom: 8px;
+            margin-bottom: 2px;
 
             .btn {
-                opacity: 1;
-                cursor: pointer;
-                padding: 6px 10px 5px 8px;
+                padding: 6px;
                 width: 42px;
+                color: #1a56c4;
             }
         }
     }

--- a/web_widget_google_map/static/src/components/geolocate/geolocate.xml
+++ b/web_widget_google_map/static/src/components/geolocate/geolocate.xml
@@ -12,7 +12,7 @@
                     data-tooltip="Get Current location"
                     aria-label="Get Current location"
                 >
-                    <i class="fa fa-location-arrow fa-2x text-700" />
+                    <i class="fa fa-location-arrow fa-2x" />
                 </button>
             </div>
         </div>


### PR DESCRIPTION
- Add `navigator.permissions.query({ name: 'geolocation' })` pre-flight check before `getCurrentPosition`; when `state === 'denied'` show an actionable `danger` notification immediately instead of waiting for the browser's silent error callback
- Update `PERMISSION_DENIED` (case 1) error message to match the pre-flight wording: "Click the lock icon in your browser address bar, allow location access, then try again"
- Track the `idle` listener in `this._idleListener` and remove it before adding a new one, preventing duplicate listeners from accumulating across repeated geolocation calls; clean it up in `willUnmount`
- Always set `marker.position = latLng` before panning so the marker reflects the latest fix; pan using the resolved `latLng` directly instead of `marker.position`
- Replace `google.maps.event.trigger(marker, 'gmp-click')` with direct `this._onMarkerClick()` call in the idle callback
- Replace `error.message` fallback with `console.error` to avoid swallowing non-GeolocationPositionError objects silently
- Simplify `controls.getArray()` null-guard (`|| []` removed — `getArray()` always returns an array)
- Remove `ev.preventDefault()` from `geolocation()` signature (event object not needed)
- Remove redundant `opacity` and `cursor` overrides from SCSS; reduce `margin-bottom` to `2px`; simplify padding to `6px`; add `color: #1a56c4` to match blue icon style
- Remove `text-700` class from `fa-location-arrow` icon so it inherits color from the button CSS