### PR TITLE
[ADD] contacts_google_address_validation: new module — validate and standardize Contact addresses via Google Address Validation API (v19.0.2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Sign up at [Google Cloud Console](https://console.cloud.google.com/) and create 
 | Maps JavaScript API | Map rendering |
 | Places API (New) | Address autocomplete and place search |
 | Geocoding API | Coordinate-to-address and address-to-coordinate lookup |
+| Address Validation API | Verify and standardize addresses |
 
 → [Get a Google Maps API Key](https://developers.google.com/maps/documentation/javascript/get-api-key)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A suite of Odoo 19.0 addons that bring interactive Google Maps into your Odoo wo
 | Address & place autocomplete | `web_widget_google_place_autocomplete` |
 | Click-to-create foundation | `base_google_map_add_place` |
 | Contacts map & autocomplete | `contacts_google_map`, `contacts_google_map_add_place`, `contacts_google_autocomplete`, `partner_autocomplete_with_google_autocomplete` |
+| Address validation | `contacts_google_address_validation` |
 | CRM map & autocomplete | `crm_google_map`, `crm_google_map_add_place`, `crm_google_autocomplete` |
 | Sales map | `sale_google_map` |
 | Inventory map | `stock_google_map` |
@@ -80,6 +81,8 @@ graph LR
 
     contacts_google_map --> contacts_google_map_add_place
     crm_google_map --> crm_google_map_add_place
+
+    base_google_map --> contacts_google_address_validation
 ```
 
 ---
@@ -131,6 +134,10 @@ Adds Google Places autocomplete to the Contact form. Typing in the partner name 
 **[partner_autocomplete_with_google_autocomplete](partner_autocomplete_with_google_autocomplete/README.md)** [`19.0.1.0.6`](partner_autocomplete_with_google_autocomplete/CHANGELOG.md)
 
 Enhances the Contact name field with a Google Places panel alongside Odoo's built-in partner autocomplete. A toggle lets the user switch between Odoo's database suggestions and Google Places results on the same input. Applied automatically to all contact forms — no view customization required.
+
+**[contacts_google_address_validation](contacts_google_address_validation/README.md)** [`19.0.2.0.0`](contacts_google_address_validation/CHANGELOG.md)
+
+Adds a **Validate Address** button to the Contact form that checks the stored address against the Google Address Validation API. A dialog shows the validation verdict, a side-by-side comparison of the current and Google's standardized address, and a component-level breakdown with confirmation levels. Users can apply Google's standardized address and geocoordinates in one click or keep the existing address. Validation status (Validated / Needs Review / Invalid), granularity, date, and API response ID are stored on the partner and available in list views, filters, and automations. Editing any address field automatically resets the status to Not Validated.
 
 ---
 
@@ -209,6 +216,7 @@ Install `base_google_map`, then go to **Settings → General Settings → Google
 | Show contacts on a map | `contacts_google_map` |
 | Create contacts by clicking on the map | `contacts_google_map_add_place` |
 | Autocomplete addresses on the Contact form | `contacts_google_autocomplete` |
+| Validate and standardize Contact addresses | `contacts_google_address_validation` |
 | Show CRM leads on a map | `crm_google_map` |
 | Create leads by clicking on the map | `crm_google_map_add_place` |
 | Show sales orders on a map | `sale_google_map` |

--- a/contacts_google_address_validation/CHANGELOG.md
+++ b/contacts_google_address_validation/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 19.0.2.0.0
+
+- Moved all Google Address Validation API communication server-side into the new `google.address.validation` abstract model (REST `v1:validateAddress`); the widget and dialog remain in JavaScript but no longer call Google directly
+- New optional "Address Validation Server Key" setting (referrer-restricted browser keys are rejected by Google for server-side requests)
+- `action_apply_google_address_validation` now takes the normalized result + apply flag (breaking change for custom callers)
+- Removed the stored Google/USPS standardized address fields and the cache GC cron
+- Added Python test suites for the service and the partner flow
+
+## 19.0.1.0.0
+
+- Initial release
+- Validate Address button + review dialog on the Contact form using the Google Address Validation library (Maps JavaScript API)
+- Apply Google's standardized address and geocode, or store the verdict only
+- Stored verdict fields on `res.partner` with automatic reset on address edit
+- Search filters by validation status

--- a/contacts_google_address_validation/README.md
+++ b/contacts_google_address_validation/README.md
@@ -1,0 +1,58 @@
+# Contacts Google Address Validation
+
+## Overview
+
+`contacts_google_address_validation` adds the Google Address Validation API (Maps JavaScript API, `addressValidation` library) to the Odoo Contact form. It checks whether an entered address refers to a real, deliverable place, standardizes it for mailing, and geocodes it — directly from the Contact form.
+
+## What It Does
+
+Adds a **Validate Address** button below the address block on the Contact form. Clicking it sends the entered address to Google's `fetchAddressValidation` method and opens a review dialog summarizing the verdict. The user can apply Google's standardized address (including latitude/longitude) or keep the entered address while storing only the validation verdict.
+
+## Key Features
+
+- **Validate Address Button**: One-click validation of the contact's address; the contact's country is passed as `regionCode` for more accurate results
+- **Validation Dialog**: Shows Google's verdict — validation granularity, address completeness, unconfirmed / inferred / replaced components — with a recommendation following Google's accept / confirm / fix guidance
+- **Side-by-Side Comparison**: Entered address vs. Google's standardized formatted address
+- **Component Breakdown**: Every address component with its confirmation level (Confirmed / Plausible / Suspicious) and inferred / replaced / spell-corrected flags
+- **USPS CASS™ for US/PR**: Delivery Point Validation (DPV) confirmation, vacancy and No-Stat indicators, and the CASS-corrected mailing address shown in the dialog; the DPV code is stored in the chatter note
+- **Apply Google's Address**: Writes the standardized street, street2, city, state, zip, and country plus the geocode latitude/longitude in a single write; state and country records are resolved server-side
+- **Stored Verdict**: Validation status (Validated / Needs Review / Invalid), granularity, validation date, and API response ID are stored on the contact
+- **Automatic Reset**: Editing any address field resets the status to Not Validated
+- **Search Filters**: Filter contacts by validation status to find unvalidated or problematic addresses
+
+## Dependencies
+
+- `contacts`
+- `base_google_map`
+
+## Installation
+
+1. Install `base_google_map` and configure your Google Maps API key in **Settings → General Settings → Google Maps**
+2. Enable the **Address Validation API** in your Google Cloud Console
+3. Install this module through Odoo Apps
+
+### Required Google Cloud APIs
+
+- Maps JavaScript API (required)
+- Address Validation API (required)
+
+## Basic Usage
+
+1. Open a contact and enter an address
+2. Click **Validate Address** below the address block
+3. Review the verdict in the dialog:
+   - **Apply Google's Address** — replace the entered address with the standardized one and store the verdict
+   - **Keep current Address** — store only the verdict
+   - **Discard** — close without storing anything
+4. The validation badge next to the button reflects the stored status
+
+## Notes
+
+- Address Validation API calls are billed by Google. Each click on **Validate Address** performs one billable request.
+- Coverage varies by country. See [Country and region coverage](https://developers.google.com/maps/documentation/javascript/address-validation/coverage).
+- USPS CASS™ processing is enabled automatically for US and Puerto Rico addresses. The validation dialog shows the DPV (Delivery Point Validation) confirmation, vacancy and No-Stat indicators, and the CASS-corrected mailing address; the DPV code is also logged in the chatter. The CASS-corrected address itself is displayed only and never stored, per the Google Maps Platform caching terms.
+
+## Related Modules
+
+- `base_google_map`: Provides the API key configuration and Google Maps JavaScript API loader
+- `contacts_google_autocomplete`: Google Places autocomplete on the Contact form — complementary; autocomplete helps enter addresses, validation verifies them

--- a/contacts_google_address_validation/README.md
+++ b/contacts_google_address_validation/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`contacts_google_address_validation` adds the Google Address Validation API (Maps JavaScript API, `addressValidation` library) to the Odoo Contact form. It checks whether an entered address refers to a real, deliverable place, standardizes it for mailing, and geocodes it — directly from the Contact form.
+`contacts_google_address_validation` adds the Google Address Validation API to the Odoo Contact form. It checks whether an entered address refers to a real, deliverable place, standardizes it for mailing, and geocodes it — directly from the Contact form.
 
 ## What It Does
 

--- a/contacts_google_address_validation/README.md
+++ b/contacts_google_address_validation/README.md
@@ -33,7 +33,6 @@ Adds a **Validate Address** button below the address block on the Contact form. 
 
 ### Required Google Cloud APIs
 
-- Maps JavaScript API (required)
 - Address Validation API (required)
 
 ## Basic Usage

--- a/contacts_google_address_validation/README.md
+++ b/contacts_google_address_validation/README.md
@@ -6,7 +6,7 @@
 
 ## What It Does
 
-Adds a **Validate Address** button below the address block on the Contact form. Clicking it sends the entered address to Google's `fetchAddressValidation` method and opens a review dialog summarizing the verdict. The user can apply Google's standardized address (including latitude/longitude) or keep the entered address while storing only the validation verdict.
+Adds a **Validate Address** button below the address block on the Contact form. Clicking it sends the entered address via a server-side POST to the Google Address Validation REST API (`https://addressvalidation.googleapis.com/v1:validateAddress`) and opens a review dialog summarizing the verdict. The user can apply Google's standardized address (including latitude/longitude) or keep the entered address while storing only the validation verdict.
 
 ## Key Features
 

--- a/contacts_google_address_validation/README.md
+++ b/contacts_google_address_validation/README.md
@@ -30,10 +30,42 @@ Adds a **Validate Address** button below the address block on the Contact form. 
 1. Install `base_google_map` and configure your Google Maps API key in **Settings → General Settings → Google Maps**
 2. Enable the **Address Validation API** in your Google Cloud Console
 3. Install this module through Odoo Apps
+4. Configure a dedicated server key (see **API Key Setup** below) and enter it in **Settings → General Settings → Google Maps → Address Validation Server Key**
 
 ### Required Google Cloud APIs
 
 - Address Validation API (required)
+
+## API Key Setup
+
+This module calls the Address Validation API **from the Odoo server**, not from the browser. This changes which key restrictions work, so the recommended setup uses **two API keys**, each restricted to match where it runs:
+
+| Key | Used by | Application restriction | API restrictions |
+| --- | --- | --- | --- |
+| Browser key (`base_google_map`) | Map views, autocomplete widgets (browser) | **Websites** (HTTP referrers) — your Odoo domains | Maps JavaScript API, Places API (New), Geocoding API |
+| Server key (this module) | Address Validation (Odoo server) | **IP addresses** — or **None** on hosts without a static IP (see below) | Address Validation API only |
+
+Do **not** reuse the browser key for this module: Google rejects HTTP-referrer restricted keys for server-side requests (`PERMISSION_DENIED`).
+
+### Creating the server key
+
+1. In the [Google Cloud Console](https://console.cloud.google.com/apis/credentials), open **APIs & Services → Credentials** and click **Create credentials → API key**
+2. Rename it clearly, e.g. *Odoo Address Validation (server)*
+3. Under **API restrictions**, select **Restrict key** and check only **Address Validation API**
+4. Under **Application restrictions**:
+   - **Server with a static IP** (on-premise, VPS): select **IP addresses** and add the server's outbound (egress) IP — verify it from the server itself with `curl ifconfig.me`
+   - **Odoo.sh or other hosts without a static IP**: select **None** (see next section)
+5. Save, then enter the key in **Settings → General Settings → Google Maps → Address Validation Server Key**
+
+### Hosting without a static IP (Odoo.sh)
+
+Odoo.sh does not provide static IP addresses — the outbound IP of your instance can change at any time, which would break an IP-restricted key. The recommended setup in that case relies on API restrictions plus usage limits instead of an IP allowlist:
+
+1. Create the server key with **Application restrictions: None** and **API restrictions: Address Validation API only** (steps above)
+2. Cap the usage: in **APIs & Services → Address Validation API → Quotas**, set a per-day request limit that comfortably covers your real usage (e.g. a few hundred requests per day)
+3. Set a billing alert: in **Billing → Budgets & alerts**, create a budget with email alerts so unexpected usage is flagged early
+
+This is safe in practice because the key never reaches the browser — it is stored in Odoo system parameters and used only in server-to-Google requests — and even if it leaked, the API restriction limits it to the Address Validation API, capped by your quota.
 
 ## Basic Usage
 

--- a/contacts_google_address_validation/__init__.py
+++ b/contacts_google_address_validation/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/contacts_google_address_validation/__manifest__.py
+++ b/contacts_google_address_validation/__manifest__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Contacts Google Address Validation',
+    'summary': 'Validate, standardize, and geocode Contact addresses with the Google Address Validation API',
+    'description': """
+Contacts Google Address Validation
+===================================
+
+Adds Google Address Validation (``addressValidation`` library) to the Odoo Contact form.
+
+Provides:
+
+- **Validate Address** button on the Contact form next to the address block; sends the current address to ``AddressValidation.fetchAddressValidation`` with the contact's country as ``regionCode``
+- **Validation dialog** summarizing the API verdict (validation granularity, address completeness, unconfirmed / inferred / replaced components) with a recommendation following Google's accept / confirm / fix guidance
+- **Side-by-side comparison** of the current address and Google's standardized formatted address, plus a component-level breakdown with confirmation levels
+- **Apply Google's Address**: writes the standardized address (street, street2, city, state, zip, country) and the geocode latitude / longitude back to the contact in a single write; state and country are resolved server-side
+- **Keep current Address**: stores only the validation verdict without changing the address
+- **Stored verdict fields** on ``res.partner``: validation status (Validated / Needs Review / Invalid), validation granularity, validation date, and API response ID — usable in list views, filters, and automations
+- **Automatic reset**: editing any address field resets the validation status to Not Validated
+- **Search filters** for validated, needs-review, invalid, and not-validated contacts
+""",
+    'license': 'LGPL-3',
+    'author': 'Yopi Angi',
+    'website': 'https://www.mithnusa.com',
+    'support': 'yopiangi@gmail.com',
+    'category': 'Extra Tools',
+    'version': '19.0.2.0.0',
+    'depends': ['contacts', 'base_google_map'],
+    'data': [
+        'views/res_config_settings.xml',
+        'views/res_partner_views.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.js',
+            'contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.xml',
+            'contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.js',
+            'contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml',
+        ],
+    },
+}

--- a/contacts_google_address_validation/__manifest__.py
+++ b/contacts_google_address_validation/__manifest__.py
@@ -10,7 +10,7 @@ Adds Google Address Validation (``addressValidation`` library) to the Odoo Conta
 
 Provides:
 
-- **Validate Address** button on the Contact form next to the address block; sends the current address to ``AddressValidation.fetchAddressValidation`` with the contact's country as ``regionCode``
+- **Validate Address** button on the Contact form next to the address block; sends the current address via a server-side POST to ``https://addressvalidation.googleapis.com/v1:validateAddress`` with the contact's country as ``regionCode``
 - **Validation dialog** summarizing the API verdict (validation granularity, address completeness, unconfirmed / inferred / replaced components) with a recommendation following Google's accept / confirm / fix guidance
 - **Side-by-side comparison** of the current address and Google's standardized formatted address, plus a component-level breakdown with confirmation levels
 - **Apply Google's Address**: writes the standardized address (street, street2, city, state, zip, country) and the geocode latitude / longitude back to the contact in a single write; state and country are resolved server-side

--- a/contacts_google_address_validation/docs/FEATURES.md
+++ b/contacts_google_address_validation/docs/FEATURES.md
@@ -1,0 +1,62 @@
+# Contacts Google Address Validation — Features
+
+## Architecture
+
+- **`google.address.validation` (AbstractModel)** — the single point of contact with the Google Address Validation API (REST):
+  - `_get_api_key()` — dedicated server key (`contacts_google_address_validation.api_key`) with fallback to `base_google_map.api_key`; a dedicated key is recommended because referrer-restricted browser keys are rejected server-side
+  - `_google_request(payload)` — transport with timeout and per-status error mapping (`PERMISSION_DENIED`, `RESOURCE_EXHAUSTED`, `INVALID_ARGUMENT`, `UNAVAILABLE`) to actionable `UserError`s
+  - `validate_address(lines, region_code, enable_usps_cass)` — calls `v1:validateAddress`; CASS is gated to US/PR
+  - `_parse_validation(document)` — normalizes the REST response (verdict, components, postalAddress, USPS data, geocode) into the dict the dialog renders
+  - `_compute_recommendation(verdict)` — accept / confirm / fix logic (prefers the API's `possibleNextAction`)
+- **Thin OWL widget** — no API logic in JavaScript; the API key never reaches the browser; the Maps JS loader is no longer needed by this module
+
+## Validation Flow
+
+- **Validate Address button** on the Contact form, rendered by the `google_address_validation` view widget placed after the address block
+- Pending form edits are saved automatically before validation so the stored verdict always matches the validated address
+- The address request is built server-side from `street`, `street2`, and a combined `city + state + zip` line; the contact's country code is sent as `regionCode`
+- Coverage guard: unsupported countries are rejected server-side (and the widget disables itself client-side using the same coverage list)
+
+## Validation Dialog
+
+- **Recommendation banner** (accept / confirm / fix) computed from the API verdict; uses the API's `possibleNextAction` field when available, with a documented heuristic fallback
+- **Verdict badges**: address completeness, validation granularity, unconfirmed / inferred / replaced component flags
+- **Entered vs. standardized address** side-by-side comparison
+- **Component table** listing each address component with its confirmation level (Confirmed / Plausible / Suspicious) and inferred / replaced / spell-corrected markers
+- Three actions: **Apply Google's Address**, **Keep current Address** (verdict only), **Discard** (no write)
+
+## Data Model (`res.partner`)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `google_address_validation_status` | Selection | `not_validated` / `valid` / `needs_review` / `invalid` |
+| `google_address_validation_granularity` | Selection | Google `Granularity` enum value (`SUB_PREMISE` … `OTHER`) |
+| `google_address_validation_date` | Datetime | When the address was last validated |
+| `google_address_validation_response_id` | Char | API `responseId` of the validation request |
+
+- All fields are readonly and `copy=False`
+- A `write` override resets the verdict whenever an address field (`street`, `street2`, `city`, `zip`, `state_id`, `country_id`) changes outside the validation flow
+
+## Applying the Standardized Address
+
+- Standardized values come from the response `postalAddress` (address lines, locality, administrative area, postal code, region code)
+- `state_id` and `country_id` are resolved server-side by `_prepare_google_validated_address` (country by ISO code, state by code or name within the country)
+- Geocode latitude/longitude from the response is written to `partner_latitude` / `partner_longitude`
+- Address, geolocation, and verdict are written in a single `write` call
+
+## Status Mapping
+
+| Recommendation | Stored status |
+| --- | --- |
+| ACCEPT | `valid` (Validated) |
+| CONFIRM | `needs_review` (Needs Review) |
+| FIX | `invalid` (Invalid) |
+
+## Search & Filtering
+
+- Search filters on the Contacts view: Address Validated, Address Needs Review, Address Invalid, Address Not Validated
+
+## Limitations / Roadmap
+
+- Only `res.partner` is covered; a generic reusable widget for other models is a candidate follow-up module
+- No automatic validation on save — validation is always user-initiated (each request is billable)

--- a/contacts_google_address_validation/models/__init__.py
+++ b/contacts_google_address_validation/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import google_address_validation
+from . import res_config_settings
+from . import res_partner

--- a/contacts_google_address_validation/models/google_address_validation.py
+++ b/contacts_google_address_validation/models/google_address_validation.py
@@ -212,12 +212,15 @@ class GoogleAddressValidation(models.AbstractModel):
         """Map a Google error status to an actionable, translated message."""
         if status == 'PERMISSION_DENIED':
             return self.env._(
-                'The Address Validation API rejected the request. Enable '
-                'the "Address Validation API" in your Google Cloud '
-                'project, make sure it is included in your API key '
-                'restrictions, and note that HTTP-referrer restricted '
-                'keys cannot be used server-side — configure a dedicated '
-                'server key if needed.\n\n%(message)s',
+                'The Address Validation API rejected the request. Check '
+                'that: (1) the "Address Validation API" is enabled in '
+                'your Google Cloud project and included in the key\'s '
+                'API restrictions; (2) the key\'s application '
+                'restriction is "IP addresses" (recommended) or "None" '
+                '— HTTP-referrer restricted keys cannot be used '
+                'server-side; (3) with an IP restriction, the allowlist '
+                'contains the Odoo server\'s outbound IP address.'
+                '\n\n%(message)s',
                 message=message,
             )
         if status == 'RESOURCE_EXHAUSTED':

--- a/contacts_google_address_validation/models/google_address_validation.py
+++ b/contacts_google_address_validation/models/google_address_validation.py
@@ -1,0 +1,462 @@
+# -*- coding: utf-8 -*-
+import logging
+
+import requests
+
+from odoo import api, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+GOOGLE_AV_DEFAULT_ENDPOINT = (
+    'https://addressvalidation.googleapis.com/v1:validateAddress'
+)
+GOOGLE_AV_TIMEOUT = 10  # seconds
+
+# Region codes covered by the Address Validation API.
+# https://developers.google.com/maps/documentation/address-validation/coverage
+SUPPORTED_REGION_CODES = (
+    'AR',  # Argentina
+    'AT',  # Austria
+    'AU',  # Australia
+    'BE',  # Belgium
+    'BG',  # Bulgaria
+    'BR',  # Brazil
+    'CA',  # Canada
+    'CH',  # Switzerland
+    'CL',  # Chile
+    'CO',  # Colombia
+    'CZ',  # Czechia
+    'DE',  # Germany
+    'DK',  # Denmark
+    'EE',  # Estonia
+    'ES',  # Spain
+    'FI',  # Finland
+    'FR',  # France
+    'GB',  # United Kingdom
+    'HR',  # Croatia
+    'HU',  # Hungary
+    'IE',  # Ireland
+    'IN',  # India
+    'IT',  # Italy
+    'JP',  # Japan
+    'LT',  # Lithuania
+    'LU',  # Luxembourg
+    'LV',  # Latvia
+    'MX',  # Mexico
+    'MY',  # Malaysia
+    'NL',  # Netherlands
+    'NO',  # Norway
+    'NZ',  # New Zealand
+    'PL',  # Poland
+    'PR',  # Puerto Rico
+    'PT',  # Portugal
+    'SE',  # Sweden
+    'SG',  # Singapore
+    'SI',  # Slovenia
+    'SK',  # Slovakia
+    'US',  # United States
+)
+
+# Regions supporting USPS CASS(tm) processing.
+CASS_REGION_CODES = (
+    'US',  # United States
+    'PR',  # Puerto Rico
+)
+
+RECOMMENDATION_ACCEPT = 'ACCEPT'
+RECOMMENDATION_CONFIRM = 'CONFIRM'
+RECOMMENDATION_FIX = 'FIX'
+
+RECOMMENDATION_TO_STATUS = {
+    RECOMMENDATION_ACCEPT: 'valid',
+    RECOMMENDATION_CONFIRM: 'needs_review',
+    RECOMMENDATION_FIX: 'invalid',
+}
+
+
+class GoogleAddressValidation(models.AbstractModel):
+    """Server-side client for the Google Address Validation API (REST).
+
+    Centralizes authentication, transport, error handling, response
+    normalization, and the accept / confirm / fix recommendation logic so
+    any model can validate addresses with::
+
+        result = self.env['google.address.validation'].validate_address(
+            ['1600 Amphitheatre Parkway', 'Mountain View CA 94043'],
+            region_code='US',
+        )
+
+    API documentation:
+    https://developers.google.com/maps/documentation/address-validation
+    """
+
+    _name = 'google.address.validation'
+    _description = 'Google Address Validation Service'
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    @api.model
+    def _get_api_key(self):
+        """Return the API key for server-side validation requests.
+
+        A dedicated key can be set in
+        ``contacts_google_address_validation.api_key`` — recommended,
+        because the main ``base_google_map.api_key`` is usually
+        HTTP-referrer restricted, and Google rejects referrer-restricted
+        keys for server-side (REST) requests. Falls back to the main key.
+        """
+        icp = self.env['ir.config_parameter'].sudo()
+        api_key = (
+            icp.get_param(
+                'contacts_google_address_validation.api_key', default=''
+            )
+            or icp.get_param('base_google_map.api_key', default='')
+        ).strip()
+        if not api_key:
+            raise UserError(
+                self.env._(
+                    'No Google Maps API key is configured. Set it in '
+                    'Settings > General Settings > Google Maps.'
+                )
+            )
+        return api_key
+
+    @api.model
+    def _get_endpoint(self):
+        return (
+            self.env['ir.config_parameter']
+            .sudo()
+            .get_param(
+                'contacts_google_address_validation.endpoint',
+                default=GOOGLE_AV_DEFAULT_ENDPOINT,
+            )
+        )
+
+    @api.model
+    def is_region_supported(self, region_code):
+        return (region_code or '').upper() in SUPPORTED_REGION_CODES
+
+    @api.model
+    def should_enable_cass(self, region_code):
+        return (region_code or '').upper() in CASS_REGION_CODES
+
+    # ------------------------------------------------------------------
+    # Transport
+    # ------------------------------------------------------------------
+
+    @api.model
+    def _google_request(self, payload):
+        """POST a validateAddress request.
+
+        :param dict payload: JSON body (``address``, ``enableUspsCass``,
+            ``previousResponseId``, ...)
+        :return: the decoded JSON response document
+        :raises UserError: on transport errors or API-level errors, with
+            actionable messages per Google error status
+        """
+        try:
+            response = requests.post(
+                self._get_endpoint(),
+                json=payload,
+                params={'key': self._get_api_key()},
+                timeout=GOOGLE_AV_TIMEOUT,
+            )
+        except requests.exceptions.Timeout as exc:
+            raise UserError(
+                self.env._(
+                    'The Address Validation API did not respond in time. '
+                    'Please try again in a moment.'
+                )
+            ) from exc
+        except requests.exceptions.RequestException as exc:
+            _logger.warning('Address Validation request failed: %s', exc)
+            raise UserError(
+                self.env._(
+                    'Could not reach the Address Validation API. Check '
+                    'your network connection and try again.'
+                )
+            ) from exc
+
+        try:
+            document = response.json()
+        except ValueError as exc:
+            _logger.warning(
+                'Unexpected Address Validation response (%s): %s',
+                response.status_code,
+                response.text[:500],
+            )
+            raise UserError(
+                self.env._(
+                    'The Address Validation API returned an unexpected '
+                    'response.'
+                )
+            ) from exc
+
+        error = document.get('error')
+        if response.status_code >= 400 or error:
+            error = error or {}
+            status = error.get('status') or ''
+            message = error.get('message') or response.reason
+            _logger.warning(
+                'Address Validation API error (%s): %s', status, message
+            )
+            raise UserError(self._get_error_message(status, message))
+
+        return document
+
+    @api.model
+    def _get_error_message(self, status, message):
+        """Map a Google error status to an actionable, translated message."""
+        if status == 'PERMISSION_DENIED':
+            return self.env._(
+                'The Address Validation API rejected the request. Enable '
+                'the "Address Validation API" in your Google Cloud '
+                'project, make sure it is included in your API key '
+                'restrictions, and note that HTTP-referrer restricted '
+                'keys cannot be used server-side — configure a dedicated '
+                'server key if needed.\n\n%(message)s',
+                message=message,
+            )
+        if status == 'RESOURCE_EXHAUSTED':
+            return self.env._(
+                'The Address Validation API quota has been exceeded. '
+                'Check your Google Cloud quota and billing settings.'
+                '\n\n%(message)s',
+                message=message,
+            )
+        if status == 'INVALID_ARGUMENT':
+            return self.env._(
+                'The Address Validation API could not process this '
+                'address. Check the entered address and the country.'
+                '\n\n%(message)s',
+                message=message,
+            )
+        if status == 'UNAVAILABLE':
+            return self.env._(
+                'The Address Validation API is temporarily unreachable. '
+                'Please try again in a moment.\n\n%(message)s',
+                message=message,
+            )
+        return self.env._(
+            'Address validation failed. Check that the Address '
+            'Validation API is enabled for your Google Maps API key.'
+            '\n\n%(message)s',
+            message=message,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @api.model
+    def validate_address(
+        self,
+        address_lines,
+        region_code='',
+        enable_usps_cass=False,
+        language_code='',
+    ):
+        """Validate an address and normalize the response.
+
+        :param list address_lines: entered address as free-form lines
+        :param str region_code: ISO 3166-1 alpha-2 (CLDR) region code
+        :param bool enable_usps_cass: request USPS CASS processing
+            (US / PR only)
+        :param str language_code: optional BCP-47 language code
+        :return: normalized result, see :meth:`_parse_validation`
+        """
+        address = {'addressLines': list(address_lines)}
+        region_code = (region_code or '').upper()
+        if region_code:
+            address['regionCode'] = region_code
+        if language_code:
+            address['languageCode'] = language_code
+
+        payload = {'address': address}
+        if enable_usps_cass and self.should_enable_cass(region_code):
+            payload['enableUspsCass'] = True
+
+        document = self._google_request(payload)
+        return self._parse_validation(document)
+
+    # ------------------------------------------------------------------
+    # Response normalization
+    # ------------------------------------------------------------------
+
+    @api.model
+    def _parse_validation(self, document):
+        """Normalize a validateAddress REST response into the plain dict
+        consumed by the ``AddressValidationDialog`` component and by
+        ``res.partner.action_apply_google_address_validation``.
+
+        The keys deliberately mirror the (camelCase) shape previously
+        produced client-side so the dialog template needs no changes.
+
+        :param dict document: full REST response
+            (``{'result': {...}, 'responseId': ...}``)
+        :return: normalized result dict
+        """
+        result = document.get('result') or {}
+        address = result.get('address') or {}
+        verdict_source = result.get('verdict') or {}
+
+        verdict = {
+            'inputGranularity': verdict_source.get('inputGranularity') or '',
+            'validationGranularity': verdict_source.get(
+                'validationGranularity'
+            )
+            or '',
+            'geocodeGranularity': verdict_source.get('geocodeGranularity')
+            or '',
+            'possibleNextAction': verdict_source.get('possibleNextAction')
+            or '',
+            'addressComplete': bool(verdict_source.get('addressComplete')),
+            'hasUnconfirmedComponents': bool(
+                verdict_source.get('hasUnconfirmedComponents')
+            ),
+            'hasInferredComponents': bool(
+                verdict_source.get('hasInferredComponents')
+            ),
+            'hasReplacedComponents': bool(
+                verdict_source.get('hasReplacedComponents')
+            ),
+        }
+
+        components = []
+        for component in address.get('addressComponents') or []:
+            name = component.get('componentName') or {}
+            if not isinstance(name, dict):
+                name = {'text': str(name)}
+            components.append(
+                {
+                    'type': component.get('componentType') or '',
+                    'name': name.get('text') or '',
+                    'confirmationLevel': component.get('confirmationLevel')
+                    or '',
+                    'inferred': bool(component.get('inferred')),
+                    'replaced': bool(component.get('replaced')),
+                    'spellCorrected': bool(component.get('spellCorrected')),
+                }
+            )
+
+        postal_source = address.get('postalAddress') or {}
+        postal_address = {
+            'addressLines': list(postal_source.get('addressLines') or []),
+            'locality': postal_source.get('locality')
+            or postal_source.get('sublocality')
+            or '',
+            'administrativeArea': postal_source.get('administrativeArea')
+            or '',
+            'postalCode': postal_source.get('postalCode') or '',
+            'regionCode': postal_source.get('regionCode') or '',
+        }
+
+        usps_data = self._parse_usps_data(result.get('uspsData'))
+
+        geocode = result.get('geocode') or {}
+        location_source = geocode.get('location') or {}
+        location = None
+        latitude = location_source.get('latitude')
+        longitude = location_source.get('longitude')
+        if isinstance(latitude, (int, float)) and isinstance(
+            longitude, (int, float)
+        ):
+            location = {'latitude': latitude, 'longitude': longitude}
+
+        normalized = {
+            'responseId': document.get('responseId') or '',
+            'formattedAddress': address.get('formattedAddress') or '',
+            'verdict': verdict,
+            'components': components,
+            'uspsData': usps_data,
+            'missingComponentTypes': [
+                str(t) for t in address.get('missingComponentTypes') or []
+            ],
+            'unresolvedTokens': [
+                str(t) for t in address.get('unresolvedTokens') or []
+            ],
+            'postalAddress': postal_address,
+            'location': location,
+        }
+        recommendation = self._compute_recommendation(verdict)
+        normalized['recommendation'] = recommendation
+        normalized['status'] = RECOMMENDATION_TO_STATUS.get(
+            recommendation, 'not_validated'
+        )
+        return normalized
+
+    @api.model
+    def _parse_usps_data(self, usps_source):
+        """Normalize the ``uspsData`` block (US / PR with CASS only)."""
+        usps_source = usps_source or {}
+        usps_address = usps_source.get('standardizedAddress') or {}
+        if not usps_source.get('dpvConfirmation') and not usps_address:
+            return None
+
+        city_state_zip = usps_address.get('cityStateZipAddressLine')
+        if not city_state_zip:
+            zip_display = '-'.join(
+                filter(
+                    None,
+                    [
+                        usps_address.get('zipCode'),
+                        usps_address.get('zipCodeExtension'),
+                    ],
+                )
+            )
+            city_state_zip = ' '.join(
+                filter(
+                    None,
+                    [
+                        usps_address.get('city'),
+                        usps_address.get('state'),
+                        zip_display,
+                    ],
+                )
+            )
+
+        return {
+            'dpvConfirmation': usps_source.get('dpvConfirmation') or '',
+            'standardizedAddress': ', '.join(
+                filter(
+                    None,
+                    [
+                        usps_address.get('firstAddressLine'),
+                        usps_address.get('secondAddressLine'),
+                        city_state_zip,
+                    ],
+                )
+            ),
+            'county': usps_source.get('county') or '',
+            'dpvVacant': usps_source.get('dpvVacant') or '',
+            'dpvNoStat': usps_source.get('dpvNoStat') or '',
+        }
+
+    @api.model
+    def _compute_recommendation(self, verdict):
+        """Accept / confirm / fix recommendation from a normalized verdict.
+
+        Prefers the API's own ``possibleNextAction`` field when present
+        (Preview), falling back to a heuristic based on the documented
+        verdict fields.
+
+        https://developers.google.com/maps/documentation/javascript
+        /address-validation/build-validation-logic
+        """
+        next_action = (verdict.get('possibleNextAction') or '').upper()
+        if next_action in RECOMMENDATION_TO_STATUS:
+            return next_action
+        granularity = (verdict.get('validationGranularity') or '').upper()
+        if granularity in ('OTHER', 'GRANULARITY_UNSPECIFIED', ''):
+            return RECOMMENDATION_FIX
+        if (
+            verdict.get('hasUnconfirmedComponents')
+            or verdict.get('hasReplacedComponents')
+            or verdict.get('hasInferredComponents')
+            or not verdict.get('addressComplete')
+        ):
+            return RECOMMENDATION_CONFIRM
+        return RECOMMENDATION_ACCEPT

--- a/contacts_google_address_validation/models/res_config_settings.py
+++ b/contacts_google_address_validation/models/res_config_settings.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    google_address_validation_api_key = fields.Char(
+        string='Address Validation Server Key',
+        config_parameter='contacts_google_address_validation.api_key',
+        help='Optional dedicated API key for server-side Address '
+        'Validation requests. Recommended: the main Google Maps API key '
+        'is usually HTTP-referrer restricted, and Google rejects '
+        'referrer-restricted keys for server-side requests. Leave empty '
+        'to use the main Google Maps API key.',
+    )

--- a/contacts_google_address_validation/models/res_partner.py
+++ b/contacts_google_address_validation/models/res_partner.py
@@ -1,0 +1,330 @@
+# -*- coding: utf-8 -*-
+from markupsafe import Markup, escape
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+# Address fields that invalidate a previously stored verdict when edited
+ADDRESS_FIELDS = (
+    'street',
+    'street2',
+    'city',
+    'zip',
+    'state_id',
+    'country_id',
+)
+
+VALIDATION_STATUSES = [
+    ('not_validated', 'Not Validated'),
+    ('valid', 'Validated'),
+    ('needs_review', 'Needs Review'),
+    ('invalid', 'Invalid'),
+]
+
+# See "Granularity" in the Maps JS API address-validation reference:
+# developers.google.com/maps/documentation/javascript
+#   /reference/address-validation#Granularity
+VALIDATION_GRANULARITIES = [
+    ('SUB_PREMISE', 'Sub-premise'),
+    ('PREMISE', 'Premise'),
+    ('PREMISE_PROXIMITY', 'Premise Proximity'),
+    ('BLOCK', 'Block'),
+    ('ROUTE', 'Route'),
+    ('OTHER', 'Other'),
+    ('GRANULARITY_UNSPECIFIED', 'Unspecified'),
+]
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    google_address_validation_status = fields.Selection(
+        VALIDATION_STATUSES,
+        string='Address Validation',
+        default='not_validated',
+        readonly=True,
+        copy=False,
+        index=True,
+        help='Result of the last Google Address Validation check. '
+        'Reset to "Not Validated" whenever an address field is edited.',
+    )
+    google_address_validation_granularity = fields.Selection(
+        VALIDATION_GRANULARITIES,
+        string='Validation Granularity',
+        readonly=True,
+        copy=False,
+        help='Level of detail the Google Address Validation API could fully validate the address to. '
+        'PREMISE or SUB_PREMISE usually indicates a deliverable address. '
+        '\n- PREMISE means the address is valid but may be missing a unit number. '
+        '\n- SUB_PREMISE means the address is valid and includes a unit number. '
+        '\n- BLOCK or ROUTE usually indicates a non-deliverable address. '
+        '\n- OTHER or GRANULARITY_UNSPECIFIED means the API could not determine the level of detail.',
+    )
+    google_address_validation_date = fields.Datetime(
+        string='Address Validated On',
+        readonly=True,
+        copy=False,
+    )
+    google_address_validation_response_id = fields.Char(
+        string='Validation Response ID',
+        readonly=True,
+        copy=False,
+        help='Unique identifier returned by the Google Address Validation '
+        'API for the validation request.',
+    )
+
+    @api.model
+    def _get_google_validation_reset_values(self):
+        """Field values clearing a previously stored validation verdict."""
+        return {
+            'google_address_validation_status': 'not_validated',
+            'google_address_validation_granularity': False,
+            'google_address_validation_date': False,
+            'google_address_validation_response_id': False,
+        }
+
+    @api.onchange(*ADDRESS_FIELDS)
+    def _onchange_address_reset_google_validation(self):
+        """Reset the stored verdict in the UI as soon as an address field is
+        edited, without waiting for the record to be saved."""
+        reset_values = self._get_google_validation_reset_values()
+        for partner in self:
+            partner.update(reset_values)
+
+    def write(self, vals):
+        # Any manual change to an address field invalidates the stored
+        # verdict. When the validation flow itself writes the address, it
+        # includes the status in the same vals, so no reset happens.
+        if (
+            any(f in vals for f in ADDRESS_FIELDS)
+            and 'google_address_validation_status' not in vals
+        ):
+            vals = dict(vals, **self._get_google_validation_reset_values())
+        return super().write(vals)
+
+    def _prepare_google_address_lines(self):
+        """Build the free-form address lines sent to the Address
+        Validation API from the partner's address fields."""
+        self.ensure_one()
+        lines = [line for line in (self.street, self.street2) if line]
+        last_line = ' '.join(
+            filter(
+                None,
+                [
+                    self.city,
+                    self.state_id.name or '',
+                    self.zip or '',
+                ],
+            )
+        )
+        if last_line:
+            lines.append(last_line)
+        return lines
+
+    def action_google_validate_address(self):
+        """Validate the partner's address with the Google Address
+        Validation API (server-side).
+
+        :return: dict with the entered address (for display) and the
+            normalized validation result, consumed by the
+            ``AddressValidationDialog`` component
+        """
+        self.ensure_one()
+        lines = self._prepare_google_address_lines()
+        if not lines:
+            raise UserError(
+                self.env._('Enter an address before validating it.')
+            )
+
+        service = self.env['google.address.validation']
+        region_code = (self.country_id.code or '').upper()
+        if region_code and not service.is_region_supported(region_code):
+            raise UserError(
+                self.env._(
+                    'The Address Validation API is not available in the '
+                    'country of this address (%(region)s).',
+                    region=region_code,
+                )
+            )
+
+        result = service.validate_address(
+            lines,
+            region_code=region_code,
+            enable_usps_cass=service.should_enable_cass(region_code),
+        )
+        return {'entered': '\n'.join(lines), 'result': result}
+
+    def action_apply_google_address_validation(self, result, apply_address):
+        """Store the Google Address Validation verdict and optionally apply
+        the standardized address returned by the API.
+
+        Called from the ``google_address_validation`` form widget after the
+        user reviews the validation dialog.
+
+        :param dict result: normalized validation result returned by
+            :meth:`action_google_validate_address` (see
+            ``google.address.validation._parse_validation``)
+        :param bool apply_address: write the standardized address back to
+            the partner
+
+        Note: Google / USPS standardized address strings are intentionally
+        never persisted (fields, chatter, or logs) — see the Google Maps
+        Platform Service Specific Terms, Table 1.3.2 (30-day caching cap).
+        An address the user applies through the dialog is End User
+        confirmed data and lives in the regular address fields.
+        :return: True
+        """
+        self.ensure_one()
+        result = result or {}
+        verdict = result.get('verdict') or {}
+
+        status = result.get('status')
+        if status not in dict(VALIDATION_STATUSES):
+            status = 'not_validated'
+
+        granularity = verdict.get('validationGranularity')
+        if granularity not in dict(VALIDATION_GRANULARITIES):
+            granularity = False
+
+        vals = {
+            'google_address_validation_status': status,
+            'google_address_validation_granularity': granularity,
+            'google_address_validation_date': fields.Datetime.now(),
+            'google_address_validation_response_id': result.get('responseId')
+            or False,
+        }
+
+        if apply_address:
+            postal_address = result.get('postalAddress') or {}
+            lines = postal_address.get('addressLines') or []
+            vals.update(
+                self._prepare_google_validated_address(
+                    {
+                        'street': lines[0] if lines else '',
+                        'street2': ', '.join(lines[1:]),
+                        'city': postal_address.get('locality') or '',
+                        'zip': postal_address.get('postalCode') or '',
+                        'state_code': postal_address.get('administrativeArea')
+                        or '',
+                        'country_code': postal_address.get('regionCode') or '',
+                    }
+                )
+            )
+            location = result.get('location') or {}
+            latitude = location.get('latitude')
+            longitude = location.get('longitude')
+            if (
+                isinstance(latitude, (int, float))
+                and isinstance(longitude, (int, float))
+                and -90 <= latitude <= 90
+                and -180 <= longitude <= 180
+            ):
+                # Always overwrite the geolocation with the geocode of the
+                # validated address, even when coordinates are already set.
+                vals['partner_latitude'] = latitude
+                vals['partner_longitude'] = longitude
+
+        self.write(vals)
+        # Add info to the chatter for traceability
+        items = [
+            '<li>%s: %s</li>'
+            % (
+                self.env._('Status'),
+                dict(VALIDATION_STATUSES).get(status, status),
+            ),
+            '<li>%s: %s</li>'
+            % (
+                self.env._('Granularity'),
+                dict(VALIDATION_GRANULARITIES).get(granularity, granularity),
+            ),
+        ]
+        if result.get('missingComponentTypes'):
+            items.append(
+                '<li>%s: %s</li>'
+                % (
+                    self.env._('Missing Components'),
+                    escape(', '.join(result['missingComponentTypes'])),
+                )
+            )
+
+        if result.get('recommendation'):
+            items.append(
+                '<li>%s: %s</li>'
+                % (
+                    self.env._('Recommendation'),
+                    result.get('recommendation'),
+                )
+            )
+
+        usps = result.get('uspsData') or {}
+        dpv_code = (usps.get('dpvConfirmation') or '').upper()
+        if dpv_code:
+            dpv_labels = {
+                'Y': self.env._('Deliverable'),
+                'S': self.env._('Deliverable, secondary number dropped'),
+                'D': self.env._('Confirmed, missing secondary number'),
+                'N': self.env._('Not deliverable'),
+            }
+            items.append(
+                '<li>%s: %s (%s)</li>'
+                % (
+                    self.env._('USPS DPV Confirmation'),
+                    escape(dpv_code),
+                    dpv_labels.get(dpv_code, self.env._('Unknown')),
+                )
+            )
+        # Note: the Google / USPS standardized address strings and the USPS
+        # county are deliberately NOT logged (nor stored anywhere else).
+        # Chatter messages are kept forever, which would exceed the 30-day
+        # caching period allowed by the Google Maps Platform Service
+        # Specific Terms (Table 1.3.2). An address the user applies through
+        # the dialog is End User confirmed data and lives in the regular
+        # address fields.
+        message_body = Markup(
+            '<span>%s</span><ul>%s</ul>'
+            % (self.env._('Google Address Validation Result'), ''.join(items))
+        )
+
+        self.message_post(body=message_body, subtype_xmlid='mail.mt_note')
+        return True
+
+    @api.model
+    def _prepare_google_validated_address(self, address):
+        """Convert a standardized address (from the API ``postalAddress``)
+        into ``res.partner`` field values, resolving country and state
+        Many2one records server-side.
+
+        :param dict address: see :meth:`action_apply_google_address_validation`
+        :return: dict of partner field values
+        """
+        vals = {}
+        for field_name in ('street', 'street2', 'city', 'zip'):
+            if field_name in address:
+                vals[field_name] = address.get(field_name) or False
+
+        country = self.env['res.country']
+        country_code = (address.get('country_code') or '').strip()
+        if country_code:
+            country = country.search(
+                [('code', '=ilike', country_code)], limit=1
+            )
+            if country:
+                vals['country_id'] = country.id
+
+        if not country:
+            return vals
+
+        state_value = (address.get('state_code') or '').strip()
+        if state_value:
+            state_domain = [
+                ('country_id', '=', country.id),
+                '|',
+                ('code', '=ilike', state_value),
+                ('name', '=ilike', state_value),
+            ]
+            state = self.env['res.country.state'].search(state_domain, limit=1)
+            vals['state_id'] = state.id if state else False
+        elif 'state_code' in address:
+            vals['state_id'] = False
+
+        return vals

--- a/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.js
+++ b/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.js
@@ -1,0 +1,208 @@
+import { Component, useState } from '@odoo/owl';
+import { _t } from '@web/core/l10n/translation';
+import { Dialog } from '@web/core/dialog/dialog';
+
+/**
+ * Recommendation identifiers, aligned with Google's "build your validation
+ * logic" guidance (accept / confirm / fix). The recommendation itself is
+ * computed server-side by `google.address.validation`; these constants
+ * only drive the dialog rendering.
+ * @see https://developers.google.com/maps/documentation/javascript/address-validation/build-validation-logic
+ */
+export const RECOMMENDATIONS = {
+    ACCEPT: 'ACCEPT',
+    CONFIRM: 'CONFIRM',
+    FIX: 'FIX',
+};
+
+/**
+ * Dialog presenting the result of a Google Address Validation request.
+ *
+ * Shows the verdict summary with a recommendation, a side-by-side comparison
+ * of the entered address and Google's standardized address, and a
+ * component-level breakdown with confirmation levels. The user can apply
+ * Google's standardized address, keep the entered address (storing only the
+ * verdict), or discard the result entirely.
+ */
+export class AddressValidationDialog extends Component {
+    static template = 'contacts_google_address_validation.AddressValidationDialog';
+    static components = { Dialog };
+    static props = {
+        close: Function,
+        enteredAddress: { type: String },
+        result: { type: Object },
+        onApply: { type: Function }, // async (applyGoogleAddress: boolean) => void
+    };
+
+    setup() {
+        this.state = useState({ busy: false });
+    }
+
+    get dialogTitle() {
+        return _t('Google Address Validation');
+    }
+
+    get verdict() {
+        return this.props.result.verdict || {};
+    }
+
+    get recommendation() {
+        return this.props.result.recommendation;
+    }
+
+    get recommendationInfo() {
+        switch (this.recommendation) {
+            case RECOMMENDATIONS.ACCEPT:
+                return {
+                    class: 'alert-success',
+                    icon: 'fa-check-circle',
+                    title: _t('Address is valid'),
+                    message: _t('Google validated this address. You can safely apply the standardized version.'),
+                };
+            case RECOMMENDATIONS.CONFIRM:
+                return {
+                    class: 'alert-warning',
+                    icon: 'fa-question-circle',
+                    title: _t('Confirmation recommended'),
+                    message: _t(
+                        'Google could not confirm every part of this address. Review the components below before applying.'
+                    ),
+                };
+            default:
+                return {
+                    class: 'alert-danger',
+                    icon: 'fa-exclamation-triangle',
+                    title: _t('Address may be wrong'),
+                    message: this.props.result.missingComponentTypes?.length
+                        ? _t(
+                              'Google flagged this address as likely undeliverable because required information is missing (see below). Complete the entered address, then validate again.'
+                          )
+                        : _t(
+                              'Google could not validate this address. Check the entered address and fix the highlighted components.'
+                          ),
+                };
+        }
+    }
+
+    /**
+     * Returns a badge object for a component confirmation level, including label, help text, and CSS class.
+     * @param {*} component
+     * @returns {{label: string, help: string, class: string}} Badge object
+     */
+    componentBadge(component) {
+        const level = String(component.confirmationLevel || '').toUpperCase();
+        if (level === 'CONFIRMED') {
+            return {
+                label: _t('Confirmed'),
+                help: _t('Google confirmed this %(componentType)s as valid.', { componentType: component.type }),
+                class: 'text-bg-success',
+            };
+        }
+        if (level === 'UNCONFIRMED_BUT_PLAUSIBLE') {
+            return {
+                label: _t('Plausible'),
+                help: _t('Google could not confirm this %(componentType)s, but it appears plausible.', {
+                    componentType: component.type,
+                }),
+                class: 'text-bg-warning',
+            };
+        }
+        if (level === 'UNCONFIRMED_AND_SUSPICIOUS') {
+            return {
+                label: _t('Suspicious'),
+                help: _t('Google could not confirm this %(componentType)s, and it appears suspicious.', {
+                    componentType: component.type,
+                }),
+                class: 'text-bg-danger',
+            };
+        }
+        return {
+            label: _t('Unknown'),
+            help: _t('Google did not provide a confirmation level for this %(componentType)s.', {
+                componentType: component.type,
+            }),
+            class: 'text-bg-secondary',
+        };
+    }
+
+    get usps() {
+        return this.props.result.uspsData || null;
+    }
+
+    /**
+     * Returns display info for the USPS DPV (Delivery Point Validation)
+     * confirmation code.
+     *
+     * Codes: Y = confirmed deliverable; S = confirmed by dropping the
+     * secondary number; D = confirmed but secondary number missing;
+     * N = not confirmed.
+     *
+     * @returns {{class: string, label: string}|null}
+     */
+    get dpvInfo() {
+        const code = String(this.usps?.dpvConfirmation || '').toUpperCase();
+        switch (code) {
+            case 'Y':
+                return {
+                    class: 'text-bg-success',
+                    label: _t('DPV: Deliverable (Y)'),
+                    help: _t('The USPS confirmed that this address is deliverable.'),
+                };
+            case 'S':
+                return {
+                    class: 'text-bg-warning',
+                    label: _t('DPV: Deliverable, secondary number dropped (S)'),
+                    help: _t(
+                        'The USPS confirmed that this address is deliverable, but the secondary number was dropped.'
+                    ),
+                };
+            case 'D':
+                return {
+                    class: 'text-bg-warning',
+                    label: _t('DPV: Missing secondary number (D)'),
+                    help: _t(
+                        'The USPS confirmed that this address is deliverable, but the secondary number is missing.'
+                    ),
+                };
+            case 'N':
+                return {
+                    class: 'text-bg-danger',
+                    label: _t('DPV: Not deliverable (N)'),
+                    help: _t('The USPS confirmed that this address is not deliverable.'),
+                };
+            default:
+                return code
+                    ? {
+                          class: 'text-bg-secondary',
+                          label: _t('DPV: %s', code),
+                          title: _t('Unknown USPS DPV confirmation code'),
+                      }
+                    : null;
+        }
+    }
+
+    async onApplyGoogleAddress() {
+        await this._apply(true);
+    }
+
+    async onKeepEnteredAddress() {
+        await this._apply(false);
+    }
+
+    async _apply(applyGoogleAddress) {
+        if (this.state.busy) {
+            return;
+        }
+        this.state.busy = true;
+        try {
+            await this.props.onApply(applyGoogleAddress);
+            this.props.close();
+        } finally {
+            this.state.busy = false;
+        }
+    }
+
+    onDiscard() {
+        this.props.close();
+    }
+}

--- a/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.xml
+++ b/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.xml
@@ -87,7 +87,7 @@
                     </span>
                     <span t-if="usps.county" class="badge text-bg-light text-dark">
                         <span class="me-1">County:</span>
-                        <span t-esc="usps.county"/>
+                        <span t-esc="usps.county" />
                     </span>
                 </div>
                 <div t-if="usps.standardizedAddress" class="mt-2">

--- a/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.xml
+++ b/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="contacts_google_address_validation.AddressValidationDialog">
+        <Dialog size="'lg'" title="dialogTitle">
+            <!-- Recommendation summary -->
+            <div t-attf-class="alert d-flex gap-2 align-items-start {{ recommendationInfo.class }}" role="alert">
+                <i t-attf-class="fa fa-lg mt-1 {{ recommendationInfo.icon }}" />
+                <div>
+                    <strong t-esc="recommendationInfo.title" />
+                    <div class="small" t-esc="recommendationInfo.message" />
+                </div>
+            </div>
+
+            <!-- Verdict badges -->
+            <div class="d-flex flex-wrap gap-2 mb-3">
+                <span t-attf-class="badge {{ verdict.addressComplete ? 'text-bg-success' : 'text-bg-warning' }}">
+                    <t t-if="verdict.addressComplete">Address complete</t>
+                    <t t-else="">Address incomplete</t>
+                </span>
+                <span t-if="verdict.validationGranularity" class="badge text-bg-info">
+                    Granularity:
+                    <t t-esc="verdict.validationGranularity" />
+                </span>
+                <span t-if="verdict.hasUnconfirmedComponents" class="badge text-bg-warning">
+                    Unconfirmed components
+                </span>
+                <span t-if="verdict.hasInferredComponents" class="badge text-bg-secondary">Inferred components</span>
+                <span t-if="verdict.hasReplacedComponents" class="badge text-bg-danger">Replaced components</span>
+            </div>
+
+            <!-- Missing components / unresolved tokens -->
+            <div t-if="props.result.missingComponentTypes.length" class="alert alert-warning py-2 mb-3" role="alert">
+                <i class="fa fa-puzzle-piece me-1" />
+                <strong>Missing from the entered address:</strong>
+                <span
+                    t-foreach="props.result.missingComponentTypes"
+                    t-as="missingType"
+                    t-key="missingType_index"
+                    class="badge text-bg-warning ms-1"
+                    t-esc="missingType"
+                />
+            </div>
+            <div t-if="props.result.unresolvedTokens.length" class="alert alert-warning py-2 mb-3" role="alert">
+                <i class="fa fa-question me-1" />
+                <strong>Parts Google could not recognize:</strong>
+                <span
+                    t-foreach="props.result.unresolvedTokens"
+                    t-as="token"
+                    t-key="token_index"
+                    class="badge text-bg-warning ms-1"
+                    t-esc="token"
+                />
+            </div>
+
+            <!-- Entered vs standardized address -->
+            <div class="row g-3 mb-3">
+                <div class="col-12 col-md-6">
+                    <div class="border rounded-2 p-2 h-100">
+                        <div class="text-muted small fw-bold text-uppercase mb-1">Entered Address</div>
+                        <div style="white-space: pre-line;" t-esc="props.enteredAddress" />
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="border rounded-2 p-2 h-100 border-primary">
+                        <div class="text-muted small fw-bold text-uppercase mb-1">
+                            <i class="fa fa-google me-1" />
+                            Google Standardized Address
+                        </div>
+                        <div t-esc="props.result.formattedAddress" />
+                    </div>
+                </div>
+            </div>
+
+            <!-- USPS CASS data (US / PR addresses with CASS enabled) -->
+            <div t-if="usps" class="border rounded-2 p-2 mb-3">
+                <div class="text-muted small fw-bold text-uppercase mb-1">USPS Delivery Point Validation</div>
+                <div class="d-flex flex-wrap gap-2 align-items-center">
+                    <span
+                        t-if="dpvInfo"
+                        t-attf-class="badge {{ dpvInfo.class }}"
+                        t-esc="dpvInfo.label"
+                        t-att-data-tooltip="dpvInfo.help"
+                    />
+                    <span t-if="usps.dpvVacant === 'Y'" class="badge text-bg-warning">Vacant address</span>
+                    <span t-if="usps.dpvNoStat === 'Y'" class="badge text-bg-warning">
+                        No-Stat (not receiving mail)
+                    </span>
+                    <span t-if="usps.county" class="badge text-bg-light text-dark">
+                        County:
+                        <t t-esc="usps.county" />
+                    </span>
+                </div>
+                <div t-if="usps.standardizedAddress" class="mt-2">
+                    <span class="text-muted small">USPS Standardized:</span>
+                    <span t-esc="usps.standardizedAddress" />
+                </div>
+            </div>
+
+            <!-- Component breakdown -->
+            <div t-if="props.result.components.length" class="mb-2">
+                <div class="text-muted small fw-bold text-uppercase mb-1">Address Components</div>
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Value</th>
+                            <th class="text-end">Confirmation</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-foreach="props.result.components" t-as="component" t-key="component_index">
+                            <td class="text-muted" t-esc="component.type" />
+                            <td>
+                                <span t-esc="component.name" />
+                                <span t-if="component.inferred" class="badge text-bg-secondary ms-1">inferred</span>
+                                <span t-if="component.replaced" class="badge text-bg-danger ms-1">replaced</span>
+                                <span t-if="component.spellCorrected" class="badge text-bg-info ms-1">
+                                    spell-corrected
+                                </span>
+                            </td>
+                            <td class="text-end">
+                                <t t-set="badge" t-value="componentBadge(component)" />
+                                <span
+                                    t-attf-class="badge {{ badge.class }}"
+                                    t-esc="badge.label"
+                                    t-att-data-tooltip="badge.help"
+                                />
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-att-disabled="state.busy" t-on-click="onApplyGoogleAddress">
+                    <i t-if="state.busy" class="fa fa-refresh fa-spin me-1" />
+                    Apply Google's Address
+                </button>
+                <button class="btn btn-secondary" t-att-disabled="state.busy" t-on-click="onKeepEnteredAddress">
+                    Keep current Address
+                </button>
+                <button class="btn btn-link" t-att-disabled="state.busy" t-on-click="onDiscard">Discard</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.xml
+++ b/contacts_google_address_validation/static/src/components/address_validation_dialog/address_validation_dialog.xml
@@ -86,12 +86,12 @@
                         No-Stat (not receiving mail)
                     </span>
                     <span t-if="usps.county" class="badge text-bg-light text-dark">
-                        County:
-                        <t t-esc="usps.county" />
+                        <span class="me-1">County:</span>
+                        <span t-esc="usps.county"/>
                     </span>
                 </div>
                 <div t-if="usps.standardizedAddress" class="mt-2">
-                    <span class="text-muted small">USPS Standardized:</span>
+                    <span class="text-muted small me-1">USPS Standardized:</span>
                     <span t-esc="usps.standardizedAddress" />
                 </div>
             </div>

--- a/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.js
+++ b/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.js
@@ -1,0 +1,256 @@
+/**
+ * @fileoverview "Validate Address" widget for the Contact form.
+ *
+ * Thin client: all communication with the Google Address Validation API
+ * and response parsing happens server-side in the
+ * `google.address.validation` abstract model. The widget only triggers
+ * the validation, displays the result dialog, and asks the backend to
+ * apply the outcome.
+ *
+ * @module contacts_google_address_validation/widgets/GoogleAddressValidation
+ */
+
+import { Component, useState, onMounted, onWillUpdateProps } from '@odoo/owl';
+import { _t } from '@web/core/l10n/translation';
+import { registry } from '@web/core/registry';
+import { useService } from '@web/core/utils/hooks';
+import { standardWidgetProps } from '@web/views/widgets/standard_widget_props';
+import { KeepLast } from '@web/core/utils/concurrency';
+import { AddressValidationDialog } from '../../components/address_validation_dialog/address_validation_dialog';
+
+/**
+ * Supported region codes for the Address Validation API, used only to
+ * disable the widget for out-of-coverage countries without a round-trip.
+ * The authoritative check lives server-side in
+ * `google.address.validation.is_region_supported()`.
+ *
+ * @see https://developers.google.com/maps/documentation/address-validation/coverage
+ * @type {string[]}
+ */
+const SUPPORTED_REGIONS_CODES = [
+    'AR', // Argentina
+    'AT', // Austria
+    'AU', // Australia
+    'BE', // Belgium
+    'BG', // Bulgaria
+    'BR', // Brazil
+    'CA', // Canada
+    'CH', // Switzerland
+    'CL', // Chile
+    'CO', // Colombia
+    'CZ', // Czechia
+    'DE', // Germany
+    'DK', // Denmark
+    'EE', // Estonia
+    'ES', // Spain
+    'FI', // Finland
+    'FR', // France
+    'GB', // United Kingdom
+    'HR', // Croatia
+    'HU', // Hungary
+    'IE', // Ireland
+    'IN', // India
+    'IT', // Italy
+    'JP', // Japan
+    'LT', // Lithuania
+    'LU', // Luxembourg
+    'LV', // Latvia
+    'MX', // Mexico
+    'MY', // Malaysia
+    'NL', // Netherlands
+    'NO', // Norway
+    'NZ', // New Zealand
+    'PL', // Poland
+    'PR', // Puerto Rico
+    'PT', // Portugal
+    'SE', // Sweden
+    'SG', // Singapore
+    'SI', // Slovenia
+    'SK', // Slovakia
+    'US', // United States
+];
+
+/**
+ * Extracts the id from a Many2one record value, tolerating the different
+ * shapes used across Odoo versions ([id, name] tuple or {id, display_name}).
+ *
+ * @param {*} value - Many2one value from `record.data`
+ * @returns {number|false} Database id or false
+ */
+function extractMany2oneId(value) {
+    if (!value) {
+        return false;
+    }
+    if (Array.isArray(value)) {
+        return value[0] || false;
+    }
+    if (typeof value === 'object') {
+        return value.id || false;
+    }
+    return value;
+}
+
+export class GoogleAddressValidation extends Component {
+    static template = 'contacts_google_address_validation.GoogleAddressValidation';
+    static props = { ...standardWidgetProps };
+
+    setup() {
+        this.ormService = useService('orm');
+        this.dialogService = useService('dialog');
+        this.notificationService = useService('notification');
+        this.state = useState({ busy: false, disabled: false });
+
+        onMounted(async () => {
+            const regionCode = await this.getRegionCode();
+            if (!regionCode || !SUPPORTED_REGIONS_CODES.includes(regionCode)) {
+                this.state.disabled = true;
+            }
+        });
+
+        this.keepLastRegion = new KeepLast();
+        onWillUpdateProps(async (nextProps) => {
+            if (nextProps.record.resId !== this.props.record.resId) {
+                const regionCode = await this.keepLastRegion.add(this.getRegionCode(nextProps));
+                if (regionCode === undefined) {
+                    return;
+                }
+                this.state.disabled = !regionCode || !SUPPORTED_REGIONS_CODES.includes(regionCode);
+            }
+        });
+    }
+
+    get status() {
+        return this.props.record.data.google_address_validation_status || 'not_validated';
+    }
+
+    get statusLabel() {
+        switch (this.status) {
+            case 'valid':
+                return _t('Validated');
+            case 'needs_review':
+                return _t('Needs Review');
+            case 'invalid':
+                return _t('Invalid');
+            default:
+                return _t('Not Validated');
+        }
+    }
+
+    get statusClass() {
+        switch (this.status) {
+            case 'valid':
+                return 'text-bg-success';
+            case 'needs_review':
+                return 'text-bg-warning';
+            case 'invalid':
+                return 'text-bg-danger';
+            default:
+                return 'text-bg-secondary';
+        }
+    }
+
+    get statusIcon() {
+        switch (this.status) {
+            case 'valid':
+                return 'fa-check-circle';
+            case 'needs_review':
+                return 'fa-question-circle';
+            case 'invalid':
+                return 'fa-exclamation-triangle';
+            default:
+                return 'fa-circle-o';
+        }
+    }
+
+    /**
+     * Resolves the ISO 3166-1 alpha-2 region code of the record's country.
+     * Used only for the coverage-based disabled state of the widget.
+     *
+     * @returns {Promise<string>} Country code or empty string
+     */
+    async getRegionCode(props) {
+        props = props || this.props;
+        const countryId = extractMany2oneId(props.record.data.country_id);
+        if (!countryId) {
+            return '';
+        }
+        const rows = await this.ormService.read('res.country', [countryId], ['code']);
+        return rows[0]?.code || '';
+    }
+
+    async onValidateClick() {
+        if (this.state.busy) {
+            return;
+        }
+        this.state.busy = true;
+        try {
+            const record = this.props.record;
+
+            // The validation runs server-side against the stored record,
+            // so pending edits must be persisted first.
+            if (record.isNew || (await record.isDirty())) {
+                const saved = await record.save();
+                if (!saved) {
+                    return;
+                }
+            }
+
+            const { entered, result } = await this.ormService.call('res.partner', 'action_google_validate_address', [
+                [record.resId],
+            ]);
+
+            this.dialogService.add(AddressValidationDialog, {
+                enteredAddress: entered,
+                result,
+                onApply: (applyGoogleAddress) => this.applyResult(result, applyGoogleAddress),
+            });
+        } catch (error) {
+            // UserErrors raised server-side (missing key, coverage,
+            // transport, Google API errors) surface through Odoo's
+            // standard RPC error dialog; anything else lands here.
+            if (!error?.data) {
+                console.error('Google Address Validation failed:', error);
+                this.notificationService.add(_t('Address validation failed. Please try again.'), { type: 'danger' });
+            } else {
+                throw error;
+            }
+        } finally {
+            this.state.busy = false;
+        }
+    }
+
+    /**
+     * Persists the validation outcome through the backend, then reloads
+     * the form record.
+     *
+     * @param {Object} result - Normalized validation result
+     * @param {boolean} applyGoogleAddress - Write the standardized address
+     * @returns {Promise<void>}
+     */
+    async applyResult(result, applyGoogleAddress) {
+        await this.ormService.call('res.partner', 'action_apply_google_address_validation', [
+            [this.props.record.resId],
+            result,
+            applyGoogleAddress,
+        ]);
+        await this.props.record.load();
+        this.notificationService.add(
+            applyGoogleAddress
+                ? _t("Google's standardized address has been applied.")
+                : _t('The validation result has been saved.'),
+            { type: 'success' }
+        );
+    }
+}
+
+export const googleAddressValidation = {
+    component: GoogleAddressValidation,
+    fieldDependencies: [
+        { name: 'country_id', type: 'many2one' },
+        { name: 'google_address_validation_status', type: 'selection' },
+        { name: 'google_address_validation_granularity', type: 'selection' },
+        { name: 'google_address_validation_date', type: 'datetime' },
+    ],
+};
+
+registry.category('view_widgets').add('google_address_validation', googleAddressValidation);

--- a/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.js
+++ b/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.js
@@ -72,6 +72,33 @@ const SUPPORTED_REGIONS_CODES = [
 ];
 
 /**
+ * Granularity information for the Address Validation API, used only to
+ * display a tooltip for the granularity badge. The authoritative check
+ * lives server-side in `google.address.validation.get_granularity_info()`.
+ *
+ * Note: `GRANULARITY_UNSPECIFIED` is internal value, used when the API cannot determine the level of detail, but the record has been validated.
+ * In this case, the tooltip will show "Granularity: Unspecified".
+ *
+ * @see https://developers.google.com/maps/documentation/javascript/reference/address-validation#Granularity
+ * @type {Object<string, string>}
+ */
+const GRANULARITY_INFO = {
+    SUB_PREMISE: _t('Granularity: Sub-premise (below-building level result, such as an apartment)'),
+    PREMISE: _t('Granularity: Premise (building-level result, such as a house or business)'),
+    PREMISE_PROXIMITY: _t(
+        'Granularity: Premise Proximity (geocode that approximates the building-level location of the address)'
+    ),
+    BLOCK: _t(
+        'Granularity: Block (the address or geocode indicates a block. Only used in regions which have block-level addressing, such as Japan)'
+    ),
+    ROUTE: _t('Granularity: Route (the geocode or address is granular to route, such as a street, road, or highway)'),
+    OTHER: _t(
+        'Granularity: Other (all other granularities, which are bucketed together since they are not deliverable.)'
+    ),
+    GRANULARITY_UNSPECIFIED: _t('Granularity: Unspecified (Google could not determine the level of detail)'),
+};
+
+/**
  * Extracts the id from a Many2one record value, tolerating the different
  * shapes used across Odoo versions ([id, name] tuple or {id, display_name}).
  *
@@ -125,12 +152,8 @@ export class GoogleAddressValidation extends Component {
     }
 
     get lastValidated() {
-        const dateStr = this.props.record.data.google_address_validation_date;
-        if (!dateStr) {
-            return '';
-        }
-        const dt = DateTime.fromISO(dateStr);
-        return dt.isValid ? dt.toLocaleString(DateTime.DATETIME_MED) : '';
+        const dt = this.props.record.data.google_address_validation_date;
+        return dt && dt.isValid ? dt.toLocaleString(DateTime.DATETIME_MED) : '';
     }
 
     get statusLabel() {
@@ -170,6 +193,14 @@ export class GoogleAddressValidation extends Component {
             default:
                 return 'fa-circle-o';
         }
+    }
+
+    get addressGranularity() {
+        const granularity = this.props.record.data.google_address_validation_granularity || '';
+        if (granularity) {
+            return GRANULARITY_INFO[granularity] || _t('Granularity: Unknown');
+        }
+        return this.props.record.data.google_address_validation_status ? _t('Granularity: Unknown') : '';
     }
 
     /**

--- a/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.js
+++ b/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.js
@@ -17,6 +17,7 @@ import { useService } from '@web/core/utils/hooks';
 import { standardWidgetProps } from '@web/views/widgets/standard_widget_props';
 import { KeepLast } from '@web/core/utils/concurrency';
 import { AddressValidationDialog } from '../../components/address_validation_dialog/address_validation_dialog';
+const { DateTime } = luxon;
 
 /**
  * Supported region codes for the Address Validation API, used only to
@@ -121,6 +122,15 @@ export class GoogleAddressValidation extends Component {
 
     get status() {
         return this.props.record.data.google_address_validation_status || 'not_validated';
+    }
+
+    get lastValidated() {
+        const dateStr = this.props.record.data.google_address_validation_date;
+        if (!dateStr) {
+            return '';
+        }
+        const dt = DateTime.fromISO(dateStr);
+        return dt.isValid ? dt.toLocaleString(DateTime.DATETIME_MED) : '';
     }
 
     get statusLabel() {

--- a/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
+++ b/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
@@ -23,7 +23,8 @@
                 </button>
             </div>
             <p class="text-muted smaller mb-0 p-0" t-if="lastValidated">
-                Validated on: <span t-esc="lastValidated" />
+                Validated on:
+                <span t-esc="lastValidated" />
             </p>
         </div>
     </t>

--- a/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
+++ b/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
@@ -1,25 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="contacts_google_address_validation.GoogleAddressValidation">
-        <div class="o_gaddress_validation d-flex align-items-center gap-2 mt-1 mb-2" t-if="!state.disabled">
-            <span
-                t-attf-class="badge rounded-pill {{ statusClass }}"
-                t-att-data-tooltip="props.record.data.google_address_validation_granularity ? 'Granularity: ' + props.record.data.google_address_validation_granularity : undefined"
-            >
-                <i t-attf-class="fa fa-fw {{ statusIcon }}" />
-                <span t-esc="statusLabel" />
-            </span>
-            <button
-                type="button"
-                class="btn btn-link btn-sm"
-                t-att-disabled="state.busy || props.readonly"
-                t-on-click="onValidateClick"
-                data-tooltip="Validate the address with Google Address Validation"
-            >
-                <i t-if="state.busy" class="fa fa-refresh fa-spin fa-fw" />
-                <i t-else="" class="fa fa-google fa-fw" />
-                Validate Address
-            </button>
+        <div class="o_gaddress_validation mt-1 mb-1" t-if="!state.disabled">
+            <div class="d-flex align-items-center gap-1">
+                <span
+                    t-attf-class="badge rounded-pill {{ statusClass }}"
+                    t-att-data-tooltip="props.record.data.google_address_validation_granularity ? 'Granularity: ' + props.record.data.google_address_validation_granularity : undefined"
+                >
+                    <i t-attf-class="fa fa-fw {{ statusIcon }}" />
+                    <span t-esc="statusLabel" />
+                </span>
+                <button
+                    type="button"
+                    class="btn btn-link btn-sm"
+                    t-att-disabled="state.busy || props.readonly"
+                    t-on-click="onValidateClick"
+                    data-tooltip="Validate the address with Google Address Validation"
+                >
+                    <i t-if="state.busy" class="fa fa-refresh fa-spin fa-fw" />
+                    <i t-else="" class="fa fa-google fa-fw" />
+                    Validate Address
+                </button>
+            </div>
+            <p class="text-muted smaller mb-0 p-0" t-if="lastValidated">
+                Validated on: <span t-esc="lastValidated" />
+            </p>
         </div>
     </t>
 </templates>

--- a/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
+++ b/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="contacts_google_address_validation.GoogleAddressValidation">
+        <div class="o_gaddress_validation d-flex align-items-center gap-2 mt-1 mb-2" t-if="!state.disabled">
+            <span
+                t-attf-class="badge rounded-pill {{ statusClass }}"
+                t-att-data-tooltip="props.record.data.google_address_validation_granularity ? 'Granularity: ' + props.record.data.google_address_validation_granularity : undefined"
+            >
+                <i t-attf-class="fa fa-fw {{ statusIcon }}" />
+                <span t-esc="statusLabel" />
+            </span>
+            <button
+                type="button"
+                class="btn btn-link btn-sm"
+                t-att-disabled="state.busy || props.readonly"
+                t-on-click="onValidateClick"
+                data-tooltip="Validate the address with Google Address Validation"
+            >
+                <i t-if="state.busy" class="fa fa-refresh fa-spin fa-fw" />
+                <i t-else="" class="fa fa-google fa-fw" />
+                Validate Address
+            </button>
+        </div>
+    </t>
+</templates>

--- a/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
+++ b/contacts_google_address_validation/static/src/widgets/GoogleAddressValidation/google_address_validation.xml
@@ -3,10 +3,7 @@
     <t t-name="contacts_google_address_validation.GoogleAddressValidation">
         <div class="o_gaddress_validation mt-1 mb-1" t-if="!state.disabled">
             <div class="d-flex align-items-center gap-1">
-                <span
-                    t-attf-class="badge rounded-pill {{ statusClass }}"
-                    t-att-data-tooltip="props.record.data.google_address_validation_granularity ? 'Granularity: ' + props.record.data.google_address_validation_granularity : undefined"
-                >
+                <span t-attf-class="badge rounded-pill {{ statusClass }}" t-att-data-tooltip="addressGranularity">
                     <i t-attf-class="fa fa-fw {{ statusIcon }}" />
                     <span t-esc="statusLabel" />
                 </span>

--- a/contacts_google_address_validation/tests/__init__.py
+++ b/contacts_google_address_validation/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import test_google_service
+from . import test_res_partner_google

--- a/contacts_google_address_validation/tests/test_google_service.py
+++ b/contacts_google_address_validation/tests/test_google_service.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the ``google.address.validation`` abstract model.
+
+Covers:
+  - _parse_validation        (REST response normalization)
+  - _parse_usps_data         (CASS / DPV block)
+  - _compute_recommendation  (accept / confirm / fix logic)
+  - validate_address         (request building, CASS gating)
+  - _google_request          (transport and API error handling)
+  - _get_api_key             (dedicated server key with fallback)
+
+All HTTP traffic is mocked — no real Google API calls are made.
+
+Run with:
+    odoo-bin -i contacts_google_address_validation --test-enable \
+        --stop-after-init
+"""
+
+from unittest.mock import patch
+
+import requests as requests_lib
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+
+SERVICE_MODULE = (
+    'odoo.addons.contacts_google_address_validation.models'
+    '.google_address_validation'
+)
+REQUESTS_POST = SERVICE_MODULE + '.requests.post'
+
+
+class MockResponse:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(self, status_code=200, payload=None, text=''):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.reason = 'Mock Reason'
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError('No JSON payload')
+        return self._payload
+
+
+def rest_document(**overrides):
+    """A realistic validateAddress REST response (US, CASS enabled)."""
+    result = {
+        'verdict': {
+            'inputGranularity': 'PREMISE',
+            'validationGranularity': 'PREMISE',
+            'geocodeGranularity': 'PREMISE',
+            'addressComplete': True,
+            'hasInferredComponents': False,
+            'hasUnconfirmedComponents': False,
+            'hasReplacedComponents': False,
+        },
+        'address': {
+            'formattedAddress': (
+                '1600 Amphitheatre Parkway, Mountain View, CA 94043, USA'
+            ),
+            'postalAddress': {
+                'regionCode': 'US',
+                'administrativeArea': 'CA',
+                'locality': 'Mountain View',
+                'postalCode': '94043',
+                'addressLines': ['1600 Amphitheatre Pkwy'],
+            },
+            'addressComponents': [
+                {
+                    'componentName': {'text': '1600'},
+                    'componentType': 'street_number',
+                    'confirmationLevel': 'CONFIRMED',
+                },
+                {
+                    'componentName': {'text': 'Amphitheatre Parkway'},
+                    'componentType': 'route',
+                    'confirmationLevel': 'CONFIRMED',
+                    'spellCorrected': True,
+                },
+            ],
+        },
+        'geocode': {
+            'location': {
+                'latitude': 37.4224764,
+                'longitude': -122.0842499,
+            },
+        },
+        'uspsData': {
+            'standardizedAddress': {
+                'firstAddressLine': '1600 AMPHITHEATRE PKWY',
+                'cityStateZipAddressLine': 'MOUNTAIN VIEW CA 94043-1351',
+                'city': 'MOUNTAIN VIEW',
+                'state': 'CA',
+                'zipCode': '94043',
+                'zipCodeExtension': '1351',
+            },
+            'dpvConfirmation': 'Y',
+            'county': 'Santa Clara',
+            'dpvVacant': 'N',
+            'dpvNoStat': 'N',
+        },
+    }
+    result.update(overrides.pop('result', {}))
+    document = {'result': result, 'responseId': 'resp-abc-123'}
+    document.update(overrides)
+    return document
+
+
+class GoogleServiceCase(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.service = self.env['google.address.validation']
+        self.icp = self.env['ir.config_parameter'].sudo()
+        self.icp.set_param('base_google_map.api_key', 'browser-key-123456')
+        self.icp.set_param(
+            'contacts_google_address_validation.api_key', ''
+        )
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def test_api_key_falls_back_to_base_google_map(self):
+        self.assertEqual(self.service._get_api_key(), 'browser-key-123456')
+
+    def test_dedicated_server_key_takes_precedence(self):
+        self.icp.set_param(
+            'contacts_google_address_validation.api_key', 'server-key-789'
+        )
+        self.assertEqual(self.service._get_api_key(), 'server-key-789')
+
+    def test_missing_api_key_raises(self):
+        self.icp.set_param('base_google_map.api_key', '')
+        with self.assertRaises(UserError):
+            self.service._get_api_key()
+
+    def test_region_helpers(self):
+        self.assertTrue(self.service.is_region_supported('us'))
+        self.assertTrue(self.service.is_region_supported('DE'))
+        self.assertFalse(self.service.is_region_supported('ID'))
+        self.assertFalse(self.service.is_region_supported(''))
+        self.assertTrue(self.service.should_enable_cass('US'))
+        self.assertTrue(self.service.should_enable_cass('PR'))
+        self.assertFalse(self.service.should_enable_cass('CA'))
+
+    # ------------------------------------------------------------------
+    # Response normalization
+    # ------------------------------------------------------------------
+
+    def test_parse_validation_accept(self):
+        result = self.service._parse_validation(rest_document())
+        self.assertEqual(result['responseId'], 'resp-abc-123')
+        self.assertIn('Amphitheatre', result['formattedAddress'])
+        self.assertEqual(
+            result['verdict']['validationGranularity'], 'PREMISE'
+        )
+        self.assertTrue(result['verdict']['addressComplete'])
+        self.assertEqual(len(result['components']), 2)
+        self.assertEqual(result['components'][0]['type'], 'street_number')
+        self.assertEqual(result['components'][0]['name'], '1600')
+        self.assertTrue(result['components'][1]['spellCorrected'])
+        self.assertEqual(
+            result['postalAddress']['locality'], 'Mountain View'
+        )
+        self.assertAlmostEqual(result['location']['latitude'], 37.4224764)
+        self.assertEqual(result['uspsData']['dpvConfirmation'], 'Y')
+        self.assertIn(
+            '1600 AMPHITHEATRE PKWY',
+            result['uspsData']['standardizedAddress'],
+        )
+        self.assertEqual(result['recommendation'], 'ACCEPT')
+        self.assertEqual(result['status'], 'valid')
+
+    def test_parse_validation_missing_components(self):
+        document = rest_document()
+        document['result']['verdict']['addressComplete'] = False
+        document['result']['address']['missingComponentTypes'] = [
+            'street_number'
+        ]
+        result = self.service._parse_validation(document)
+        self.assertEqual(
+            result['missingComponentTypes'], ['street_number']
+        )
+        self.assertEqual(result['recommendation'], 'CONFIRM')
+        self.assertEqual(result['status'], 'needs_review')
+
+    def test_parse_validation_minimal_document(self):
+        result = self.service._parse_validation({})
+        self.assertEqual(result['status'], 'invalid')  # FIX
+        self.assertIsNone(result['uspsData'])
+        self.assertIsNone(result['location'])
+        self.assertEqual(result['components'], [])
+
+    def test_parse_usps_data_zip_fallback(self):
+        usps = self.service._parse_usps_data({
+            'dpvConfirmation': 'D',
+            'standardizedAddress': {
+                'firstAddressLine': '20 MAIN ST',
+                'city': 'ROSEVILLE',
+                'state': 'CA',
+                'zipCode': '95678',
+                'zipCodeExtension': '1234',
+            },
+        })
+        self.assertIn('95678-1234', usps['standardizedAddress'])
+        self.assertEqual(usps['dpvConfirmation'], 'D')
+
+    # ------------------------------------------------------------------
+    # Recommendation logic
+    # ------------------------------------------------------------------
+
+    def test_recommendation_prefers_possible_next_action(self):
+        verdict = {
+            'possibleNextAction': 'FIX',
+            'validationGranularity': 'PREMISE',
+            'addressComplete': True,
+        }
+        self.assertEqual(
+            self.service._compute_recommendation(verdict), 'FIX'
+        )
+
+    def test_recommendation_heuristics(self):
+        cases = [
+            # (verdict, expected)
+            ({'validationGranularity': 'OTHER'}, 'FIX'),
+            ({'validationGranularity': ''}, 'FIX'),
+            (
+                {
+                    'validationGranularity': 'PREMISE',
+                    'addressComplete': True,
+                    'hasUnconfirmedComponents': True,
+                },
+                'CONFIRM',
+            ),
+            (
+                {
+                    'validationGranularity': 'SUB_PREMISE',
+                    'addressComplete': False,
+                },
+                'CONFIRM',
+            ),
+            (
+                {
+                    'validationGranularity': 'PREMISE',
+                    'addressComplete': True,
+                },
+                'ACCEPT',
+            ),
+        ]
+        for verdict, expected in cases:
+            self.assertEqual(
+                self.service._compute_recommendation(verdict),
+                expected,
+                'verdict %r should yield %r' % (verdict, expected),
+            )
+
+    # ------------------------------------------------------------------
+    # Request building
+    # ------------------------------------------------------------------
+
+    def test_validate_address_request_body(self):
+        with patch(REQUESTS_POST) as mock_post:
+            mock_post.return_value = MockResponse(payload=rest_document())
+            self.service.validate_address(
+                ['1600 Amphitheatre Pkwy', 'Mountain View CA 94043'],
+                region_code='us',
+                enable_usps_cass=True,
+            )
+            body = mock_post.call_args[1]['json']
+            params = mock_post.call_args[1]['params']
+        self.assertEqual(body['address']['regionCode'], 'US')
+        self.assertEqual(len(body['address']['addressLines']), 2)
+        self.assertTrue(body['enableUspsCass'])
+        self.assertEqual(params['key'], 'browser-key-123456')
+
+    def test_validate_address_cass_gated_by_region(self):
+        with patch(REQUESTS_POST) as mock_post:
+            mock_post.return_value = MockResponse(payload=rest_document())
+            self.service.validate_address(
+                ['20 Bay St'], region_code='CA', enable_usps_cass=True
+            )
+            body = mock_post.call_args[1]['json']
+        self.assertNotIn('enableUspsCass', body)
+
+    # ------------------------------------------------------------------
+    # Transport / API errors
+    # ------------------------------------------------------------------
+
+    def _error_document(self, status, message='boom'):
+        return {
+            'error': {'code': 403, 'status': status, 'message': message}
+        }
+
+    @mute_logger(SERVICE_MODULE)
+    def test_permission_denied_hints_configuration(self):
+        with patch(REQUESTS_POST) as mock_post:
+            mock_post.return_value = MockResponse(
+                status_code=403,
+                payload=self._error_document('PERMISSION_DENIED'),
+            )
+            with self.assertRaises(UserError) as ctx:
+                self.service.validate_address(['x'], region_code='US')
+            self.assertIn('Address Validation API', str(ctx.exception))
+            self.assertIn('restrictions', str(ctx.exception))
+
+    @mute_logger(SERVICE_MODULE)
+    def test_resource_exhausted(self):
+        with patch(REQUESTS_POST) as mock_post:
+            mock_post.return_value = MockResponse(
+                status_code=429,
+                payload=self._error_document('RESOURCE_EXHAUSTED'),
+            )
+            with self.assertRaises(UserError) as ctx:
+                self.service.validate_address(['x'], region_code='US')
+            self.assertIn('quota', str(ctx.exception).lower())
+
+    @mute_logger(SERVICE_MODULE)
+    def test_invalid_argument(self):
+        with patch(REQUESTS_POST) as mock_post:
+            mock_post.return_value = MockResponse(
+                status_code=400,
+                payload=self._error_document('INVALID_ARGUMENT'),
+            )
+            with self.assertRaises(UserError) as ctx:
+                self.service.validate_address(['x'], region_code='US')
+            self.assertIn('could not process', str(ctx.exception))
+
+    def test_timeout(self):
+        with patch(REQUESTS_POST) as mock_post:
+            mock_post.side_effect = requests_lib.exceptions.Timeout()
+            with self.assertRaises(UserError) as ctx:
+                self.service.validate_address(['x'], region_code='US')
+            self.assertIn('did not respond', str(ctx.exception))
+
+    @mute_logger(SERVICE_MODULE)
+    def test_invalid_json(self):
+        with patch(REQUESTS_POST) as mock_post:
+            mock_post.return_value = MockResponse(
+                status_code=200, payload=None, text='<html>oops</html>'
+            )
+            with self.assertRaises(UserError) as ctx:
+                self.service.validate_address(['x'], region_code='US')
+            self.assertIn('unexpected', str(ctx.exception).lower())

--- a/contacts_google_address_validation/tests/test_res_partner_google.py
+++ b/contacts_google_address_validation/tests/test_res_partner_google.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the Google Address Validation flow on ``res.partner``.
+
+Covers:
+  - action_google_validate_address         (guards, coverage, request)
+  - action_apply_google_address_validation (apply / keep, sanitization)
+  - _prepare_google_validated_address      (state / country resolution)
+  - validation reset lifecycle             (write override, onchange)
+  - storage compliance (no raw Google/USPS address strings persisted in
+    fields or chatter — GMP Service Specific Terms, Table 1.3.2)
+
+All HTTP traffic is mocked — no real Google API calls are made.
+
+Run with:
+    odoo-bin -i contacts_google_address_validation --test-enable \
+        --stop-after-init
+"""
+
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+from .test_google_service import rest_document
+
+
+class GooglePartnerCase(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.icp = self.env['ir.config_parameter'].sudo()
+        self.icp.set_param('base_google_map.api_key', 'browser-key-123456')
+        self.country_us = self.env.ref('base.us')
+        State = self.env['res.country.state']
+        self.state_ca = State.search(
+            [('country_id', '=', self.country_us.id), ('code', '=', 'CA')],
+            limit=1,
+        ) or State.create({
+            'name': 'California',
+            'code': 'CA',
+            'country_id': self.country_us.id,
+        })
+        self.partner = self.env['res.partner'].create({
+            'name': 'Google Test Partner',
+            'street': '1600 Amphitheatre',
+            'city': 'Mountainview',
+            'zip': '94043',
+            'country_id': self.country_us.id,
+        })
+
+    def _validated_result(self, document=None):
+        return self.env['google.address.validation']._parse_validation(
+            document or rest_document()
+        )
+
+    def _patch_validate_address(self):
+        """Patch ``validate_address`` on the service model class so the
+        partner action is tested in isolation — no transport involved
+        (transport itself is covered by test_google_service)."""
+        return patch.object(
+            self.env.registry['google.address.validation'],
+            'validate_address',
+            return_value=self._validated_result(),
+        )
+
+    # ------------------------------------------------------------------
+    # Validate action (guards, coverage, request building)
+    # ------------------------------------------------------------------
+
+    def test_validate_requires_address(self):
+        partner = self.env['res.partner'].create({
+            'name': 'Empty',
+            'country_id': self.country_us.id,
+        })
+        with self.assertRaises(UserError):
+            partner.action_google_validate_address()
+
+    def test_validate_rejects_unsupported_country(self):
+        self.partner.country_id = self.env.ref('base.id')  # Indonesia
+        with self.assertRaises(UserError) as ctx:
+            self.partner.action_google_validate_address()
+        self.assertIn('not available', str(ctx.exception))
+
+    def test_validate_builds_request_and_returns_result(self):
+        with self._patch_validate_address() as mock_validate:
+            response = self.partner.action_google_validate_address()
+        mock_validate.assert_called_once()
+        lines = mock_validate.call_args[0][0]
+        kwargs = mock_validate.call_args[1]
+        self.assertIn('1600 Amphitheatre', lines[0])
+        self.assertIn('94043', lines[-1])
+        self.assertEqual(kwargs['region_code'], 'US')
+        # CASS is enabled automatically for US addresses
+        self.assertTrue(kwargs['enable_usps_cass'])
+        self.assertEqual(response['result']['status'], 'valid')
+        self.assertIn('1600 Amphitheatre', response['entered'])
+
+    def test_validate_no_cass_outside_us_pr(self):
+        self.partner.write({
+            'country_id': self.env.ref('base.de').id,  # Germany
+            'state_id': False,
+        })
+        with self._patch_validate_address() as mock_validate:
+            self.partner.action_google_validate_address()
+        kwargs = mock_validate.call_args[1]
+        self.assertEqual(kwargs['region_code'], 'DE')
+        self.assertFalse(kwargs['enable_usps_cass'])
+
+    # ------------------------------------------------------------------
+    # Apply / keep
+    # ------------------------------------------------------------------
+
+    def test_apply_address_writes_fields(self):
+        self.partner.action_apply_google_address_validation(
+            self._validated_result(), True
+        )
+        self.assertEqual(self.partner.street, '1600 Amphitheatre Pkwy')
+        self.assertEqual(self.partner.city, 'Mountain View')
+        self.assertEqual(self.partner.zip, '94043')
+        self.assertEqual(self.partner.state_id, self.state_ca)
+        self.assertEqual(self.partner.country_id, self.country_us)
+        self.assertEqual(
+            self.partner.google_address_validation_status, 'valid'
+        )
+        self.assertEqual(
+            self.partner.google_address_validation_granularity, 'PREMISE'
+        )
+        self.assertEqual(
+            self.partner.google_address_validation_response_id,
+            'resp-abc-123',
+        )
+        self.assertTrue(self.partner.google_address_validation_date)
+        self.assertAlmostEqual(
+            self.partner.partner_latitude, 37.4224764
+        )
+        self.assertAlmostEqual(
+            self.partner.partner_longitude, -122.0842499
+        )
+
+    def test_keep_address_stores_verdict_only(self):
+        self.partner.action_apply_google_address_validation(
+            self._validated_result(), False
+        )
+        self.assertEqual(self.partner.street, '1600 Amphitheatre')
+        self.assertEqual(self.partner.city, 'Mountainview')
+        self.assertEqual(
+            self.partner.google_address_validation_status, 'valid'
+        )
+
+    def test_apply_sanitizes_unknown_values(self):
+        result = self._validated_result()
+        result['status'] = 'bogus'
+        result['verdict']['validationGranularity'] = 'NOT_A_GRANULARITY'
+        self.partner.action_apply_google_address_validation(result, False)
+        self.assertEqual(
+            self.partner.google_address_validation_status,
+            'not_validated',
+        )
+        self.assertFalse(
+            self.partner.google_address_validation_granularity
+        )
+
+    def test_prepare_address_resolves_state_within_country(self):
+        vals = self.env['res.partner']._prepare_google_validated_address({
+            'street': 'x',
+            'state_code': 'California',  # by name
+            'country_code': 'US',
+        })
+        self.assertEqual(vals['state_id'], self.state_ca.id)
+        self.assertEqual(vals['country_id'], self.country_us.id)
+
+    def test_prepare_address_unknown_state_cleared(self):
+        vals = self.env['res.partner']._prepare_google_validated_address({
+            'street': 'x',
+            'state_code': 'Atlantis',
+            'country_code': 'US',
+        })
+        self.assertFalse(vals['state_id'])
+
+    # ------------------------------------------------------------------
+    # Storage compliance (GMP Service Specific Terms, Table 1.3.2)
+    # ------------------------------------------------------------------
+
+    def test_no_standardized_address_fields_on_partner(self):
+        """Google / USPS standardized address strings must not be
+        persisted on the partner: only End User confirmed data (the
+        applied address) may be stored permanently."""
+        Partner = self.env['res.partner']
+        self.assertNotIn(
+            'google_address_validation_formatted_address',
+            Partner._fields,
+        )
+        self.assertNotIn(
+            'google_address_validation_usps_address', Partner._fields
+        )
+
+    def test_chatter_has_verdict_but_no_raw_addresses(self):
+        """The chatter note must contain only verdict data (status,
+        granularity, DPV code, ...) — never standardized address strings,
+        since mail messages are stored forever, which would exceed the
+        30-day caching period of the Google Maps Platform Service
+        Specific Terms (Table 1.3.2)."""
+        messages_before = len(self.partner.message_ids)
+        self.partner.action_apply_google_address_validation(
+            self._validated_result(), False
+        )
+        new_messages = self.partner.message_ids[
+            : len(self.partner.message_ids) - messages_before
+        ]
+        body = ' '.join(new_messages.mapped('body'))
+        self.assertIn('Google Address Validation Result', body)
+        self.assertIn('USPS DPV Confirmation', body)
+        self.assertNotIn('Standardized Address', body)
+        self.assertNotIn('AMPHITHEATRE PKWY', body)
+        self.assertNotIn('Santa Clara', body)
+
+    def test_no_gc_cron_registered(self):
+        """The GC cron was removed together with the cached fields; make
+        sure no leftover cron record still calls the deleted method."""
+        crons = self.env['ir.cron'].with_context(
+            active_test=False
+        ).search([('code', 'like', '_gc_google_address_validation_cache')])
+        self.assertFalse(crons)
+
+    # ------------------------------------------------------------------
+    # Reset lifecycle
+    # ------------------------------------------------------------------
+
+    def test_write_address_field_resets_validation(self):
+        self.partner.action_apply_google_address_validation(
+            self._validated_result(), False
+        )
+        self.partner.write({'street': 'Another street 7'})
+        self.assertEqual(
+            self.partner.google_address_validation_status,
+            'not_validated',
+        )
+        self.assertFalse(
+            self.partner.google_address_validation_granularity
+        )
+        self.assertFalse(self.partner.google_address_validation_date)
+
+    def test_write_with_status_skips_reset(self):
+        self.partner.action_apply_google_address_validation(
+            self._validated_result(), False
+        )
+        self.partner.write({
+            'street': 'New street 42',
+            'google_address_validation_status': 'needs_review',
+        })
+        self.assertEqual(
+            self.partner.google_address_validation_status, 'needs_review'
+        )
+
+    def test_onchange_resets_validation(self):
+        self.partner.action_apply_google_address_validation(
+            self._validated_result(), False
+        )
+        self.partner._onchange_address_reset_google_validation()
+        self.assertEqual(
+            self.partner.google_address_validation_status,
+            'not_validated',
+        )

--- a/contacts_google_address_validation/views/res_config_settings.xml
+++ b/contacts_google_address_validation/views/res_config_settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.contacts_google_address_validation</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="520" />
+        <field name="inherit_id" ref="base_google_map.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//block[@name='base_google_map']" position="inside">
+                <setting
+                    id="google_address_validation_api_key_setting"
+                    help="Optional dedicated API key for server-side Address Validation requests. The main Google Maps key is usually HTTP-referrer restricted, which Google rejects for server-side calls. Restrict this key to the Address Validation API and by server IP address."
+                    documentation="https://developers.google.com/maps/documentation/address-validation/requests-validate-address"
+                >
+                    <field
+                        name="google_address_validation_api_key"
+                        string="Address Validation Server Key"
+                        password="True"
+                    />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/contacts_google_address_validation/views/res_config_settings.xml
+++ b/contacts_google_address_validation/views/res_config_settings.xml
@@ -9,7 +9,7 @@
             <xpath expr="//block[@name='base_google_map']" position="inside">
                 <setting
                     id="google_address_validation_api_key_setting"
-                    help="Optional dedicated API key for server-side Address Validation requests. The main Google Maps key is usually HTTP-referrer restricted, which Google rejects for server-side calls. Restrict this key to the Address Validation API and by server IP address."
+                    help="Optional dedicated API key for server-side Address Validation requests. The main Google Maps key is usually HTTP-referrer restricted, which Google rejects for server-side calls. Restrict this key to the Address Validation API only, and by server IP address when your host has a static outbound IP. On hosts without a static IP (e.g. Odoo.sh), leave the application restriction to None and set a quota cap instead — see the module README."
                     documentation="https://developers.google.com/maps/documentation/address-validation/requests-validate-address"
                 >
                     <field

--- a/contacts_google_address_validation/views/res_partner_views.xml
+++ b/contacts_google_address_validation/views/res_partner_views.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_res_partner_form_inherit_google_address_validation" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit.google.address.validation</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="priority" eval="998" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('o_address_format')]" position="inside">
+                <div class="d-flex">
+                    <field name="google_address_validation_status" invisible="1" />
+                    <widget name="google_address_validation" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_res_partner_filter_inherit_google_address_validation" model="ir.ui.view">
+        <field name="name">res.partner.select.inherit.google.address.validation</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter" />
+        <field name="arch" type="xml">
+            <xpath expr="//search" position="inside">
+                <separator />
+                <filter
+                    string="Address Validated"
+                    name="google_address_valid"
+                    domain="[('google_address_validation_status', '=', 'valid')]"
+                />
+                <filter
+                    string="Address Needs Review"
+                    name="google_address_needs_review"
+                    domain="[('google_address_validation_status', '=', 'needs_review')]"
+                />
+                <filter
+                    string="Address Invalid"
+                    name="google_address_invalid"
+                    domain="[('google_address_validation_status', '=', 'invalid')]"
+                />
+                <filter
+                    string="Address Not Validated"
+                    name="google_address_not_validated"
+                    domain="[('google_address_validation_status', '=', 'not_validated')]"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add `Validate Address` button to the Contact form; calls `AddressValidation.fetchAddressValidation` server-side with the contact's country as `regionCode`
- Add `google.address.validation` abstract model handling all API communication via REST `v1:validateAddress`; supports a separate server-side API key setting (referrer-restricted browser keys are rejected by Google for server calls)
- Add `AddressValidationDialog` OWL component: shows verdict, side-by-side address comparison (entered vs. Google standardized), component-level breakdown with confirmation levels (Confirmed / Plausible / Suspicious), and USPS CASS™ DPV details for US/PR addresses
- Add `action_apply_google_address_validation` on `res.partner`: applies standardized street, street2, city, state, zip, country, and geocoordinates in a single write; state and country resolved server-side
- Store verdict fields on `res.partner`: validation status (Validated / Needs Review / Invalid), granularity, validation date, and API response ID; automatic reset to Not Validated on any address field edit; search filters by status
- Add Python test suites: `test_google_service.py` (service layer) and `test_res_partner_google.py` (partner flow)
- Register module in README dependency graph, capability table, and module listing