### PR TITLE
[FIX] web_widget_google_map: fix WebGL context leak, wrong marker detach API, and orphaned default panorama in StreetView dialog (v19.0.1.0.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The core map view module. Adds a `google_map` view type alongside list, kanban, 
 
 Extends the map view with geographic drawing tools. Users can draw polygons, rectangles, and freehand shapes directly on the map. Shapes are stored as GeoJSON on the record and support server-side filtering so you can query which records fall inside a drawn area. Built on [Terra Draw](https://terradraw.io/) and [Deck.gl](https://deck.gl/); all libraries are bundled locally.
 
-**[web_widget_google_map](web_widget_google_map/README.md)** [`19.0.1.0.7`](web_widget_google_map/CHANGELOG.md)
+**[web_widget_google_map](web_widget_google_map/README.md)** [`19.0.1.0.9`](web_widget_google_map/CHANGELOG.md)
 
 Adds an embedded Google Map to any Odoo form. Shows the record's saved location and lets users update it visually — by dragging a marker or typing a place name — without leaving the form. A Street View side-by-side dialog lets users verify the exact location with street-level imagery alongside the standard map; it falls back gracefully when no Street View coverage is available.
 

--- a/web_widget_google_map/CHANGELOG.md
+++ b/web_widget_google_map/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## 19.0.1.0.9
+
+### Fixed
+
+- **`GoogleMapStreetViewSideBySideDialog._cleanup()` — wrong marker detach API**: `_locationMarker.map = null` (the `AdvancedMarkerElement` shorthand) replaced with `_locationMarker.setMap(null)`, which is the correct `OverlayView` API now that the fallback pin is a custom overlay rather than an `AdvancedMarkerElement`.
+- **`GoogleMapStreetViewSideBySideDialog._cleanup()` — SDK default panorama left alive**: When Street View is unavailable the user can still drag pegman onto the left map, causing the Maps SDK to lazily create its own default panorama. Added explicit fetch and disposal (`setVisible(false)`, `clearInstanceListeners`, `unbindAll`) of that default panorama in the `_cleanup` no-panorama branch.
+- **`GoogleMapStreetViewSideBySideDialog._cleanup()` — DOM clear interrupting active WebGL render**: The synchronous `.innerHTML = ''` on the map and Street View containers could run mid-render and corrupt the WebGL context. Deferred to `requestAnimationFrame` so the DOM teardown never interrupts an active paint. The synchronous teardown (`unbindAll`, `clearInstanceListeners`, nulling refs) still runs immediately to stop tile fetching.
+
+### Changed
+
+- **`GoogleMapStreetViewSideBySideDialog` — removed `mapId` from `Map` constructor**: The dialog's left-panel map is now intentionally plain/raster (no vector rendering). A vector map that shared a `mapId` with other maps on the page was causing the parent view's map to go blank after the dialog closed due to exhausting the browser's shared WebGL context limit. Removing `mapId` avoids that shared context entirely.
+- **`GoogleMapStreetViewSideBySideDialog` — `AdvancedMarkerElement` → `LocationPinOverlay`**: When Street View is unavailable, the location pin is now rendered via a lazily-built `OverlayView` subclass (`LocationPinOverlay`) instead of `AdvancedMarkerElement`. `AdvancedMarkerElement` requires a `mapId` which this dialog's map no longer sets; `OverlayView` works on any map type.
+- **`google_map.js` — `GoogleMapWidget.setup()` JSDoc**: Removed stale `state.isMapVisible` / collapsible-toggle / static-image description left over from the previous two-button design; replaced with an accurate one-liner.
+
+### Improved
+
+- **Manifest — summary and description**: Updated to reflect the single-button widget design; removed all references to the Maps Static API and the collapsible image preview.
+
 ## 19.0.1.0.8
 
 ### Changed

--- a/web_widget_google_map/__manifest__.py
+++ b/web_widget_google_map/__manifest__.py
@@ -23,7 +23,7 @@ Provides:
     "website": "https://www.mithnusa.com",
     "support": "yopiangi@gmail.com",
     "category": "Extra Tools",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     "depends": ["base_google_map"],
     "assets": {
         "web.assets_backend": [

--- a/web_widget_google_map/static/src/widgets/GoogleMapStreetViewSideBySideDialog/google_map_street_view_side_by_side_dialog.js
+++ b/web_widget_google_map/static/src/widgets/GoogleMapStreetViewSideBySideDialog/google_map_street_view_side_by_side_dialog.js
@@ -4,6 +4,53 @@ import { useService } from '@web/core/utils/hooks';
 import { _t } from '@web/core/l10n/translation';
 import { useGoogleMapsAPILoader } from '@base_google_map/utils/loader_google_map';
 
+// Lazily-built `OverlayView` subclass used to mark the target location when
+// Street View isn't available. Built on first use (after the `maps` library
+// has loaded) rather than at module scope, since `google.maps.OverlayView`
+// doesn't exist until then. Avoids `AdvancedMarkerElement` (needs a `mapId`,
+// which this dialog's map intentionally doesn't set) and the deprecated
+// `google.maps.Marker`.
+let LocationPinOverlay;
+function getLocationPinOverlay() {
+    if (!LocationPinOverlay) {
+        LocationPinOverlay = class extends google.maps.OverlayView {
+            constructor(position, map) {
+                super();
+                this.position = position;
+                this.div = null;
+                this.setMap(map);
+            }
+            onAdd() {
+                this.div = document.createElement('div');
+                Object.assign(this.div.style, {
+                    position: 'absolute',
+                    width: '18px',
+                    height: '18px',
+                    marginLeft: '-8px',
+                    marginTop: '-8px',
+                    borderRadius: '50%',
+                    background: '#ea4335',
+                    border: '2px solid #ffffff',
+                    boxShadow: '0 1px 4px rgba(0, 0, 0, 0.4)',
+                });
+                this.getPanes().overlayMouseTarget.appendChild(this.div);
+            }
+            draw() {
+                const point = this.getProjection()?.fromLatLngToDivPixel(this.position);
+                if (point && this.div) {
+                    this.div.style.left = `${point.x}px`;
+                    this.div.style.top = `${point.y}px`;
+                }
+            }
+            onRemove() {
+                this.div?.parentNode?.removeChild(this.div);
+                this.div = null;
+            }
+        };
+    }
+    return LocationPinOverlay;
+}
+
 export class GoogleMapStreetViewSideBySideDialog extends Component {
     static template = 'web_widget_google_map.GoogleMapStreetViewSideBySideDialog';
     static components = { Dialog };
@@ -19,7 +66,7 @@ export class GoogleMapStreetViewSideBySideDialog extends Component {
     static defaultProps = {
         title: _t('Street View'),
         pitch: 10,
-        zoom: 0,
+        zoom: 0, // Default zoom level for Street View panorama (0-5).
     };
 
     setup() {
@@ -72,7 +119,7 @@ export class GoogleMapStreetViewSideBySideDialog extends Component {
 
     _cleanup() {
         if (this._locationMarker) {
-            this._locationMarker.map = null;
+            this._locationMarker.setMap(null);
             this._locationMarker = null;
         }
         if (this.panorama) {
@@ -89,50 +136,62 @@ export class GoogleMapStreetViewSideBySideDialog extends Component {
             google.maps.event.clearInstanceListeners(this.panorama);
             this.panorama.unbindAll();
             this.panorama = null;
+        } else if (this.googleMap) {
+            // No explicit panorama was bound (Street View unavailable branch),
+            // but the user may still have dragged pegman onto the left map —
+            // a nearby road can have coverage even if the exact address
+            // doesn't. In that case the SDK lazily creates its own default
+            // panorama for the pegman control that we hold no other
+            // reference to; fetch and dispose of it explicitly here.
+            const defaultStreetView = this.googleMap.getStreetView();
+            if (defaultStreetView) {
+                defaultStreetView.setVisible(false);
+                google.maps.event.clearInstanceListeners(defaultStreetView);
+                defaultStreetView.unbindAll();
+            }
         }
         if (this.googleMap) {
             google.maps.event.clearInstanceListeners(this.googleMap);
             this.googleMap.unbindAll();
             this.googleMap = null;
         }
-        // Remove the canvas elements so the browser can release their WebGL
-        // contexts immediately rather than waiting for GC. Without this, rapid
-        // open/close cycles exhaust the browser's WebGL context limit (~16) and
-        // cause subsequent map renders to go blank.
-        if (this.mapRef.el) {
-            this.mapRef.el.innerHTML = '';
-        }
-        if (this.streetViewRef.el) {
-            this.streetViewRef.el.innerHTML = '';
-        }
+        // _cleanup() — defer the destructive DOM clear to the next frame so it never
+        // interrupts a live WebGL render pass on this (or a sibling) vector map.
+        // The explicit teardown above (unbindAll/clearInstanceListeners/nulling refs)
+        // still runs synchronously and immediately stops tile/imagery fetching.
+        requestAnimationFrame(() => {
+            if (this.mapRef.el) {
+                this.mapRef.el.innerHTML = '';
+            }
+            if (this.streetViewRef.el) {
+                this.streetViewRef.el.innerHTML = '';
+            }
+        });
     }
 
     async initializeMapAndStreetView() {
         if (this.googleMap || this._initInProgress) return;
         try {
             this._initInProgress = true;
-            const [
-                { Map },
-                { StreetViewPanorama, StreetViewService, StreetViewStatus },
-                { AdvancedMarkerElement },
-                { spherical },
-            ] = await Promise.all([
-                this.apiLoader.importLibrary('maps'),
-                this.apiLoader.importLibrary('streetView'),
-                this.apiLoader.importLibrary('marker'),
-                this.apiLoader.importLibrary('geometry'),
-            ]);
+            const [{ Map }, { StreetViewPanorama, StreetViewService, StreetViewStatus }, { spherical }] =
+                await Promise.all([
+                    this.apiLoader.importLibrary('maps'),
+                    this.apiLoader.importLibrary('streetView'),
+                    this.apiLoader.importLibrary('geometry'),
+                ]);
 
             if (!this._isMounted) return;
 
-            const settings = this.apiLoader.getSettings();
             const { lat, lng, heading, pitch, zoom } = this.props;
             const position = { lat, lng };
 
             // Always create the map so the left panel is usable regardless.
+            // No mapId: this map is intentionally plain/raster, not vector-rendered
+            // (WebGL). Vector maps sharing a mapId with other maps on the page were
+            // implicated in the parent view's map going blank after this dialog
+            // closes; going raster here avoids that shared WebGL context entirely.
             const map = new Map(this.mapRef.el, {
                 center: position,
-                mapId: settings.map_id,
                 zoom: 14,
             });
             this.googleMap = map;
@@ -155,7 +214,8 @@ export class GoogleMapStreetViewSideBySideDialog extends Component {
 
             if (svStatus !== StreetViewStatus.OK) {
                 this.state.streetViewAvailable = false;
-                this._locationMarker = new AdvancedMarkerElement({ map, position });
+                const LocationPinOverlay = getLocationPinOverlay();
+                this._locationMarker = new LocationPinOverlay(position, map);
                 return;
             }
 


### PR DESCRIPTION
- Remove `mapId` from the dialog's left-panel `Map` constructor — a vector map sharing a `mapId` with other maps on the page was exhausting the browser's shared WebGL context limit (~16) and causing the parent view's map to go blank after the dialog closed; the dialog map is now intentionally plain/raster
- Replace `AdvancedMarkerElement` (requires `mapId`) with a lazily-built `LocationPinOverlay` (`OverlayView` subclass) for the no-Street-View fallback pin; `LocationPinOverlay` is built on first use after the `maps` library loads and works on any map type
- Fix `_cleanup()`: replace `_locationMarker.map = null` with `_locationMarker.setMap(null)` — the correct `OverlayView` API for removing a custom overlay
- Add disposal of the SDK's default panorama in `_cleanup()` for the no-Street-View branch: `getStreetView()` + `setVisible(false)` + `clearInstanceListeners` + `unbindAll` — prevents the lazy panorama the SDK creates when the user drags pegman from leaking after dialog close
- Defer `.innerHTML = ''` DOM teardown to `requestAnimationFrame` so it never interrupts a live WebGL render pass; synchronous `unbindAll` / `clearInstanceListeners` / ref-nulling still runs immediately to stop tile fetching
- Drop `marker` library from `Promise.all` in `initializeMapAndStreetView` (no longer needed after switching to `LocationPinOverlay`)