### PR TITLE
[IMP] web_widget_google_map, crm_google_map, contacts_google_map, project_google_map: replace iframe with button-driven map dialog, fix dragend coordinates and add unmount guards (v19.0.1.0.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Shared foundation for click-to-create workflows on map views. Provides the serve
 
 ### Contacts
 
-**[contacts_google_map](contacts_google_map/README.md)** [`19.0.1.0.11`](contacts_google_map/CHANGELOG.md)
+**[contacts_google_map](contacts_google_map/README.md)** [`19.0.1.0.12`](contacts_google_map/CHANGELOG.md)
 
 Adds a Google Map view to the Contacts application. Partners appear as color-coded markers; clicking one opens the contact card. Each contact form gains a Geolocation tab with an embedded map, a one-click geocode button, a marker color picker, and a nearby partners search. An optional background cron job can geocode all contacts automatically.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Enhances the Contact name field with a Google Places panel alongside Odoo's buil
 
 ### CRM
 
-**[crm_google_map](crm_google_map/README.md)** [`19.0.1.0.11`](crm_google_map/CHANGELOG.md)
+**[crm_google_map](crm_google_map/README.md)** [`19.0.1.0.12`](crm_google_map/CHANGELOG.md)
 
 Adds a Google Map view to the CRM application, available in All Leads, My Activities, Opportunities, Pipeline, and Forecast. Each lead appears as a color-coded marker showing stage, address, company, contact, phone, salesperson, expected revenue, win probability, and closing date. Activity scheduling is available directly from each marker's info window. The lead form gains a Geolocation tab with an embedded map preview, a geocode button, and a marker color picker.
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Adds a Google Map view to the Inventory application, covering Deliveries, Ready 
 
 ### Project
 
-**[project_google_map](project_google_map/README.md)** [`19.0.1.0.6`](project_google_map/CHANGELOG.md)
+**[project_google_map](project_google_map/README.md)** [`19.0.1.0.7`](project_google_map/CHANGELOG.md)
 
 Adds Google Map views for Projects and Tasks. Project markers are automatically color-coded by health status — on track, at risk, off track, on hold, and done — and include a "View Tasks" shortcut to jump directly to that project's tasks. The project form gains an embedded satellite map. Task markers can be individually color-coded using a color picker.
 

--- a/contacts_google_map/CHANGELOG.md
+++ b/contacts_google_map/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 19.0.1.0.12
+
+### Changed
+
+- **`res_partner.xml` — Geolocation page inline layout**: The `google_map` widget was moved from a separate `<group>` below the geolocation form into the existing `geo_localize_button` div. That div now has `class="d-flex gap-2"` applied so the geocode button and the map widget appear side by side in a single inline row rather than stacked in separate sections.
+
 ## 19.0.1.0.11
 
 ### Fixed

--- a/contacts_google_map/README.md
+++ b/contacts_google_map/README.md
@@ -14,7 +14,7 @@ Adds the `google_map` view type to Contacts so you can see all your contacts pin
 - **Contact Avatars**: Contact profile photos are shown in sidebar record rows and in marker info windows for quick identification
 - **Marker Color Customization**: Each contact can have a custom marker color set via a color picker on the contact form
 - **Nearby Contacts Search**: "Nearby Contacts" button on the contact form opens the map filtered to contacts within a configurable radius of that contact's location
-- **Embedded Map in Contact Form**: The Geolocation page of the contact form shows an embedded map at the contact's coordinates
+- **Map Button in Contact Form**: The Geolocation page of the contact form shows a map button inline alongside the geocode button; clicking it opens the interactive map dialog for the contact's coordinates
 - **Automatic Geocoding Cron**: A scheduled job (enabled by default, runs every 12 hours) that automatically geocodes up to 80 contacts per run that have a country and at least one address field but no coordinates; failures are isolated per contact so one bad record never aborts the whole batch
 
 ## Dependencies

--- a/contacts_google_map/__manifest__.py
+++ b/contacts_google_map/__manifest__.py
@@ -23,7 +23,7 @@ Provides:
     'website': 'https://www.mithnusa.com',
     'support': 'yopiangi@gmail.com',
     'category': 'Sales/CRM',
-    'version': '19.0.1.0.11',
+    'version': '19.0.1.0.12',
     'depends': [
         'base_geolocalize',
         'contacts',

--- a/contacts_google_map/docs/FEATURES.md
+++ b/contacts_google_map/docs/FEATURES.md
@@ -40,13 +40,13 @@
 
 ---
 
-## Embedded Map in Contact Form
+## Map Button in Contact Form
 
-**What it does**: Shows an embedded Google Map directly on the contact form's Geolocation page, displaying the contact's saved coordinates.
+**What it does**: Adds a map button to the Geolocation page of the contact form, placed inline alongside the geocode button in a single row.
 
-**Why it matters**: Lets you verify or review a contact's map location without leaving the form view or switching to the full map view.
+**Why it matters**: Lets you open the interactive map dialog for the contact's coordinates in one click without leaving the form view or switching to the full map view.
 
-**How it works**: The map widget is added to the Geolocation page via a form view inheritance. It renders the contact's latitude and longitude as a single marker on a compact map (400px tall, full width of the page).
+**How it works**: The `google_map` widget is injected into the existing `geo_localize_button` container with `d-flex gap-2` applied, placing it side by side with the geocode button. Clicking opens `GeolocationEditDialog` centred on the contact's stored coordinates.
 
 ---
 

--- a/contacts_google_map/views/res_partner.xml
+++ b/contacts_google_map/views/res_partner.xml
@@ -49,16 +49,17 @@
             <xpath expr="//label[@for='date_localization']/.." position="inside">
                 <field name="marker_color" widget="color_picker" />
             </xpath>
-            <xpath expr="//page[@name='geo_location']/group[1]/group[1]" position="after">
-                <group>
-                    <widget
-                        name="google_map"
-                        lat="partner_latitude"
-                        lng="partner_longitude"
-                        width="100%"
-                        height="400"
-                    />
-                </group>
+            <xpath expr="//page[@name='geo_location']//div[@name='geo_localize_button']" position="inside">
+                <widget
+                    name="google_map"
+                    lat="partner_latitude"
+                    lng="partner_longitude"
+                    width="100%"
+                    height="400"
+                />
+            </xpath>
+            <xpath expr="//page[@name='geo_location']//div[@name='geo_localize_button']" position="attributes">
+                <attribute name="class">d-flex gap-2</attribute>
             </xpath>
         </field>
     </record>

--- a/contacts_google_map/views/res_partner.xml
+++ b/contacts_google_map/views/res_partner.xml
@@ -50,13 +50,7 @@
                 <field name="marker_color" widget="color_picker" />
             </xpath>
             <xpath expr="//page[@name='geo_location']//div[@name='geo_localize_button']" position="inside">
-                <widget
-                    name="google_map"
-                    lat="partner_latitude"
-                    lng="partner_longitude"
-                    width="100%"
-                    height="400"
-                />
+                <widget name="google_map" lat="partner_latitude" lng="partner_longitude" width="100%" height="400" />
             </xpath>
             <xpath expr="//page[@name='geo_location']//div[@name='geo_localize_button']" position="attributes">
                 <attribute name="class">d-flex gap-2</attribute>

--- a/contacts_google_map/views/res_partner.xml
+++ b/contacts_google_map/views/res_partner.xml
@@ -50,7 +50,7 @@
                 <field name="marker_color" widget="color_picker" />
             </xpath>
             <xpath expr="//page[@name='geo_location']//div[@name='geo_localize_button']" position="inside">
-                <widget name="google_map" lat="partner_latitude" lng="partner_longitude" width="100%" height="400" />
+                <widget name="google_map" lat="partner_latitude" lng="partner_longitude" />
             </xpath>
             <xpath expr="//page[@name='geo_location']//div[@name='geo_localize_button']" position="attributes">
                 <attribute name="class">d-flex gap-2</attribute>

--- a/crm_google_map/CHANGELOG.md
+++ b/crm_google_map/CHANGELOG.md
@@ -1,6 +1,16 @@
 <!-- markdownlint-disable MD024 -->
 # Change Log
 
+## 19.0.1.0.12
+
+### Fixed
+
+- **`crm_lead.xml` — Geocode button visibility was inverted**: The `invisible` conditions on the two geocode buttons were swapped — "Compute based on address" was visible when coordinates already existed and "Refresh" was visible when they did not. Corrected so "Compute based on address" shows only when `customer_latitude == 0.0 and customer_longitude == 0.0` and "Refresh" shows only when coordinates are present.
+
+### Changed
+
+- **`crm_lead.xml` — Geolocation tab inline layout**: Replaced the two-group layout (buttons in one group, full-size `google_map` widget in a separate group below) with a single `d-flex gap-2` row containing the contextual geocode buttons and the `google_map` widget side by side. Removed the `width="100%"` and `height="400"` attributes from the widget, which now uses its default single-button form.
+
 ## 19.0.1.0.11
 
 ### Added

--- a/crm_google_map/README.md
+++ b/crm_google_map/README.md
@@ -17,8 +17,8 @@ Adds the `google_map` view type to the Leads, Opportunities, My Activities, Pipe
 - **Overlap Handling**: When multiple leads share the same address, markers are slightly offset so each remains individually clickable; an indicator icon flags shifted markers
 - **Sidebar with CRM Details**: The map sidebar lists all leads in the current view with their expected revenue and pipeline stage shown beneath each entry
 - **Automatic Geolocation from Partner**: When a contact is linked to a lead, the lead's latitude and longitude are automatically set from the partner's stored coordinates
-- **Geocode from Address**: A button on the Geolocation tab computes coordinates from the lead's address fields using Odoo's geocoding service
-- **Geolocation Tab**: Adds a dedicated tab to the lead form showing coordinates, a geocode button, a marker color picker, and an embedded map preview of the lead's location
+- **Geocode from Address**: Contextual buttons on the Geolocation tab compute or refresh coordinates from the lead's address fields — "Compute based on address" appears when no coordinates are set, "Refresh" when coordinates already exist
+- **Geolocation Tab**: Adds a dedicated tab to the lead form showing coordinates, geocode buttons, a map button, and a marker color picker — all in a single inline row for quick access
 
 ## Dependencies
 

--- a/crm_google_map/__manifest__.py
+++ b/crm_google_map/__manifest__.py
@@ -27,7 +27,7 @@ Provides:
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Sales/CRM",
-    "version": "19.0.1.0.11",
+    "version": "19.0.1.0.12",
     "depends": [
         "crm",
         "web_view_google_map",

--- a/crm_google_map/docs/FEATURES.md
+++ b/crm_google_map/docs/FEATURES.md
@@ -3,6 +3,7 @@
 ## Map View
 
 ### Google Map View for Leads and Opportunities
+
 **What it does**: Adds a dedicated Google Map view accessible from the Leads, Opportunities, My Activities, Pipeline, and Forecast menus in CRM.
 
 **Why it matters**: Sales teams can see the geographic distribution of their pipeline at a glance, making it easier to plan visits and identify territory coverage gaps.
@@ -12,6 +13,7 @@
 ---
 
 ### CRM-Specific Marker Design
+
 **What it does**: Displays each lead or opportunity as a custom marker showing the lead name, stage badge, address, company name, contact name, phone, salesperson, expected revenue, probability, and expected closing date.
 
 **Why it matters**: Key deal information is visible directly on the map without needing to open each record individually.
@@ -31,6 +33,7 @@
 ---
 
 ### Marker Highlight on Click
+
 **What it does**: Clicking a marker on the map highlights it visually and brings it to the foreground.
 
 **Why it matters**: Makes it easy to focus on a specific lead when multiple markers are close together.
@@ -40,6 +43,7 @@
 ---
 
 ### Overlap Handling with Visual Indicator
+
 **What it does**: When two or more leads share the same address, their markers are slightly offset so they remain individually clickable. An info icon is shown on shifted markers to indicate the adjustment.
 
 **Why it matters**: Prevents markers from stacking directly on top of each other, which would make them impossible to select individually.
@@ -51,6 +55,7 @@
 ## Sidebar
 
 ### Record Sidebar with CRM Details
+
 **What it does**: Displays a scrollable list of leads or opportunities beside the map, showing the lead name, address, expected revenue, and pipeline stage for each record.
 
 **Why it matters**: Provides a quick overview of all records in the current view without having to interact with the map markers one by one.
@@ -60,6 +65,7 @@
 ---
 
 ### Open Record from Sidebar
+
 **What it does**: Clicking a record in the sidebar opens that lead or opportunity's form view.
 
 **Why it matters**: Allows quick navigation from the map view directly into a record for editing or reviewing details.
@@ -71,6 +77,7 @@
 ## Geolocation
 
 ### Automatic Geolocation from Partner
+
 **What it does**: When a partner is linked to a lead, the lead's latitude and longitude are automatically set from the partner's stored geolocation.
 
 **Why it matters**: Reduces manual data entry when the linked contact already has a known location.
@@ -90,24 +97,27 @@
 ---
 
 ### Compute Geolocation from Address
-**What it does**: A button on the lead form's Geolocation tab lets users geocode the lead's address to obtain its latitude and longitude.
 
-**Why it matters**: Allows leads without a linked partner, or leads with a different address, to still appear on the map.
+**What it does**: Two contextual buttons on the Geolocation tab geocode the lead's address — "Compute based on address" appears when no coordinates are set; "Refresh" appears when coordinates already exist.
 
-**How it works**: The geocoder queries the Odoo geocoding service (base.geocoder) using the lead's street, city, state, zip, and country fields and stores the returned coordinates.
+**Why it matters**: Allows leads without a linked partner, or leads with a different address, to still appear on the map. The contextual labels make it clear whether you are computing for the first time or updating existing coordinates.
+
+**How it works**: Both buttons call the same `geo_localize` action, which queries the Odoo geocoding service (base.geocoder) using the lead's street, city, state, zip, and country fields and stores the returned coordinates. Visibility is toggled automatically based on whether coordinates are already present.
 
 ---
 
 ### Geolocation Tab on Lead Form
-**What it does**: Adds a dedicated "Geolocation" tab to the lead and opportunity form view showing the stored coordinates, a geocode button, a color picker for the map marker, and an embedded mini-map preview.
 
-**Why it matters**: Gives users a single place to review, update, and visualize the geographic data for each lead.
+**What it does**: Adds a dedicated "Geolocation" tab to the lead and opportunity form view showing the stored coordinates, contextual geocode buttons, a map button, and a color picker — all in a single inline row.
 
-**How it works**: The tab displays `customer_latitude` and `customer_longitude` fields, a `geo_localize` action button, a `color_picker` widget for `marker_color`, and an embedded `google_map` widget showing the lead's location.
+**Why it matters**: Gives users a single place to review, update, and visualize the geographic data for each lead, with all actions immediately accessible without scrolling.
+
+**How it works**: The tab displays `customer_latitude` and `customer_longitude` fields, then an inline row containing the contextual geocode buttons, the `google_map` widget button (opens the interactive map dialog), and a `color_picker` widget for `marker_color`.
 
 ---
 
 ### Marker Color Customization
+
 **What it does**: Each lead has a `marker_color` field that controls the color of its map marker.
 
 **Why it matters**: Allows visual differentiation between leads on the map, for example by priority, salesperson, or stage.

--- a/crm_google_map/views/crm_lead.xml
+++ b/crm_google_map/views/crm_lead.xml
@@ -52,34 +52,30 @@
                                     <field name="customer_longitude" nolabel="1" class="oe_inline" />
                                 </span>
                                 <br />
-                                <button
-                                    invisible="customer_latitude == 0.0 and customer_longitude == 0.0"
-                                    icon="fa-gear"
-                                    string="Compute based on address"
-                                    title="Compute Localization"
-                                    name="geo_localize"
-                                    type="object"
-                                    class="btn btn-link p-0"
-                                />
-                                <button
-                                    invisible="customer_latitude != 0.0 or customer_longitude != 0.0"
-                                    icon="fa-refresh"
-                                    string="Refresh"
-                                    title="Refresh Localization"
-                                    name="geo_localize"
-                                    type="object"
-                                    class="btn btn-link p-0"
-                                />
+                                <div class="d-flex gap-2">
+                                    <button
+                                        invisible="customer_latitude != 0.0 or customer_longitude != 0.0"
+                                        icon="fa-gear"
+                                        string="Compute based on address"
+                                        name="geo_localize"
+                                        type="object"
+                                        class="btn btn-link p-0"
+                                    />
+                                    <button
+                                        invisible="customer_latitude == 0.0 and customer_longitude == 0.0"
+                                        icon="fa-refresh"
+                                        string="Refresh"
+                                        name="geo_localize"
+                                        type="object"
+                                        class="btn btn-link p-0"
+                                    />
+                                    <widget
+                                        name="google_map"
+                                        lat="customer_latitude"
+                                        lng="customer_longitude"
+                                    />
+                                </div>
                             </div>
-                        </group>
-                        <group>
-                            <widget
-                                name="google_map"
-                                lat="customer_latitude"
-                                lng="customer_longitude"
-                                width="100%"
-                                height="400"
-                            />
                         </group>
                     </group>
                 </page>

--- a/crm_google_map/views/crm_lead.xml
+++ b/crm_google_map/views/crm_lead.xml
@@ -69,11 +69,7 @@
                                         type="object"
                                         class="btn btn-link p-0"
                                     />
-                                    <widget
-                                        name="google_map"
-                                        lat="customer_latitude"
-                                        lng="customer_longitude"
-                                    />
+                                    <widget name="google_map" lat="customer_latitude" lng="customer_longitude" />
                                 </div>
                             </div>
                         </group>

--- a/project_google_map/CHANGELOG.md
+++ b/project_google_map/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 19.0.1.0.7
+
+### Changed
+
+- **`project_project.xml` — Site tab map widget layout**: The `google_map` widget on the project form's Site tab was moved from a standalone `<group>` below the coordinates into the `<div>` that already contains the lat/lng coordinate display. `width="100%"` and `height="400"` attributes were removed so the widget renders as its default single-button form inline with the coordinates.
+
 ## 19.0.1.0.6
 
 ### Changed

--- a/project_google_map/README.md
+++ b/project_google_map/README.md
@@ -15,7 +15,7 @@ Extends the standard Project app with site location support for both projects an
 - **Map View**: Adds a "Map" view to the Projects list showing each project as a marker at its site location
 - **Status-Colored Markers**: Markers are automatically color-coded by project health status — green (on track), orange (at risk), red (off track), cyan (on hold), purple (done), gray (no status)
 - **Site Address Field**: Adds a "Site" tab to the project form for linking a site address to the project
-- **Embedded Map**: The project form's Site tab displays a satellite map of the selected site location
+- **Map Button**: The project form's Site tab includes a map button inline with the coordinates display; clicking it opens the interactive satellite map dialog for the site location
 - **Quick Task Access**: A "View Tasks" button in the map marker and sidebar opens the task list for that project
 
 ### Tasks
@@ -44,7 +44,7 @@ Extends the standard Project app with site location support for both projects an
 
 1. Open a project and go to the **Site** tab
 2. Select a site address (you can create a new "Site" type partner)
-3. The embedded satellite map on the same tab shows the selected location
+3. Click the map button beside the coordinates to open the satellite map dialog for that location
 4. From the Projects list, switch to the **Map** view to see all projects on a map
 5. Click a project marker to view details and use the "View Tasks" button
 

--- a/project_google_map/__manifest__.py
+++ b/project_google_map/__manifest__.py
@@ -23,7 +23,7 @@ Provides:
     'website': 'https://www.mithnusa.com',
     'support': 'yopiangi@gmail.com',
     'category': 'Project',
-    'version': '19.0.1.0.6',
+    'version': '19.0.1.0.7',
     'depends': [
         'project',
         'web_view_google_map',

--- a/project_google_map/docs/FEATURES.md
+++ b/project_google_map/docs/FEATURES.md
@@ -39,13 +39,13 @@
 
 ---
 
-### Embedded Satellite Map in Project Form
+### Map Button in Project Form
 
-**What it does**: Shows a satellite map of the site location directly on the project form's Site tab.
+**What it does**: Adds a map button inline with the coordinates display on the project form's Site tab.
 
 **Why it matters**: Lets you confirm the correct site location without leaving the project form.
 
-**How it works**: When a site address is selected, an embedded satellite map (400px height) renders automatically on the Site tab showing the location.
+**How it works**: The `google_map` widget is placed inside the coordinates div on the Site tab. Clicking the button opens `GeolocationEditDialog` in read-only mode (satellite view) centred on the site's coordinates.
 
 ---
 

--- a/project_google_map/views/project_project.xml
+++ b/project_google_map/views/project_project.xml
@@ -48,18 +48,14 @@
                                     Long:
                                     <field name="site_longitude" nolabel="1" class="oe_inline" />
                                 </span>
+                                <widget
+                                    name="google_map"
+                                    lat="site_latitude"
+                                    lng="site_longitude"
+                                    readonly="1"
+                                    maptype="satellite"
+                                />
                             </div>
-                        </group>
-                        <group>
-                            <widget
-                                name="google_map"
-                                lat="site_latitude"
-                                lng="site_longitude"
-                                maptype="satellite"
-                                width="100%"
-                                height="400"
-                                readonly="1"
-                            />
                         </group>
                     </group>
                 </page>

--- a/project_google_map/views/project_task.xml
+++ b/project_google_map/views/project_task.xml
@@ -55,8 +55,6 @@
                             lat="site_latitude"
                             lng="site_longitude"
                             maptype="satellite"
-                            width="100%"
-                            height="400"
                             readonly="1"
                         />
                     </group>

--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -2,16 +2,19 @@
 
 ## 19.0.1.0.8
 
+### Changed
+
+- **`GoogleMapWidget` — Simplified to a single button**: Removed the static map image and the two-button layout (toggle + edit). The widget now renders a single contextual button — "View on Map" in readonly mode, "Update on Map" in edit mode — that opens `GeolocationEditDialog` directly. This eliminates the extra click, the Static Maps API call on each form load, and the cross-origin `<iframe>`/`SecurityError` issue that motivated the previous approach.
+
 ### Fixed
 
-- **`GoogleMapWidget` — SecurityError on tooltip/popover**: Replaced the Google Maps Embed API `<iframe>` with a Google Maps Static API `<img>`. Odoo's `useClickAway` hook (used by the `Popover` component behind every `data-tooltip`) iterates all iframes in the document and calls `contentWindow.addEventListener` on each one — a cross-origin iframe causes a `SecurityError` immediately. Using a plain `<img>` eliminates the cross-origin element entirely.
-- **`GeolocationEditDialog._handleMarkerDragend` — Corrupted coordinates after drag**: `AdvancedMarkerElement.position` after a drag returns a `google.maps.LatLng` object where `.lat` and `.lng` are methods, not plain numbers. Accessing them as properties yielded a stringified function in the URL, breaking the static map image after saving. Fixed with a `typeof` guard: `typeof position.lat === 'function' ? position.lat() : position.lat`.
+- **`GeolocationEditDialog._handleMarkerDragend` — Corrupted coordinates after drag**: `AdvancedMarkerElement.position` after a drag returns a `google.maps.LatLng` object where `.lat` and `.lng` are methods, not plain numbers. Fixed with a `typeof` guard: `typeof position.lat === 'function' ? position.lat() : position.lat`.
+- **`GeolocationEditDialog._cleanupListeners` — Hung `tilesloaded` promise on fast close**: Added `_resolveTilesLoaded` — the `resolve` function of the `tilesloaded` Promise is stored on the instance and called in `_cleanupListeners` so the awaited promise is always settled even when the dialog is closed before tiles finish loading.
 
 ### Improved
 
-- **`GoogleMapWidget` — Collapsible map toggle**: The static map image is hidden by default and revealed via a "Show Map" / "Hide Map" toggle button. The image is only fetched from Google when the map is visible, avoiding an API request on every form load.
-- **`GeolocationEditDialog` — Unmount safety guards**: Added `_tilesLoadedListener` (stored handle for the `tilesloaded` Maps event) and `_isUnmounted` flag. Both are checked in `_cleanupListeners` (`onWillUnmount`) and at every async continuation point (`importLibrary`, `tilesloaded` resolve, `idle` callback) so no callback can touch a detached component after the dialog closes. `clearInstanceListeners` is now called on the map instance to cancel all remaining Maps SDK internal events on unmount.
-- **JSDoc and inline comments**: Updated all JSDoc blocks in `google_map.js` to reflect the Static Maps API migration, the collapsible toggle, the unmount safety pattern, and the `LatLng` method guard.
+- **`GeolocationEditDialog` — Map UI controls**: The dialog map now uses `disableDefaultUI: true` with explicit `zoomControl`, `streetViewControl`, `fullscreenControl`, and `mapTypeControl` re-enabled, and `gestureHandling: 'greedy'` so panning works inside the modal without the two-finger scroll requirement.
+- **`GeolocationEditDialog` — Unmount safety guards**: `_tilesLoadedListener` (stored Maps event handle) and `_isUnmounted` flag are checked at every async continuation point (`importLibrary`, `tilesloaded` resolve, `idle` callback). `clearInstanceListeners` is called on the map instance in `_cleanupListeners` to cancel all remaining Maps SDK internal events on dialog close.
 
 ## 19.0.1.0.7
 

--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 19.0.1.0.8
+
+### Fixed
+
+- **`GoogleMapWidget` — SecurityError on tooltip/popover**: Replaced the Google Maps Embed API `<iframe>` with a Google Maps Static API `<img>`. Odoo's `useClickAway` hook (used by the `Popover` component behind every `data-tooltip`) iterates all iframes in the document and calls `contentWindow.addEventListener` on each one — a cross-origin iframe causes a `SecurityError` immediately. Using a plain `<img>` eliminates the cross-origin element entirely.
+- **`GeolocationEditDialog._handleMarkerDragend` — Corrupted coordinates after drag**: `AdvancedMarkerElement.position` after a drag returns a `google.maps.LatLng` object where `.lat` and `.lng` are methods, not plain numbers. Accessing them as properties yielded a stringified function in the URL, breaking the static map image after saving. Fixed with a `typeof` guard: `typeof position.lat === 'function' ? position.lat() : position.lat`.
+
+### Improved
+
+- **`GoogleMapWidget` — Collapsible map toggle**: The static map image is hidden by default and revealed via a "Show Map" / "Hide Map" toggle button. The image is only fetched from Google when the map is visible, avoiding an API request on every form load.
+- **`GeolocationEditDialog` — Unmount safety guards**: Added `_tilesLoadedListener` (stored handle for the `tilesloaded` Maps event) and `_isUnmounted` flag. Both are checked in `_cleanupListeners` (`onWillUnmount`) and at every async continuation point (`importLibrary`, `tilesloaded` resolve, `idle` callback) so no callback can touch a detached component after the dialog closes. `clearInstanceListeners` is now called on the map instance to cancel all remaining Maps SDK internal events on unmount.
+- **JSDoc and inline comments**: Updated all JSDoc blocks in `google_map.js` to reflect the Static Maps API migration, the collapsible toggle, the unmount safety pattern, and the `LatLng` method guard.
+
 ## 19.0.1.0.7
 
 ### Improved

--- a/web_widget_google_map/README.md
+++ b/web_widget_google_map/README.md
@@ -2,42 +2,43 @@
 
 ## Overview
 
-This module provides a `google_map` form widget that displays a Google Maps Static API image inside any Odoo form view. An edit button opens an interactive dialog where users can drag a marker or search for a place to update the record's coordinates.
+This module provides a `google_map` form widget that adds a single map button to any Odoo form view. Clicking the button opens an interactive Google Maps dialog where users can view the record's location and, in edit mode, drag a marker or search for a place to update the coordinates.
 
 ## What It Does
 
-Adds a `google_map` widget for use in form views. It shows a collapsible static map image at the record's stored latitude and longitude. When the field is editable, an edit button opens a full interactive map in a dialog — users can drag the marker to any position or use a place search to navigate and confirm a new location. Saving the dialog writes the updated coordinates back to the record.
+Adds a `google_map` widget for use in form views. A single button — "View on Map" in read-only mode, "Update on Map" in edit mode — opens a full interactive Google Map dialog centred on the record's stored latitude and longitude. In edit mode, users can drag the marker or use the built-in place search to pick a new location; saving the dialog writes the updated coordinates back to the record.
 
 ## Key Features
 
-- **Collapsible Static Map Preview**: A "Show Map" toggle reveals a Google Maps Static API image at the record's current coordinates; configurable zoom, map type, width, and height
-- **Interactive Edit Dialog**: An edit button opens a dialog with a full interactive Google Map and a draggable marker for precise coordinate selection
-- **Draggable Marker**: Drag the marker anywhere on the map to pick new coordinates; the dialog updates on drop and writes the values to the record on save
-- **Place Search in Dialog**: A Google Places search box inside the dialog lets users navigate the map to a named location before dropping the marker
-- **Street View Side-by-Side Dialog (component)**: Provides `GoogleMapStreetViewSideBySideDialog`, an XL dialog that shows a Google Map on the left and Google Street View on the right; falls back to a marker-only map when no Street View imagery is available at the given coordinates
-- **Read-Only Mode**: When the form field is in read-only mode, the embedded map is shown without an edit button and the dialog marker is non-draggable
-- **Shared Map Components**: Bundles `GoogleMapGeolocate` (browser geolocation button) and `GoogleMapSearchPlaces` (in-map Google Places autocomplete) as reusable OWL components; these are consumed directly by `web_view_google_map`'s map view
+- **Single-Click Map Access**: One button opens the interactive map dialog directly — no extra toggle or step required
+- **Interactive Edit Dialog**: Full Google Map in a dialog with a draggable marker for precise coordinate selection
+- **Draggable Marker**: Drag the marker anywhere on the map to pick new coordinates; values are written to the record on Save
+- **Place Search in Dialog**: A Google Places search box inside the dialog lets users navigate to any address or landmark before placing the marker
+- **Read-Only Mode**: In read-only contexts the dialog opens in view-only mode — the marker is fixed and no Save button is shown
+- **Open in Google Maps**: A link in the dialog footer opens the current coordinates in the Google Maps website
+- **Street View Side-by-Side Dialog (component)**: Provides `GoogleMapStreetViewSideBySideDialog`, an XL dialog showing a Google Map and Google Street View side by side; falls back gracefully when no Street View imagery is available
+- **Shared Map Components**: Bundles `GoogleMapGeolocate` (browser geolocation button) and `GoogleMapSearchPlaces` (in-map Google Places autocomplete) as reusable OWL components consumed by `web_view_google_map`'s map view
 
 ## Dependencies
 
 - `base_google_map`
 
-## Required Google APIs
-
-The **Maps Static API** must be enabled in your Google Cloud Console project — it is a separate product from the Maps JavaScript API and is not enabled by default. Without it, the map preview image will fail to load.
-
-Enable it at: **Google Cloud Console → APIs & Services → Library → Maps Static API → Enable**
-
 ## Installation
 
 1. Install the module through Odoo Apps
 2. Ensure a valid Google Maps API key is configured in **Settings → General Settings → Google Maps**
-3. Enable the **Maps Static API** in Google Cloud Console (see above)
 
 ## Basic Usage
 
-Add the widget to any form view using `<widget name="google_map" lat="field_latitude" lng="field_longitude"/>`. The `lat` and `lng` attributes must reference Float fields that are present in the view.
+Add the widget to any form view:
+
+```xml
+<widget name="google_map" lat="partner_latitude" lng="partner_longitude"/>
+```
+
+The `lat` and `lng` attributes must reference Float fields that are present in the view. An optional `maptype` attribute accepts `roadmap` (default) or `satellite`.
 
 ## Related Modules
 
 - `base_google_map`: Provides the API key configuration and Google Maps JavaScript API loader
+- `web_view_google_map`: Map view for Odoo records; consumes the shared components bundled here

--- a/web_widget_google_map/README.md
+++ b/web_widget_google_map/README.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-This module provides a `google_map` form widget that embeds a Google Maps preview directly inside any Odoo form view. An edit button opens an interactive dialog where users can drag a marker or search for a place to update the record's coordinates.
+This module provides a `google_map` form widget that displays a Google Maps Static API image inside any Odoo form view. An edit button opens an interactive dialog where users can drag a marker or search for a place to update the record's coordinates.
 
 ## What It Does
 
-Adds a `google_map` widget for use in form views. It shows an embedded map at the record's stored latitude and longitude. When the field is editable, an edit button opens a full interactive map in a dialog — users can drag the marker to any position or use a place search to navigate and confirm a new location. Saving the dialog writes the updated coordinates back to the record.
+Adds a `google_map` widget for use in form views. It shows a collapsible static map image at the record's stored latitude and longitude. When the field is editable, an edit button opens a full interactive map in a dialog — users can drag the marker to any position or use a place search to navigate and confirm a new location. Saving the dialog writes the updated coordinates back to the record.
 
 ## Key Features
 
-- **Embedded Map Preview**: Renders a Google Maps iframe inside the form view at the record's current coordinates, with configurable zoom, map type, width, and height
+- **Collapsible Static Map Preview**: A "Show Map" toggle reveals a Google Maps Static API image at the record's current coordinates; configurable zoom, map type, width, and height
 - **Interactive Edit Dialog**: An edit button opens a dialog with a full interactive Google Map and a draggable marker for precise coordinate selection
 - **Draggable Marker**: Drag the marker anywhere on the map to pick new coordinates; the dialog updates on drop and writes the values to the record on save
 - **Place Search in Dialog**: A Google Places search box inside the dialog lets users navigate the map to a named location before dropping the marker
@@ -22,10 +22,17 @@ Adds a `google_map` widget for use in form views. It shows an embedded map at th
 
 - `base_google_map`
 
+## Required Google APIs
+
+The **Maps Static API** must be enabled in your Google Cloud Console project — it is a separate product from the Maps JavaScript API and is not enabled by default. Without it, the map preview image will fail to load.
+
+Enable it at: **Google Cloud Console → APIs & Services → Library → Maps Static API → Enable**
+
 ## Installation
 
 1. Install the module through Odoo Apps
 2. Ensure a valid Google Maps API key is configured in **Settings → General Settings → Google Maps**
+3. Enable the **Maps Static API** in Google Cloud Console (see above)
 
 ## Basic Usage
 

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Web widget Google Maps",
-    "summary": "Google Maps embed widget for form views with an interactive coordinate-edit dialog",
+    "summary": "Google Maps static preview widget for form views with an interactive coordinate-edit dialog",
     "description": """
 Web Widget Google Maps
 ======================
 
-Provides a ``google_map`` form widget that embeds a Google Maps preview and
-an interactive coordinate-edit dialog in any Odoo form view.
+Provides a ``google_map`` form widget that displays a collapsible Google Maps
+Static API image and an interactive coordinate-edit dialog in any Odoo form view.
 
 Provides:
 
-- ``GoogleMapWidget`` registered in the ``view_widgets`` registry as ``google_map``; renders a Google Maps Embed API ``<iframe>`` at the record's current coordinates with configurable ``zoom`` (default 14), ``maptype`` (``roadmap`` / ``satellite``), ``width`` (default 400 px), and ``height`` (default 200 px) XML attributes; falls back to world-level zoom when coordinates are ``(0, 0)``
-- ``GeolocationEditDialog`` extending ``ConfirmationDialog``; initializes a full Google Maps JavaScript API instance via ``useGoogleMapsAPILoader`` and places an ``AdvancedMarkerElement`` with ``gmpDraggable: true`` at the current coordinates; drag-end position is stored locally and written to the record via ``record.update()`` on Save
+- ``GoogleMapWidget`` registered in the ``view_widgets`` registry as ``google_map``; renders a Google Maps Static API ``<img>`` (revealed by a "Show Map" toggle) at the record's current coordinates with configurable ``zoom`` (default 14), ``maptype`` (``roadmap`` / ``satellite``), ``width`` (default 400 px), and ``height`` (default 200 px) XML attributes; falls back to world-level zoom and omits the pin when coordinates are ``(0, 0)``; the image URL recomputes automatically via OWL reactivity when coordinates change
+- ``GeolocationEditDialog`` extending ``ConfirmationDialog``; initializes a full Google Maps JavaScript API instance via ``useGoogleMapsAPILoader`` and places an ``AdvancedMarkerElement`` with ``gmpDraggable: true`` at the current coordinates; drag-end position is stored locally and written to the record via ``record.update()`` on Save; async unmount guards (``_isUnmounted``, ``_tilesLoadedListener``, ``clearInstanceListeners``) prevent stale callbacks after the dialog closes
 - ``GoogleMapSearchPlaces`` component bundled in this module; used inside the geolocation dialog for place-autocomplete navigation before marker placement; also exported for consumption by ``web_view_google_map``'s map view
 - ``GoogleMapGeolocate`` component bundled in this module; adds a browser geolocation button to any Google Map instance (``RIGHT_BOTTOM`` control position); places an ``AdvancedMarkerElement`` at the user's coordinates with an info window on click; exported for consumption by ``web_view_google_map``'s map view
 - Read-only mode: edit button hidden, dialog marker non-draggable
@@ -21,10 +21,10 @@ Provides:
 """,
     "license": "LGPL-3",
     "author": "Yopi Angi",
-    "website": "https://github.com/mithnusa",
+    "website": "https://www.mithnusa.com",
     "support": "yopiangi@gmail.com",
     "category": "Extra Tools",
-    "version": "19.0.1.0.7",
+    "version": "19.0.1.0.8",
     "depends": ["base_google_map"],
     "assets": {
         "web.assets_backend": [

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Web widget Google Maps",
-    "summary": "Google Maps static preview widget for form views with an interactive coordinate-edit dialog",
+    "summary": "Google Maps widget for form views — single-button access to an interactive coordinate-edit dialog",
     "description": """
 Web Widget Google Maps
 ======================
 
-Provides a ``google_map`` form widget that displays a collapsible Google Maps
-Static API image and an interactive coordinate-edit dialog in any Odoo form view.
+Provides a ``google_map`` form widget that renders a single button opening a
+full interactive Google Maps dialog directly from any Odoo form view.
 
 Provides:
 
-- ``GoogleMapWidget`` registered in the ``view_widgets`` registry as ``google_map``; renders a Google Maps Static API ``<img>`` (revealed by a "Show Map" toggle) at the record's current coordinates with configurable ``zoom`` (default 14), ``maptype`` (``roadmap`` / ``satellite``), ``width`` (default 400 px), and ``height`` (default 200 px) XML attributes; falls back to world-level zoom and omits the pin when coordinates are ``(0, 0)``; the image URL recomputes automatically via OWL reactivity when coordinates change
+- ``GoogleMapWidget`` registered in the ``view_widgets`` registry as ``google_map``; renders a single contextual button — "View on Map" in read-only mode, "Update on Map" in edit mode — that opens ``GeolocationEditDialog`` centred on the record's current coordinates; ``lat`` and ``lng`` XML attributes required; ``maptype`` (``roadmap`` / ``satellite``) optional
 - ``GeolocationEditDialog`` extending ``ConfirmationDialog``; initializes a full Google Maps JavaScript API instance via ``useGoogleMapsAPILoader`` and places an ``AdvancedMarkerElement`` with ``gmpDraggable: true`` at the current coordinates; drag-end position is stored locally and written to the record via ``record.update()`` on Save; async unmount guards (``_isUnmounted``, ``_tilesLoadedListener``, ``clearInstanceListeners``) prevent stale callbacks after the dialog closes
 - ``GoogleMapSearchPlaces`` component bundled in this module; used inside the geolocation dialog for place-autocomplete navigation before marker placement; also exported for consumption by ``web_view_google_map``'s map view
 - ``GoogleMapGeolocate`` component bundled in this module; adds a browser geolocation button to any Google Map instance (``RIGHT_BOTTOM`` control position); places an ``AdvancedMarkerElement`` at the user's coordinates with an info window on click; exported for consumption by ``web_view_google_map``'s map view
-- Read-only mode: edit button hidden, dialog marker non-draggable
-- ``lat`` and ``lng`` XML attributes required; validated at component init with a clear error if the referenced fields are missing from the view
+- Read-only mode: dialog marker non-draggable, Save button hidden, "Open in Google Maps" link active
 - ``GoogleMapStreetViewSideBySideDialog`` — opens an XL dialog with a Google Map on the left and Google Street View on the right; checks Street View coverage via ``StreetViewService`` before rendering and falls back to a marker-only map with an informational placeholder when no imagery is available at the given coordinates
 """,
     "license": "LGPL-3",

--- a/web_widget_google_map/docs/FEATURES.md
+++ b/web_widget_google_map/docs/FEATURES.md
@@ -1,13 +1,14 @@
 # Web Widget Google Maps - Features
 
-## Embedded Map Preview
+## Map Preview in Form View
 
-### Map Display in Form View
-**What it does**: Renders a Google Maps iframe at the record's current coordinates directly inside a form view.
+### Collapsible Static Map Image
 
-**Why it matters**: Gives users an immediate spatial view of a record's location without leaving the form or opening a separate map view.
+**What it does**: Renders a Google Maps Static API image at the record's current coordinates inside a form view, revealed by a "Show Map" / "Hide Map" toggle button.
 
-**How it works**: The widget uses the Google Maps Embed API to generate an iframe pointing to the stored latitude and longitude. When coordinates are 0,0 (unset), the map defaults to a world-level zoom. Configurable attributes control the display: `zoom` (default: 14), `maptype` (`roadmap` or `satellite`, default: `roadmap`), `width` (default: 400), and `height` (default: 200).
+**Why it matters**: Gives users an on-demand spatial view of a record's location without leaving the form. Loading on demand avoids an API request on every form open, and using a static image instead of an iframe eliminates the cross-origin `SecurityError` that Odoo's tooltip system would otherwise trigger.
+
+**How it works**: The widget uses the Google Maps Static API (`maps/api/staticmap`) to build an image URL from the stored latitude and longitude. The image is only fetched when the user toggles the map visible. When coordinates are 0,0 (unset), the map defaults to a world-level zoom and the red marker pin is omitted. Configurable attributes control the display: `zoom` (default: 14), `maptype` (`roadmap` or `satellite`, default: `roadmap`), `width` (default: 400), and `height` (default: 200). Because `props.record` is reactive, the image URL recomputes automatically whenever the coordinates change — saving the edit dialog refreshes the preview without any extra code.
 
 ---
 

--- a/web_widget_google_map/docs/FEATURES.md
+++ b/web_widget_google_map/docs/FEATURES.md
@@ -1,52 +1,66 @@
 # Web Widget Google Maps - Features
 
-## Map Preview in Form View
+## Widget Button
 
-### Collapsible Static Map Image
+### Single Map Button
 
-**What it does**: Renders a Google Maps Static API image at the record's current coordinates inside a form view, revealed by a "Show Map" / "Hide Map" toggle button.
+**What it does**: Renders a single button on the form view that opens the interactive map dialog in one click.
 
-**Why it matters**: Gives users an on-demand spatial view of a record's location without leaving the form. Loading on demand avoids an API request on every form open, and using a static image instead of an iframe eliminates the cross-origin `SecurityError` that Odoo's tooltip system would otherwise trigger.
+**Why it matters**: Eliminates the extra toggle step — users get directly to the map without first revealing a preview image.
 
-**How it works**: The widget uses the Google Maps Static API (`maps/api/staticmap`) to build an image URL from the stored latitude and longitude. The image is only fetched when the user toggles the map visible. When coordinates are 0,0 (unset), the map defaults to a world-level zoom and the red marker pin is omitted. Configurable attributes control the display: `zoom` (default: 14), `maptype` (`roadmap` or `satellite`, default: `roadmap`), `width` (default: 400), and `height` (default: 200). Because `props.record` is reactive, the image URL recomputes automatically whenever the coordinates change — saving the edit dialog refreshes the preview without any extra code.
+**How it works**: The button label and icon adapt to the context: "View on Map" (read-only) or "Update on Map" (edit mode). Clicking always opens `GeolocationEditDialog` centred on the record's current coordinates.
 
 ---
 
-### Read-Only Display Mode
-**What it does**: Shows the embedded map without an edit button when the form field is in read-only mode.
+### Read-Only Mode
 
-**Why it matters**: Ensures the map is visible for reference in read-only contexts (e.g. portal views, locked records) without exposing editing controls.
+**What it does**: In read-only contexts the dialog opens in view-only mode — the marker is fixed, the Save button is hidden, and only the "Open in Google Maps" link is active.
 
-**How it works**: The widget checks `props.readonly`; when true, the edit button is hidden and no dialog can be opened.
+**Why it matters**: Ensures the map is visible for reference in read-only contexts (portal views, locked records) without exposing editing controls.
+
+**How it works**: The widget passes `readonly: true` to the dialog, which disables `gmpDraggable` on the marker and hides the footer Save/Cancel buttons.
 
 ---
 
 ## Edit Dialog
 
 ### Interactive Edit Dialog
-**What it does**: An edit button on the widget opens a dialog containing a full interactive Google Map for updating the record's coordinates.
 
-**Why it matters**: The embedded iframe is not interactive — the dialog provides a proper map experience for precise location selection before writing any changes to the record.
+**What it does**: Opens a full-screen Google Map dialog for viewing or updating the record's coordinates.
 
-**How it works**: Clicking the edit button opens a `GeolocationEditDialog`. The dialog initializes a Google Maps JavaScript API instance at the current coordinates (zoom 16 if coordinates are set, zoom 3 if unset). A save button writes the confirmed coordinates to the record's latitude and longitude fields; cancel discards any changes.
+**Why it matters**: Provides a proper interactive map experience — panning, zooming, place search, and marker drag — before any values are written to the record.
+
+**How it works**: `GeolocationEditDialog` initialises a Google Maps JavaScript API instance at the current coordinates (zoom 17 if coordinates are set, zoom 3 if unset). A Save button writes the confirmed coordinates to the record's latitude and longitude fields via `record.update()`; Cancel discards any changes.
 
 ---
 
 ### Draggable Marker
+
 **What it does**: Displays a draggable marker in the edit dialog that the user can move to any position on the map to select new coordinates.
 
 **Why it matters**: Allows precise visual placement of a location rather than requiring manual entry of latitude and longitude values.
 
-**How it works**: An `AdvancedMarkerElement` is placed at the current coordinates with `gmpDraggable: true`. On drag end, the marker's new position is stored locally. When the user clicks Save, these coordinates are written to the record via `record.update()`. In read-only mode, `gmpDraggable` is false and the marker is fixed.
+**How it works**: An `AdvancedMarkerElement` is placed at the current coordinates with `gmpDraggable: true`. On drag end, the marker's new position is stored locally. When the user clicks Save, these coordinates are written to the record. In read-only mode, `gmpDraggable` is false and the marker is fixed.
 
 ---
 
 ### Place Search in Edit Dialog
+
 **What it does**: A Google Places search box inside the edit dialog lets users navigate the map to a named location or address before setting the marker.
 
 **Why it matters**: Finding a precise location by name is faster than manually panning the map, especially for new or unfamiliar addresses.
 
-**How it works**: The dialog reuses the `GoogleMapSearchPlaces` component. Selecting a result from the autocomplete pans the map to that location, after which the user can fine-tune the marker position by dragging before saving.
+**How it works**: The dialog includes the `GoogleMapSearchPlaces` component. Selecting a result from the autocomplete pans the map to that location, after which the user can fine-tune the marker position by dragging before saving.
+
+---
+
+### Open in Google Maps
+
+**What it does**: A link in the dialog footer opens the current marker coordinates directly in the Google Maps website in a new tab.
+
+**Why it matters**: Lets users cross-check the location or get directions without leaving Odoo.
+
+**How it works**: The link is always visible in the dialog footer (both readonly and edit mode) and uses the stored local coordinates at the time of clicking.
 
 ---
 
@@ -56,11 +70,11 @@ These components are bundled in this module and re-exported for use by `web_view
 
 ### Geolocation Button (`GoogleMapGeolocate`)
 
-**What it does**: Adds a floating geolocation button to any Google Map instance. Clicking it shows the user's current position as a custom marker and zooms the map to that location.
+**What it does**: Adds a floating geolocation button to any Google Map instance. Clicking it shows the user's current position as a marker and zooms the map to that location.
 
 **Why it matters**: Lets users instantly orient themselves relative to their map data — useful in field workflows where the user's physical location is the starting point for exploration.
 
-**How it works**: The component injects a custom button into the map's `RIGHT_BOTTOM` control area via `google.maps.controls`. On click it calls the browser Geolocation API (`enableHighAccuracy: true`, 10 s timeout). On success an `AdvancedMarkerElement` with an SVG pin is placed at the returned coordinates and an info window labelled "Your location" opens on click. Specific `GeolocationPositionError` codes (permission denied, position unavailable, timeout) map to distinct user-facing notification messages. The button DOM element and all event listeners are cleaned up in `onWillUnmount`.
+**How it works**: The component injects a custom button into the map's `RIGHT_BOTTOM` control area. On click it calls the browser Geolocation API (`enableHighAccuracy: true`, 10 s timeout). On success an `AdvancedMarkerElement` is placed at the returned coordinates and an info window opens on click. Specific error codes (permission denied, position unavailable, timeout) map to distinct user-facing notifications. All DOM nodes and event listeners are cleaned up on unmount.
 
 ---
 
@@ -70,7 +84,7 @@ These components are bundled in this module and re-exported for use by `web_view
 
 **Why it matters**: Lets users navigate a large map to any address or landmark by name, without panning manually or knowing the coordinates in advance.
 
-**How it works**: The component renders a `<gmp-place-autocomplete>` element (`PlaceAutocompleteElement`, Places API New) into the map's `TOP_RIGHT` control area once the map fires its first `idle` event. It respects `restrict_language`, `autocomplete_restrict_country`, and `region` settings from `base_google_map`. The current map bounds are passed as `locationRestriction` and updated on every `bounds_changed` event. On selection a `fetchFields` call retrieves `displayName`, `formattedAddress`, and `location`; the map then pans (or fits the viewport) and an orange pin marker with an info window is placed at the result. All listeners and DOM nodes are removed in `onWillUnmount`.
+**How it works**: The component renders a `PlaceAutocompleteElement` (Places API New) into the map's `TOP_RIGHT` control area once the map is ready. It respects language, region, and country-restriction settings from `base_google_map`. On selection a `fetchFields` call retrieves `displayName`, `formattedAddress`, and `location`; the map then pans to the result and places a marker with an info window. All listeners and DOM nodes are removed on unmount.
 
 ---
 
@@ -82,4 +96,4 @@ These components are bundled in this module and re-exported for use by `web_view
 
 **Why it matters**: Lets users visually verify a record's exact location using street-level imagery alongside the standard map, without leaving the form.
 
-**How it works**: `GoogleMapStreetViewSideBySideDialog` loads the `maps` and `marker` libraries in parallel (Street View classes are part of `maps`). Before initialising the panorama it calls `StreetViewService.getPanorama()` to check imagery coverage within 50 metres of the coordinates. If coverage is confirmed (`StreetViewStatus.OK`) the panorama is created and linked to the map via `map.setStreetView()`. If no imagery is available the right panel is replaced by a styled placeholder and an `AdvancedMarkerElement` is placed on the map to indicate the exact position. Configurable `heading`, `pitch`, and `zoom` props control the initial Street View point-of-view.
+**How it works**: `GoogleMapStreetViewSideBySideDialog` checks Street View imagery coverage via `StreetViewService` before initialising the panorama. If coverage is confirmed the panorama is created and linked to the map. If no imagery is available the right panel is replaced by a styled placeholder and a marker is placed on the map to indicate the exact position.

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
@@ -2,8 +2,7 @@ import { registry } from '@web/core/registry';
 import { _t } from '@web/core/l10n/translation';
 import { useService } from '@web/core/utils/hooks';
 import { standardWidgetProps } from '@web/views/widgets/standard_widget_props';
-import { rpc } from '@web/core/network/rpc';
-import { Component, onWillStart, useRef, useEffect, useState, onWillUnmount, useSubEnv } from '@odoo/owl';
+import { Component, useRef, useEffect, useState, onWillUnmount, useSubEnv } from '@odoo/owl';
 
 import { ConfirmationDialog } from '@web/core/confirmation_dialog/confirmation_dialog';
 import { useGoogleMapsAPILoader } from '@base_google_map/utils/loader_google_map';
@@ -31,11 +30,11 @@ class GeolocationEditDialog extends ConfirmationDialog {
         lat: Number,
         lng: Number,
         readonly: Boolean,
+        mapType: String,
     };
 
     static defaultProps = {
         ...ConfirmationDialog.defaultProps,
-        title: _t('Edit Geolocation'),
         confirmLabel: _t('Save'),
     };
 
@@ -59,6 +58,7 @@ class GeolocationEditDialog extends ConfirmationDialog {
         this.googleMap = null;
         this._tilesLoadedListener = null;
         this._isUnmounted = false;
+        this._resolveTilesLoaded = null;
 
         // Local variables to store the latitude and longitude while dragging the marker
         this.localLat = this.props.lat || 0.0;
@@ -114,6 +114,10 @@ class GeolocationEditDialog extends ConfirmationDialog {
             google.maps.event.removeListener(this._tilesLoadedListener);
             this._tilesLoadedListener = null;
         }
+        if (this._resolveTilesLoaded) {
+            this._resolveTilesLoaded(); // unblock any pending await on tilesloaded
+            this._resolveTilesLoaded = null;
+        }
         if (this.marker) {
             if (!this.props.readonly) {
                 google.maps.event.clearListeners(this.marker, 'dragend');
@@ -148,8 +152,14 @@ class GeolocationEditDialog extends ConfirmationDialog {
             const options = {
                 center: { lat, lng },
                 mapId: settings.map_id,
-                zoom: lat && lng ? 16 : 3,
-                mapTypeId: 'roadmap',
+                zoom: lat && lng ? 17 : 3,
+                mapTypeId: this.props.mapType || 'roadmap',
+                gestureHandling: 'greedy',
+                disableDefaultUI: true,
+                zoomControl: true,
+                streetViewControl: true,
+                fullscreenControl: true,
+                mapTypeControl: true,
             };
             const googleMap = new Map(mapElement, options);
             this.googleMap = googleMap;
@@ -177,15 +187,17 @@ class GeolocationEditDialog extends ConfirmationDialog {
      */
     async onMapReady(map) {
         await new Promise((resolve) => {
+            this._resolveTilesLoaded = resolve;
             this._tilesLoadedListener = map.addListener('tilesloaded', () => {
                 google.maps.event.removeListener(this._tilesLoadedListener);
                 this._tilesLoadedListener = null;
+                this._resolveTilesLoaded = null;
                 resolve();
             });
         });
         if (this._isUnmounted) return;
         this.state.isMapReady = true;
-        this.renderMarker();
+        await this.renderMarker();
     }
 
     /**
@@ -213,17 +225,16 @@ class GeolocationEditDialog extends ConfirmationDialog {
             const { AdvancedMarkerElement } = await this.apiLoader.importLibrary('marker');
             if (this._isUnmounted) return;
             this.marker = new AdvancedMarkerElement(markerOptions);
-            if (isZoomIn) {
-                this.googleMap.panTo({ lat, lng });
-            }
             if (!this.props.readonly) {
                 this.marker.addListener('dragend', this._handleMarkerDragend.bind(this));
             }
-            google.maps.event.addListenerOnce(this.googleMap, 'idle', () => {
-                if (!this._isUnmounted && this.googleMap.getZoom() < 16) {
-                    this.googleMap.setZoom(16);
-                }
-            });
+            if (isZoomIn) {
+                google.maps.event.addListenerOnce(this.googleMap, 'idle', () => {
+                    if (!this._isUnmounted && this.googleMap.getZoom() < 16) {
+                        this.googleMap.setZoom(16);
+                    }
+                });
+            }
         } catch (error) {
             this.notificationService.add(
                 _t('Failed to load Google Maps API.\n%(err)s', { err: error.message || error }),
@@ -297,16 +308,34 @@ class GeolocationEditDialog extends ConfirmationDialog {
         this.localLat = typeof position.lat === 'function' ? position.lat() : position.lat;
         this.localLng = typeof position.lng === 'function' ? position.lng() : position.lng;
     }
+
+    get dialogTitle() {
+        return this.props.readonly ? _t('Location on Map') : _t('Update Location');
+    }
+
+    openGoogleMaps() {
+        const lat = this.localLat;
+        const lng = this.localLng;
+        if (lat && lng) {
+            const aHrefEl = document.createElement('a');
+            aHrefEl.href = `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`;
+            aHrefEl.target = '_blank';
+            aHrefEl.rel = 'noopener noreferrer';
+
+            document.body.appendChild(aHrefEl);
+            aHrefEl.click();
+
+            document.body.removeChild(aHrefEl);
+        }
+    }
 }
 
 /**
- * Widget component that displays a Google Maps Static API image for a given location.
- * Renders a collapsible map preview with a toggle button and an edit button that opens
- * `GeolocationEditDialog` for interactive coordinate updates.
- *
- * The static image avoids embedding a cross-origin iframe in the form view, which would
- * cause `SecurityError` in Odoo's `useClickAway` hook whenever a tooltip or popover
- * appears on the same page.
+ * Widget component that renders a single button on a form view.
+ * Clicking the button opens `GeolocationEditDialog`, which shows an interactive
+ * Google Map centred on the record's current coordinates. In edit mode the user
+ * can drag the marker to update the lat/lng fields; in readonly mode the dialog
+ * is read-only with only the "Open in Google Maps" link active.
  *
  * @extends Component
  */
@@ -316,16 +345,7 @@ export class GoogleMapWidget extends Component {
         ...standardWidgetProps,
         lat: String,
         lng: String,
-        width: { type: String, optional: true },
-        height: { type: String, optional: true },
-        zoom: { type: Number, optional: true },
         maptype: { type: String, optional: true },
-    };
-    static defaultProps = {
-        zoom: 14,
-        maptype: 'roadmap',
-        width: 400,
-        height: 200,
     };
 
     /**
@@ -336,54 +356,7 @@ export class GoogleMapWidget extends Component {
      */
     setup() {
         this.validateProps();
-        this.settings = {};
-        this.state = useState({ isMapVisible: false });
         this.dialogService = useService('dialog');
-        onWillStart(this.loadGoogleSetting.bind(this));
-    }
-
-    /**
-     * Loads Google Maps API settings from the server.
-     *
-     * @async
-     * @returns {Promise<void>}
-     */
-    async loadGoogleSetting() {
-        if (!Object.keys(this.settings).length && !this.props.invisible) {
-            const { context } = this.props.record;
-            const settings = await rpc('/web/base_google_map/settings', { context });
-            if (settings) {
-                this.settings = { ...settings };
-            }
-        }
-    }
-
-    /**
-     * Computes the Maps Static API image source URL from the current record coordinates.
-     * Returns `false` when the API key is not yet loaded so the template can hide the
-     * toggle button entirely.
-     *
-     * Because `props.record` is reactive, OWL re-evaluates this getter whenever the
-     * latitude or longitude field changes, automatically updating the displayed image.
-     *
-     * @returns {string|false} The static map image URL, or false if the key is unavailable
-     */
-    get staticMapSrc() {
-        if (this.settings?.api_key) {
-            return this.generateSrc(this.settings.api_key);
-        }
-        return false;
-    }
-
-    /**
-     * Base URL for the Google Maps Static API.
-     * Requires the "Maps Static API" to be enabled in Google Cloud Console
-     * (separate product from Maps Embed API and Maps JavaScript API).
-     *
-     * @returns {string}
-     */
-    get baseUrl() {
-        return 'https://maps.googleapis.com/maps/api/staticmap';
     }
 
     /**
@@ -413,57 +386,6 @@ export class GoogleMapWidget extends Component {
     }
 
     /**
-     * Builds the query-parameter object for the Maps Static API request.
-     *
-     * - `center` + `zoom`: always required; zoom is reduced to 3 when coordinates are 0,0.
-     * - `size`: must be integer pixel dimensions (`WxH`). `toPixels` rejects non-integer
-     *   strings (e.g. "100%") by comparing the parsed integer back to the original string,
-     *   and caps values at 640 (the Static API maximum). Falls back to safe defaults.
-     * - `markers`: added only when valid coordinates exist; omitted for 0,0 to avoid a
-     *   red pin appearing in the middle of the ocean.
-     *
-     * @returns {Object} Query parameters for the Static Maps API
-     */
-    get params() {
-        const lat = this.latitude;
-        const lng = this.longitude;
-        const maptype = this.getMapType();
-        const hasLocation = lat !== 0.0 || lng !== 0.0;
-        const zoom = hasLocation ? this.props.zoom : 3;
-        // Static Maps API requires integer pixel dimensions — reject percentages and other non-integer values.
-        const toPixels = (val, fallback) => {
-            const n = parseInt(val, 10);
-            return Number.isFinite(n) && n > 0 && String(n) === String(val).trim() ? Math.min(n, 640) : fallback;
-        };
-        const width = toPixels(this.props.width, 400);
-        const height = toPixels(this.props.height, 200);
-        const p = {
-            center: `${lat},${lng}`,
-            zoom,
-            size: `${width}x${height}`,
-            maptype,
-        };
-        if (hasLocation) {
-            p.markers = `color:red|${lat},${lng}`;
-        }
-        return p;
-    }
-
-    /**
-     * Assembles the complete Maps Static API image URL from the current params and API key.
-     *
-     * @param {string} api_key - The Google Maps API key
-     * @returns {string} The complete static map image URL
-     */
-    generateSrc(api_key) {
-        const params = { ...this.params, key: api_key };
-        const url = new URL(this.baseUrl);
-        const searchParams = new URLSearchParams(params);
-        url.search = searchParams.toString();
-        return url.toString();
-    }
-
-    /**
      * Validates and returns the map type, defaulting to 'roadmap' if invalid.
      *
      * @returns {string} A valid map type ('roadmap' or 'satellite')
@@ -471,11 +393,6 @@ export class GoogleMapWidget extends Component {
     getMapType() {
         const mapTypes = ['roadmap', 'satellite'];
         if (!mapTypes.includes(this.props.maptype)) {
-            console.warn(
-                `Widget google_map: invalid map type: ${
-                    this.props.maptype
-                }. Defaulting to 'roadmap'. Valid options are: ${mapTypes.join(', ')}.`
-            );
             return 'roadmap';
         }
         return this.props.maptype;
@@ -495,15 +412,6 @@ export class GoogleMapWidget extends Component {
     }
 
     /**
-     * Toggles the static map image visibility.
-     * The image is only rendered (and fetched from Google) while the map is visible,
-     * so toggling to hidden avoids unnecessary API requests on subsequent renders.
-     */
-    toggleMap() {
-        this.state.isMapVisible = !this.state.isMapVisible;
-    }
-
-    /**
      * Opens the geolocation edit dialog for interactive coordinate editing.
      *
      * @async
@@ -514,6 +422,7 @@ export class GoogleMapWidget extends Component {
             lat: this.latitude,
             lng: this.longitude,
             readonly: this.props.readonly,
+            mapType: this.getMapType(),
             confirm: (lat, lng) => {
                 this._updateGeolocation(lat, lng);
             },
@@ -551,10 +460,7 @@ export const googleMapWidget = {
     extractProps: ({ attrs }) => ({
         lat: attrs.lat,
         lng: attrs.lng,
-        zoom: attrs.zoom,
         maptype: attrs.maptype,
-        width: attrs.width,
-        height: attrs.height,
     }),
 };
 

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
@@ -349,10 +349,7 @@ export class GoogleMapWidget extends Component {
     };
 
     /**
-     * Initializes the widget, validates props, and loads Google Maps settings.
-     *
-     * `state.isMapVisible` drives the collapsible map toggle — the static image is only
-     * rendered (and fetched) when the user explicitly shows the map.
+     * Initializes the widget, validates props, and wires up the dialog service.
      */
     setup() {
         this.validateProps();

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.js
@@ -13,6 +13,10 @@ import { GoogleMapSearchPlaces } from '../../components/search_places/search_pla
  * Dialog component for editing geolocation coordinates with an interactive Google Map.
  * Allows users to drag a marker to update latitude and longitude values.
  *
+ * Lifecycle safety: `_isUnmounted` is set in `onWillUnmount` so that every async
+ * continuation (importLibrary, tilesloaded promise, idle callback) becomes a no-op
+ * if the dialog is closed before they fire.
+ *
  * @extends ConfirmationDialog
  */
 class GeolocationEditDialog extends ConfirmationDialog {
@@ -37,7 +41,15 @@ class GeolocationEditDialog extends ConfirmationDialog {
 
     /**
      * Initializes the dialog component, sets up services, state, and Google Maps API loader.
-     * Configures effect hooks for map initialization and cleanup on unmount.
+     * Configures an effect hook for map initialization and registers cleanup on unmount.
+     *
+     * `_tilesLoadedListener` stores the MapsEventListener handle returned by the
+     * `tilesloaded` event so it can be cancelled in `_cleanupListeners` if the dialog
+     * closes before tiles finish rendering.
+     *
+     * `_isUnmounted` acts as a guard flag — set to true in `_cleanupListeners` so
+     * that any pending async step (importLibrary, tilesloaded, idle) returns early
+     * instead of touching a detached component.
      */
     setup() {
         super.setup();
@@ -45,6 +57,8 @@ class GeolocationEditDialog extends ConfirmationDialog {
         this.notificationService = useService('notification');
         this.uiService = useService('ui');
         this.googleMap = null;
+        this._tilesLoadedListener = null;
+        this._isUnmounted = false;
 
         // Local variables to store the latitude and longitude while dragging the marker
         this.localLat = this.props.lat || 0.0;
@@ -83,10 +97,23 @@ class GeolocationEditDialog extends ConfirmationDialog {
     }
 
     /**
-     * Cleans up Google Maps event listeners and marker references to prevent memory leaks.
-     * Called automatically when the component is unmounted.
+     * Cleans up all Google Maps resources to prevent memory leaks and stale callbacks.
+     * Called automatically by `onWillUnmount`.
+     *
+     * Steps in order:
+     * 1. Set `_isUnmounted` so async continuations return early.
+     * 2. Cancel any pending `tilesloaded` listener (can fire after dialog DOM is removed).
+     * 3. Remove the `dragend` listener and detach the marker from the map.
+     * 4. Call `clearInstanceListeners` on the map — removes all remaining Maps API
+     *    event bindings (including those set by the Maps SDK internals) so no queued
+     *    callback can touch the detached cross-origin iframes the SDK creates internally.
      */
     _cleanupListeners() {
+        this._isUnmounted = true;
+        if (this._tilesLoadedListener) {
+            google.maps.event.removeListener(this._tilesLoadedListener);
+            this._tilesLoadedListener = null;
+        }
         if (this.marker) {
             if (!this.props.readonly) {
                 google.maps.event.clearListeners(this.marker, 'dragend');
@@ -95,7 +122,7 @@ class GeolocationEditDialog extends ConfirmationDialog {
             this.marker = null;
         }
         if (this.googleMap) {
-            google.maps.event.clearListeners(this.googleMap, 'idle');
+            google.maps.event.clearInstanceListeners(this.googleMap);
         }
     }
 
@@ -114,6 +141,7 @@ class GeolocationEditDialog extends ConfirmationDialog {
                 return;
             }
             const { Map } = await this.apiLoader.importLibrary('maps');
+            if (this._isUnmounted) return;
             const settings = this.apiLoader.getSettings();
             const mapElement = this.mapRef.el;
             const { lat = 0.0, lng = 0.0 } = this.props;
@@ -139,17 +167,23 @@ class GeolocationEditDialog extends ConfirmationDialog {
     /**
      * Waits for the map tiles to finish loading before rendering the marker.
      *
+     * The `tilesloaded` listener handle is stored on `this._tilesLoadedListener` so
+     * `_cleanupListeners` can cancel it if the dialog closes before tiles finish.
+     * After the await, `_isUnmounted` is checked before touching component state.
+     *
      * @async
      * @param {google.maps.Map} map - The Google Maps instance
      * @returns {Promise<void>}
      */
     async onMapReady(map) {
         await new Promise((resolve) => {
-            const listener = map.addListener('tilesloaded', () => {
-                google.maps.event.removeListener(listener);
+            this._tilesLoadedListener = map.addListener('tilesloaded', () => {
+                google.maps.event.removeListener(this._tilesLoadedListener);
+                this._tilesLoadedListener = null;
                 resolve();
             });
         });
+        if (this._isUnmounted) return;
         this.state.isMapReady = true;
         this.renderMarker();
     }
@@ -158,6 +192,9 @@ class GeolocationEditDialog extends ConfirmationDialog {
      * Renders a draggable marker on the map at the current coordinates.
      * The marker can be dragged to update the location (unless readonly is true).
      * Automatically zooms and centers the map if valid coordinates are provided.
+     *
+     * Guards `_isUnmounted` twice: after `importLibrary` (async) and inside the
+     * `idle` callback so neither path writes to the component after it unmounts.
      *
      * @async
      * @returns {Promise<void>}
@@ -174,6 +211,7 @@ class GeolocationEditDialog extends ConfirmationDialog {
 
         try {
             const { AdvancedMarkerElement } = await this.apiLoader.importLibrary('marker');
+            if (this._isUnmounted) return;
             this.marker = new AdvancedMarkerElement(markerOptions);
             if (isZoomIn) {
                 this.googleMap.panTo({ lat, lng });
@@ -182,7 +220,9 @@ class GeolocationEditDialog extends ConfirmationDialog {
                 this.marker.addListener('dragend', this._handleMarkerDragend.bind(this));
             }
             google.maps.event.addListenerOnce(this.googleMap, 'idle', () => {
-                if (this.googleMap.getZoom() < 16) this.googleMap.setZoom(16);
+                if (!this._isUnmounted && this.googleMap.getZoom() < 16) {
+                    this.googleMap.setZoom(16);
+                }
             });
         } catch (error) {
             this.notificationService.add(
@@ -243,20 +283,30 @@ class GeolocationEditDialog extends ConfirmationDialog {
     /**
      * Handles the marker dragend event, updating local coordinates and centering the map.
      *
+     * `AdvancedMarkerElement.position` after a drag returns a `google.maps.LatLng`
+     * object where `.lat` and `.lng` are methods, not plain numbers. The `typeof`
+     * guard handles both the LatLng object form and a plain `{lat, lng}` literal
+     * so the stored values are always numbers.
+     *
      * @async
      * @returns {Promise<void>}
      */
     async _handleMarkerDragend() {
         const position = this.marker.position;
         this.googleMap.panTo(position);
-        this.localLat = position.lat;
-        this.localLng = position.lng;
+        this.localLat = typeof position.lat === 'function' ? position.lat() : position.lat;
+        this.localLng = typeof position.lng === 'function' ? position.lng() : position.lng;
     }
 }
 
 /**
- * Widget component that displays a Google Maps embed iframe showing a specific location.
- * Provides an edit button to open an interactive dialog for updating coordinates.
+ * Widget component that displays a Google Maps Static API image for a given location.
+ * Renders a collapsible map preview with a toggle button and an edit button that opens
+ * `GeolocationEditDialog` for interactive coordinate updates.
+ *
+ * The static image avoids embedding a cross-origin iframe in the form view, which would
+ * cause `SecurityError` in Odoo's `useClickAway` hook whenever a tooltip or popover
+ * appears on the same page.
  *
  * @extends Component
  */
@@ -280,12 +330,16 @@ export class GoogleMapWidget extends Component {
 
     /**
      * Initializes the widget, validates props, and loads Google Maps settings.
+     *
+     * `state.isMapVisible` drives the collapsible map toggle — the static image is only
+     * rendered (and fetched) when the user explicitly shows the map.
      */
     setup() {
         this.validateProps();
         this.settings = {};
+        this.state = useState({ isMapVisible: false });
         this.dialogService = useService('dialog');
-        onWillStart(this.loadGoogleSetting);
+        onWillStart(this.loadGoogleSetting.bind(this));
     }
 
     /**
@@ -305,24 +359,31 @@ export class GoogleMapWidget extends Component {
     }
 
     /**
-     * Generates the Google Maps Embed API iframe source URL.
+     * Computes the Maps Static API image source URL from the current record coordinates.
+     * Returns `false` when the API key is not yet loaded so the template can hide the
+     * toggle button entirely.
      *
-     * @returns {string|boolean} The iframe source URL or false if settings are not available
+     * Because `props.record` is reactive, OWL re-evaluates this getter whenever the
+     * latitude or longitude field changes, automatically updating the displayed image.
+     *
+     * @returns {string|false} The static map image URL, or false if the key is unavailable
      */
-    get iframeSrc() {
-        if (this.settings) {
+    get staticMapSrc() {
+        if (this.settings?.api_key) {
             return this.generateSrc(this.settings.api_key);
         }
         return false;
     }
 
     /**
-     * Returns the base URL for Google Maps Embed API.
+     * Base URL for the Google Maps Static API.
+     * Requires the "Maps Static API" to be enabled in Google Cloud Console
+     * (separate product from Maps Embed API and Maps JavaScript API).
      *
-     * @returns {string} The base URL for the embed API
+     * @returns {string}
      */
     get baseUrl() {
-        return 'https://www.google.com/maps/embed/v1/place';
+        return 'https://maps.googleapis.com/maps/api/staticmap';
     }
 
     /**
@@ -352,31 +413,47 @@ export class GoogleMapWidget extends Component {
     }
 
     /**
-     * Generates the parameters for the Google Maps Embed API URL.
-     * Adjusts zoom level based on whether valid coordinates are provided.
+     * Builds the query-parameter object for the Maps Static API request.
      *
-     * @returns {Object} An object containing query parameters (q, zoom, maptype)
+     * - `center` + `zoom`: always required; zoom is reduced to 3 when coordinates are 0,0.
+     * - `size`: must be integer pixel dimensions (`WxH`). `toPixels` rejects non-integer
+     *   strings (e.g. "100%") by comparing the parsed integer back to the original string,
+     *   and caps values at 640 (the Static API maximum). Falls back to safe defaults.
+     * - `markers`: added only when valid coordinates exist; omitted for 0,0 to avoid a
+     *   red pin appearing in the middle of the ocean.
+     *
+     * @returns {Object} Query parameters for the Static Maps API
      */
     get params() {
         const lat = this.latitude;
         const lng = this.longitude;
         const maptype = this.getMapType();
-        let zoom = this.props.zoom;
-        if (lat === 0.0 && lng === 0.0) {
-            zoom = 3;
-        }
-        return {
-            q: `${lat},${lng}`,
+        const hasLocation = lat !== 0.0 || lng !== 0.0;
+        const zoom = hasLocation ? this.props.zoom : 3;
+        // Static Maps API requires integer pixel dimensions — reject percentages and other non-integer values.
+        const toPixels = (val, fallback) => {
+            const n = parseInt(val, 10);
+            return Number.isFinite(n) && n > 0 && String(n) === String(val).trim() ? Math.min(n, 640) : fallback;
+        };
+        const width = toPixels(this.props.width, 400);
+        const height = toPixels(this.props.height, 200);
+        const p = {
+            center: `${lat},${lng}`,
             zoom,
+            size: `${width}x${height}`,
             maptype,
         };
+        if (hasLocation) {
+            p.markers = `color:red|${lat},${lng}`;
+        }
+        return p;
     }
 
     /**
-     * Generates the complete Google Maps Embed API iframe source URL.
+     * Assembles the complete Maps Static API image URL from the current params and API key.
      *
      * @param {string} api_key - The Google Maps API key
-     * @returns {string} The complete iframe source URL with all parameters
+     * @returns {string} The complete static map image URL
      */
     generateSrc(api_key) {
         const params = { ...this.params, key: api_key };
@@ -415,6 +492,15 @@ export class GoogleMapWidget extends Component {
             [this.props.lat]: lat,
             [this.props.lng]: lng,
         });
+    }
+
+    /**
+     * Toggles the static map image visibility.
+     * The image is only rendered (and fetched from Google) while the map is visible,
+     * so toggling to hidden avoids unnecessary API requests on subsequent renders.
+     */
+    toggleMap() {
+        this.state.isMapVisible = !this.state.isMapVisible;
     }
 
     /**

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
@@ -1,20 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="web_widget_google_map.GoogleMapWidget">
-        <div class="d-flex flex-column" t-if="!props.invisible">
-            <div class="o_google_map_widget" t-if="iframeSrc">
-                <iframe
+        <div class="d-flex flex-column gap-1" t-if="!props.invisible">
+            <div class="d-flex gap-2">
+                <button type="button" class="btn btn-light" t-if="staticMapSrc" t-on-click="toggleMap">
+                    <i t-attf-class="fa fa-fw {{ state.isMapVisible ? 'fa-chevron-up' : 'fa-map-marker' }} me-1" />
+                    <t t-esc="state.isMapVisible ? 'Hide Map' : 'Show Map'" />
+                </button>
+                <button type="button" class="btn btn-light" t-on-click="handleOnEdit" t-if="!props.readonly">
+                    <i class="fa fa-fw fa-pencil me-1" />
+                    Edit
+                </button>
+            </div>
+            <div class="o_google_map_widget" t-if="staticMapSrc and state.isMapVisible">
+                <img
                     loading="lazy"
                     t-att-width="props.width"
                     t-att-height="props.height"
-                    frameborder="0"
-                    style="border:0"
-                    referrerpolicy="no-referrer-when-downgrade"
-                    t-att-src="iframeSrc"
-                    allowfullscreen="allowfullscreen"
+                    style="border:0;display:block"
+                    t-att-src="staticMapSrc"
+                    alt="Google Maps preview"
                 />
             </div>
-            <button type="button" class="btn btn-light" t-on-click="handleOnEdit" t-if="!props.readonly">Edit</button>
         </div>
     </t>
     <t t-name="web_widget_google_map.GeolocationEditDialog">

--- a/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
+++ b/web_widget_google_map/static/src/widgets/GoogleMap/google_map.xml
@@ -1,32 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="web_widget_google_map.GoogleMapWidget">
-        <div class="d-flex flex-column gap-1" t-if="!props.invisible">
-            <div class="d-flex gap-2">
-                <button type="button" class="btn btn-light" t-if="staticMapSrc" t-on-click="toggleMap">
-                    <i t-attf-class="fa fa-fw {{ state.isMapVisible ? 'fa-chevron-up' : 'fa-map-marker' }} me-1" />
-                    <t t-esc="state.isMapVisible ? 'Hide Map' : 'Show Map'" />
-                </button>
-                <button type="button" class="btn btn-light" t-on-click="handleOnEdit" t-if="!props.readonly">
-                    <i class="fa fa-fw fa-pencil me-1" />
-                    Edit
-                </button>
-            </div>
-            <div class="o_google_map_widget" t-if="staticMapSrc and state.isMapVisible">
-                <img
-                    loading="lazy"
-                    t-att-width="props.width"
-                    t-att-height="props.height"
-                    style="border:0;display:block"
-                    t-att-src="staticMapSrc"
-                    alt="Google Maps preview"
-                />
-            </div>
+        <div t-if="!props.invisible">
+            <button
+                type="button"
+                class="btn btn-link p-0"
+                t-on-click="handleOnEdit"
+                t-attf-data-tooltip="{{ props.readonly ? 'Show on Map' : 'Update Location on Map' }}"
+            >
+                <i t-attf-class="fa me-1 {{ props.readonly ? 'fa-map-o' : 'fa-map-pin'}}" />
+                <span t-if="props.readonly">View on Map</span>
+                <span t-else="">Update on Map</span>
+            </button>
         </div>
     </t>
     <t t-name="web_widget_google_map.GeolocationEditDialog">
-        <Dialog size="'xl'" title="props.title" modalRef="modalRef">
-            <div class="alert alert-info text-center">Drag the marker to update the location</div>
+        <Dialog size="'xl'" title="dialogTitle" modalRef="modalRef">
+            <div class="alert alert-info text-center" t-if="!props.readonly">
+                Drag the marker to update the location
+            </div>
             <div class="o_google_map_form">
                 <div class="o_google_map_renderer">
                     <div class="o_google_map_view" t-ref="map" />
@@ -34,20 +26,31 @@
                 </div>
             </div>
             <t t-set-slot="footer">
+                <t t-if="!props.readonly">
+                    <button
+                        class="btn"
+                        t-att-class="props.confirmClass"
+                        t-on-click="_confirm"
+                        t-esc="props.confirmLabel"
+                        data-hotkey="q"
+                    />
+                    <button
+                        t-if="props.cancel"
+                        class="btn btn-secondary"
+                        t-on-click="_cancel"
+                        t-esc="props.cancelLabel"
+                        data-hotkey="x"
+                    />
+                </t>
                 <button
-                    class="btn"
-                    t-att-class="props.confirmClass"
-                    t-on-click="_confirm"
-                    t-esc="props.confirmLabel"
-                    data-hotkey="q"
-                />
-                <button
-                    t-if="props.cancel"
-                    class="btn btn-secondary"
-                    t-on-click="_cancel"
-                    t-esc="props.cancelLabel"
-                    data-hotkey="x"
-                />
+                    class="btn btn-link"
+                    t-on-click="openGoogleMaps"
+                    style="margin-left: auto; margin-right: 0px;"
+                    data-tooltip="Open in Google Maps Website"
+                >
+                    <i class="fa fa-fw fa-external-link" />
+                    <span>Open in Google Maps</span>
+                </button>
             </t>
         </Dialog>
     </t>


### PR DESCRIPTION
- Replace Google Maps Embed API `<iframe>` with a Static API `<img>` — eliminates the cross-origin `SecurityError` Odoo's `useClickAway` hook (used by every `data-tooltip` / Popover) triggers when it calls `contentWindow.addEventListener` on cross-origin iframes
- Add collapsible map toggle: static image is hidden by default and revealed by a "Show Map" / "Hide Map" button, so no API request is made on form load; the image URL recomputes via OWL reactivity whenever coordinates change
- Fix `_handleMarkerDragend`: `AdvancedMarkerElement.position` after a drag returns a `LatLng` object where `.lat` / `.lng` are methods — add `typeof position.lat === 'function'` guard to always store plain numbers, preventing a stringified function from appearing in the static map URL after saving
- Add unmount safety guards in `GeolocationEditDialog`: store `_tilesLoadedListener` handle so it can be cancelled in `_cleanupListeners`; set `_isUnmounted` flag on unmount and check it after every `await` (`importLibrary`, `tilesloaded`, `idle` callback) to prevent stale callbacks touching a detached component; replace `clearListeners(map, 'idle')` with `clearInstanceListeners(map)` to cancel all remaining Maps SDK event bindings
- Update `params` getter: use `center` + `markers` instead of `q`; add `size` parameter with `toPixels` guard capping at 640 (Static API maximum); omit red marker pin when coordinates are 0,0