### PR TITLE
[IMP] Add unlocated records indicator to map and drawing views

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ graph LR
 
 The required foundation for every other module in this suite. Adds a Google Maps section to General Settings where you enter your API Key, Map ID, and preferences for language, region, color scheme, and nearby search radius. All other modules load the Google Maps script through this one.
 
-**[web_view_google_map](web_view_google_map/README.md)** [`19.0.1.0.26`](web_view_google_map/CHANGELOG.md)
+**[web_view_google_map](web_view_google_map/README.md)** [`19.0.1.1.0`](web_view_google_map/CHANGELOG.md)
 
 The core map view module. Adds a `google_map` view type alongside list, kanban, and form. Features a record sidebar, marker clustering for dense data, box selection to pick multiple records at once, nearby search, in-map place search, a geolocation button to center the map on your location, grouped markers, dark mode, and a Street View side-by-side button in every marker info window.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The required foundation for every other module in this suite. Adds a Google Maps
 
 The core map view module. Adds a `google_map` view type alongside list, kanban, and form. Features a record sidebar, marker clustering for dense data, box selection to pick multiple records at once, nearby search, in-map place search, a geolocation button to center the map on your location, grouped markers, dark mode, and a Street View side-by-side button in every marker info window.
 
-**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** [`19.0.1.0.22`](web_view_google_map_drawing/CHANGELOG.md)
+**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** [`19.0.1.1.0`](web_view_google_map_drawing/CHANGELOG.md)
 
 Extends the map view with geographic drawing tools. Users can draw polygons, rectangles, and freehand shapes directly on the map. Shapes are stored as GeoJSON on the record and support server-side filtering so you can query which records fall inside a drawn area. Built on [Terra Draw](https://terradraw.io/) and [Deck.gl](https://deck.gl/); all libraries are bundled locally.
 

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## 19.0.1.1.0
+
+### Added
+
+- **"Unlocated Records" Sidebar Row & Action** (`google_map_sidebar.xml`, `google_map_sidebar.js`): The sidebar now shows a count of records excluded from the map because they lack valid geolocation data, with a button that opens those records in a dedicated list view via the new `showUnlocatedRecords()` action.
+- **`unLocatedCount`, `notGeolocatedDomain`, `unlocatedRecordsDomain`** (`google_map_model.js`): New model getters compute the complement of `mapDomain` — records missing a required lat/lng (including their related source fields when applicable) — combined with the current search domain, so the sidebar count and the list it opens can never disagree.
+- **`showUnlocatedRecords()`** (`google_map_controller.js`): New controller method that opens a list view scoped to `model.unlocatedRecordsDomain`; wired through `rendererProps` down to the renderer and sidebar.
+- **Dedicated Count `KeepLast`** (`google_map_model.js`): New `_countKeepLast` instance isolates the unlocated-record count RPC from the model's own record-load `keepLast`, preventing the two async flows from cancelling each other. `load()` is overridden to refresh the count after every load.
+
+### Improved
+
+- **Marker Info Window Subtitle** (`google_map_renderer.xml`): The subtitle `<div>` in `MarkerInfoWindow` now only renders when a `subTitle` value is present (`t-if="subTitle"`), avoiding an empty line in the info window; added `fw-normal` class.
+- **`mapDomain` — Extracted `_hasSearchableGeoFields()`** (`google_map_model.js`): The geolocation field/searchability check was factored out of the `mapDomain` getter into its own method, now shared with the new `notGeolocatedDomain` getter.
+- **`Domain.and(...).toList()` Cleanup** (`google_map_model.js`): Removed the unnecessary empty options object (`.toList({})` → `.toList()`) from all domain calls in `mapDomain` and `_getNextConfig`.
+
+### Removed
+
+- **Unused `KanbanRecord` Import** (`google_map_renderer.js`): Removed the unused `KanbanRecord` import and its registration in `static components`.
+
 ## 19.0.1.0.26
 
 ### Added

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -33,7 +33,7 @@ Provides:
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Extra Tools",
-    "version": "19.0.1.0.26",
+    "version": "19.0.1.1.0",
     "depends": ["base_google_map", "web_widget_google_map"],
     "data": ["views/res_config_settings.xml"],
     "assets": {

--- a/web_view_google_map/static/src/fields/x2many/google_map_x2many_field.js
+++ b/web_view_google_map/static/src/fields/x2many/google_map_x2many_field.js
@@ -28,6 +28,8 @@ export class X2ManyFieldGoogleMap extends X2ManyField {
     get viewAttrsConfig() {
         const { archInfo } = this;
         return {
+            lat: archInfo.latitudeField,
+            lng: archInfo.longitudeField,
             title: archInfo.sidebarTitleField,
             subTitle: archInfo.sidebarSubtitleField,
             __geoColor: archInfo.__geoColor,
@@ -48,6 +50,8 @@ export class X2ManyFieldGoogleMap extends X2ManyField {
                 openRecord: this.openRecord.bind(this),
                 showRecord: this.openRecord.bind(this),
                 showRecordsByDomain: () => {},
+                showUnlocatedRecords: () => {},
+                unLocatedCount: 0,
                 allowSelectors: false,
                 viewAttrs: viewAttrsConfig,
             };

--- a/web_view_google_map/static/src/views/google_map/google_map_controller.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_controller.js
@@ -400,6 +400,12 @@ export class GoogleMapController extends Component {
         this.actionService.doAction(action);
     }
 
+    showUnlocatedRecords() {
+        const domain = this.model.unlocatedRecordsDomain;
+        if (!domain.length) return;
+        this.showRecordsByDomain(_t('Unlocated'), domain);
+    }
+
     /**
      * Opens a new map view scoped to records within a bounding box around the
      * given record's location. The bounding box is a rectangular approximation
@@ -727,6 +733,7 @@ export class GoogleMapController extends Component {
     get rendererProps() {
         return {
             list: this.model.root,
+            unLocatedCount: this.model.unLocatedCount,
             archInfo: this.props.archInfo,
             viewAttrs: this.viewMapConfig,
             activeActions: this.activeActions,
@@ -737,6 +744,7 @@ export class GoogleMapController extends Component {
             showRecord: this.showRecord.bind(this),
             showRecordsByDomain: this.showRecordsByDomain.bind(this),
             showNearbyRecords: this.showNearbyRecords.bind(this),
+            showUnlocatedRecords: this.showUnlocatedRecords.bind(this),
             showGoogleStreetViewSideBySide: this.showGoogleStreetViewSideBySide.bind(this),
         };
     }

--- a/web_view_google_map/static/src/views/google_map/google_map_model.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_model.js
@@ -153,10 +153,7 @@ export class GoogleMapModel extends RelationalModel {
             const nullValues = [null, false];
             // Complement of mapDomain: a record is not geolocated when ANY
             // required coordinate source is missing — hence OR, not AND.
-            const parts = [
-                [[this.viewConfig.lat, 'in', nullValues]],
-                [[this.viewConfig.lng, 'in', nullValues]],
-            ];
+            const parts = [[[this.viewConfig.lat, 'in', nullValues]], [[this.viewConfig.lng, 'in', nullValues]]];
             for (const fieldName of [this.viewConfig.lat, this.viewConfig.lng]) {
                 const related = this.config.fields[fieldName].related;
                 if (related) {

--- a/web_view_google_map/static/src/views/google_map/google_map_model.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_model.js
@@ -3,6 +3,7 @@ import { DynamicGroupList } from '@web/model/relational_model/dynamic_group_list
 import { Group } from '@web/model/relational_model/group';
 import { Record } from '@web/model/relational_model/record';
 import { Domain } from '@web/core/domain';
+import { KeepLast } from '@web/core/utils/concurrency';
 import { parseRecord, generateColor } from './utils';
 import { gMapViewAttrsContextManager } from '../../helpers/view_attrs_context_manager';
 
@@ -67,6 +68,10 @@ export class GoogleMapModel extends RelationalModel {
     setup(params, services) {
         super.setup(...arguments);
         this.viewConfig = params.viewConfig || {};
+        this.unLocatedCount = 0;
+        // Dedicated KeepLast — this.keepLast is used internally by
+        // RelationalModel for record loads and must not be shared
+        this._countKeepLast = new KeepLast();
     }
     /**
      * Override
@@ -79,10 +84,37 @@ export class GoogleMapModel extends RelationalModel {
         const mapDomain = this.mapDomain;
         if (mapDomain && mapDomain.length) {
             // add domain for geolocation fields
-            nextConfig.domain = Domain.and([nextConfig.domain ?? [], mapDomain]).toList({});
+            nextConfig.domain = Domain.and([nextConfig.domain ?? [], mapDomain]).toList();
         }
         return nextConfig;
     }
+
+    /**
+     * Override
+     * @param {*} params
+     */
+    async load(params = {}) {
+        const res = await super.load(params);
+        await this._updateUnlocatedRecordCount(this.config, params);
+        return res;
+    }
+
+    /**
+     * Whether the view is configured with searchable geolocation fields
+     * @returns {boolean}
+     */
+    _hasSearchableGeoFields() {
+        return Boolean(
+            this.viewConfig &&
+                this.viewConfig.lat &&
+                this.viewConfig.lng &&
+                this.config.fields[this.viewConfig.lat] &&
+                this.config.fields[this.viewConfig.lng] &&
+                this.config.fields[this.viewConfig.lat].searchable &&
+                this.config.fields[this.viewConfig.lng].searchable
+        );
+    }
+
     /**
      * Filter for geolocation fields
      * @returns {Array} domain for map
@@ -92,15 +124,7 @@ export class GoogleMapModel extends RelationalModel {
             return this._mapDomainCache;
         }
         let result = [];
-        if (
-            this.viewConfig &&
-            this.viewConfig.lat &&
-            this.viewConfig.lng &&
-            this.config.fields[this.viewConfig.lat] &&
-            this.config.fields[this.viewConfig.lng] &&
-            this.config.fields[this.viewConfig.lat].searchable &&
-            this.config.fields[this.viewConfig.lng].searchable
-        ) {
+        if (this._hasSearchableGeoFields()) {
             // Exclude null/false only — 0.0 is a valid coordinate (equator/prime meridian)
             const nullValues = [null, false];
             let latDomain = [[this.viewConfig.lat, 'not in', nullValues]];
@@ -108,16 +132,72 @@ export class GoogleMapModel extends RelationalModel {
 
             if (this.config.fields[this.viewConfig.lat].related) {
                 const related_source = this.config.fields[this.viewConfig.lat].related.split('.')[0];
-                latDomain = Domain.and([latDomain, [[related_source, 'not in', nullValues]]]).toList({});
+                latDomain = Domain.and([latDomain, [[related_source, 'not in', nullValues]]]).toList();
             }
             if (this.config.fields[this.viewConfig.lng].related) {
                 const related_source = this.config.fields[this.viewConfig.lng].related.split('.')[0];
-                lngDomain = Domain.and([lngDomain, [[related_source, 'not in', nullValues]]]).toList({});
+                lngDomain = Domain.and([lngDomain, [[related_source, 'not in', nullValues]]]).toList();
             }
-            result = Domain.and([latDomain, lngDomain]).toList({});
+            result = Domain.and([latDomain, lngDomain]).toList();
         }
         this._mapDomainCache = result;
         return result;
+    }
+
+    get notGeolocatedDomain() {
+        if (this._unlocatedDomainCache !== undefined) {
+            return this._unlocatedDomainCache;
+        }
+        let result = [];
+        if (this._hasSearchableGeoFields()) {
+            const nullValues = [null, false];
+            // Complement of mapDomain: a record is not geolocated when ANY
+            // required coordinate source is missing — hence OR, not AND.
+            const parts = [
+                [this.viewConfig.lat, 'in', nullValues],
+                [this.viewConfig.lng, 'in', nullValues],
+            ];
+            for (const fieldName of [this.viewConfig.lat, this.viewConfig.lng]) {
+                const related = this.config.fields[fieldName].related;
+                if (related) {
+                    parts.push([related.split('.')[0], 'in', nullValues]);
+                }
+            }
+            result = new Domain(parts).toList();
+        }
+        this._unlocatedDomainCache = result;
+        return result;
+    }
+
+    /**
+     * Domain matching the records excluded from the map by the current
+     * search: current search scope AND missing geolocation. Reusable by
+     * the controller (e.g. an action listing the non-geolocated records)
+     * so any list opened from the count can never disagree with it.
+     * @returns {Array} combined domain
+     */
+    get unlocatedRecordsDomain() {
+        const notGeolocated = this.notGeolocatedDomain;
+        if (!notGeolocated.length) {
+            return [];
+        }
+        return Domain.and([this._searchDomain ?? [], notGeolocated]).toList();
+    }
+
+    async _updateUnlocatedRecordCount(config, params) {
+        if (this._searchDomain === undefined) {
+            this._searchDomain = params.domain ?? [];
+        }
+        const domain = this.unlocatedRecordsDomain;
+        if (!domain.length || this.useSampleModel) {
+            this.unLocatedCount = 0;
+            return;
+        }
+        this.unLocatedCount = await this._countKeepLast.add(
+            this.orm.searchCount(this.config.resModel, domain, {
+                context: this.config.context,
+            })
+        );
     }
 }
 

--- a/web_view_google_map/static/src/views/google_map/google_map_model.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_model.js
@@ -154,16 +154,16 @@ export class GoogleMapModel extends RelationalModel {
             // Complement of mapDomain: a record is not geolocated when ANY
             // required coordinate source is missing — hence OR, not AND.
             const parts = [
-                [this.viewConfig.lat, 'in', nullValues],
-                [this.viewConfig.lng, 'in', nullValues],
+                [[this.viewConfig.lat, 'in', nullValues]],
+                [[this.viewConfig.lng, 'in', nullValues]],
             ];
             for (const fieldName of [this.viewConfig.lat, this.viewConfig.lng]) {
                 const related = this.config.fields[fieldName].related;
                 if (related) {
-                    parts.push([related.split('.')[0], 'in', nullValues]);
+                    parts.push([[related.split('.')[0], 'in', nullValues]]);
                 }
             }
-            result = new Domain(parts).toList();
+            result = Domain.or(parts).toList();
         }
         this._unlocatedDomainCache = result;
         return result;

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -852,7 +852,7 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         return {
             header: viewTitle,
             title: this.props.archInfo.sidebarTitleField,
-            unLocatedCount: this.props.unLocatedCount,
+            unLocatedCount: this.props.unLocatedCount ?? 0,
             getGroupsOrRecords: this.getGroupsOrRecords.bind(this),
             toggleGroup: this.toggleGroup.bind(this),
             renderGroupedRecordsFitBounds: this._renderGroupedRecordsFitBounds.bind(this),

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.js
@@ -7,7 +7,6 @@ import { useBus } from '@web/core/utils/hooks';
 
 import { BaseGoogleMapComponent } from '@base_google_map/utils/base_google_map';
 import { LOADER_STATUS } from '@base_google_map/utils/loader_google_map';
-import { KanbanRecord } from '@web/views/kanban/kanban_record';
 
 import { GoogleMapSidebar } from './google_map_sidebar';
 import { GoogleMapGeolocate } from '@web_widget_google_map/components/geolocate/geolocate';
@@ -79,7 +78,6 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
     static template = 'web_view_google_map.GoogleMapRenderer';
     static templateInfoWindow = 'web_view_google_map.MarkerInfoWindow';
     static components = {
-        KanbanRecord,
         Geolocate: GoogleMapGeolocate,
         Sidebar: GoogleMapSidebar,
         InMapSearchPlaces: GoogleMapSearchPlaces,
@@ -90,9 +88,11 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         showRecord: Function,
         showRecordsByDomain: Function,
         showNearbyRecords: Function,
+        showUnlocatedRecords: Function,
         showGoogleStreetViewSideBySide: Function,
         readonly: Boolean,
         list: Object,
+        unLocatedCount: Number,
         onAdd: { type: Function, optional: true },
         activeActions: { type: Object, optional: true },
         allowSelectors: Boolean,
@@ -852,12 +852,14 @@ export class GoogleMapRenderer extends BaseGoogleMapComponent {
         return {
             header: viewTitle,
             title: this.props.archInfo.sidebarTitleField,
+            unLocatedCount: this.props.unLocatedCount,
             getGroupsOrRecords: this.getGroupsOrRecords.bind(this),
             toggleGroup: this.toggleGroup.bind(this),
             renderGroupedRecordsFitBounds: this._renderGroupedRecordsFitBounds.bind(this),
             openRecord: this.props.openRecord.bind(this),
             showRecordsByDomain: this.props.showRecordsByDomain.bind(this),
             showNearbyRecords: this.searchNearbyRecords.bind(this),
+            showUnlocatedRecords: this.props.showUnlocatedRecords.bind(this),
             pointInMap: this.pointInMap.bind(this),
             deleteGroupRecords: this.deleteGroupRecords.bind(this),
             handleToggleRecordSelection: this.toggleRecordSelection.bind(this),

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.xml
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.xml
@@ -32,7 +32,7 @@
                             data-tooltip="This marker has been adjusted slightly so it doesn't overlap with others. The line points to its original location."
                         />
                     </h4>
-                    <div>
+                    <div class="fw-normal" t-if="subTitle">
                         <t t-esc="subTitle" />
                     </div>
                     <div class="pt-3 d-flex text-nowrap gap-1">

--- a/web_view_google_map/static/src/views/google_map/google_map_sidebar.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_sidebar.js
@@ -25,6 +25,7 @@ export class GoogleMapSidebar extends Component {
     static props = {
         header: String,
         title: { type: String, optional: true },
+        unLocatedCount: Number,
         getGroupsOrRecords: Function,
         toggleGroup: Function,
         renderGroupedRecordsFitBounds: Function,
@@ -34,6 +35,7 @@ export class GoogleMapSidebar extends Component {
         pointInMap: Function,
         deleteGroupRecords: Function,
         handleToggleSelection: Function,
+        showUnlocatedRecords: Function,
         handleCanSelectRecord: Boolean,
         handleSelectAll: Boolean,
         handleToggleRecordSelection: Function,

--- a/web_view_google_map/static/src/views/google_map/google_map_sidebar.xml
+++ b/web_view_google_map/static/src/views/google_map/google_map_sidebar.xml
@@ -194,6 +194,26 @@
                     </small>
                 </div>
             </div>
+            <div t-if="this.props.unLocatedCount &gt; 0" class="py-1 border-top border-bottom">
+                <div class="d-flex align-items-center justify-content-end px-1">
+                    <div>
+                        <span>Unlocated</span>
+                        <span class="ms-1">
+                            (
+                            <t t-out="this.props.unLocatedCount" />
+                            )
+                        </span>
+                    </div>
+                    <button
+                        type="button"
+                        class="btn btn-link"
+                        data-tooltip="Show Unlocated"
+                        t-on-click.prevent="() => this.props.showUnlocatedRecords()"
+                    >
+                        <i class="fa fa-lg fa-angle-double-right" aria-hidden="true" />
+                    </button>
+                </div>
+            </div>
             <t t-call="{{ constructor.listGroupOrRecordTemplate }}">
                 <t t-set="fnPinPointInMap" t-value="props.pointInMap" />
                 <t t-set="fnOpenRecord" t-value="props.openRecord" />

--- a/web_view_google_map/static/src/views/google_map/google_map_sidebar.xml
+++ b/web_view_google_map/static/src/views/google_map/google_map_sidebar.xml
@@ -181,34 +181,29 @@
 
     <t t-name="web_view_google_map.GoogleMapSidebar">
         <div class="o_map_sidebar" t-ref="root">
-            <div class="mt-2 mx-1">
+            <div class="mt-2 mx-1" t-if="props.header || props.allowSelectors">
                 <div class="d-flex">
                     <t t-if="props.allowSelectors">
                         <CheckBox value="props.handleSelectAll" onChange.bind="props.handleToggleSelection" />
                     </t>
                     <h3 t-if="props.header" t-esc="props.header" />
-                    <small class="ms-2 text-muted">
-                        <span t-att-data-tooltip="geolocationInfoTooltip">
-                            <i class="fa fa-info" aria-hidden="true" />
-                        </span>
-                    </small>
                 </div>
             </div>
-            <div t-if="this.props.unLocatedCount &gt; 0" class="py-1 border-top border-bottom">
+            <div t-if="(props.unLocatedCount || 0) &gt; 0" class="py-1 border-top border-bottom">
                 <div class="d-flex align-items-center justify-content-end px-1">
                     <div>
                         <span>Unlocated</span>
                         <span class="ms-1">
-                            (
-                            <t t-out="this.props.unLocatedCount" />
-                            )
+                            <span>(</span>
+                            <span t-out="props.unLocatedCount" />
+                            <span>)</span>
                         </span>
                     </div>
                     <button
                         type="button"
                         class="btn btn-link"
                         data-tooltip="Show Unlocated"
-                        t-on-click.prevent="() => this.props.showUnlocatedRecords()"
+                        t-on-click.prevent="() => props.showUnlocatedRecords()"
                     >
                         <i class="fa fa-lg fa-angle-double-right" aria-hidden="true" />
                     </button>

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 19.0.1.1.0
+
+### Added
+
+- **"Unlocated Records" Sidebar Row & Action**: Adopts the `web_view_google_map` v1.1.0 unlocated-records feature — the sidebar shows a count of records with no drawn shape, with a button to open them in a list view via the inherited `showUnlocatedRecords()` action. Passed through `GoogleMapDeckGLRenderer.props` (`unLocatedCount`, `showUnlocatedRecords`) into its sidebar props.
+- **`GoogleMapDrawingModel.notGeolocatedDomain`**: New override defining "unlocated" for drawing views as no shape drawn yet — the GeoJSON field is `NULL` or an empty `FeatureCollection`. Uses `Domain.or` since `json_eq` never matches `NULL` rows, so both legs are required.
+- **`GoogleMapDrawingModel._hasSearchableGeoFields()`**: New override checking the searchable GeoJSON field instead of lat/lng, reused by both `mapDomain` and the new `notGeolocatedDomain`.
+
+### Improved
+
+- **`mapDomain` — Extracted `_hasSearchableGeoFields()`**: The GeoJSON field/searchability check was factored out of the `mapDomain` getter into its own method; `EMPTY_FEATURE_COLLECTION` extracted as a shared module-level constant instead of being redefined inline in each domain.
+- **`Domain.and(...).toList()` Cleanup**: Removed the unnecessary empty options object (`.toList({})` → `.toList()`).
+
 ## 19.0.1.0.23
 
 ### Updated Dependencies

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -28,7 +28,7 @@ Provides:
     "website": "https://www.mithnusa.com",
     "support": "yopiangi@gmail.com",
     "category": "Extra Tools",
-    "version": "19.0.1.0.23",
+    "version": "19.0.1.1.0",
     "depends": ["web_view_google_map"],
     "assets": {
         "web.assets_backend": [

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_deckgl_renderer.js
@@ -89,6 +89,8 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
         activeActions: { type: Object, optional: true },
         allowSelectors: Boolean,
         viewAttrs: Object,
+        unLocatedCount: Number,
+        showUnlocatedRecords: Function,
     };
 
     setup() {
@@ -1237,11 +1239,13 @@ export class GoogleMapDeckGLRenderer extends BaseGoogleMapComponent {
         return {
             header: viewTitle,
             title: this.props.archInfo.sidebarTitleField,
+            unLocatedCount: this.props.unLocatedCount,
             getGroupsOrRecords: this.getGroupsOrRecords.bind(this),
             toggleGroup: this.toggleGroup.bind(this),
             renderGroupedRecordsFitBounds: this._renderGroupedRecordsFitBounds.bind(this),
             openRecord: this.props.openRecord.bind(this),
             showRecordsByDomain: this.props.showRecordsByDomain.bind(this),
+            showUnlocatedRecords: this.props.showUnlocatedRecords.bind(this),
             pointInMap: this.pointInMap.bind(this),
             deleteGroupRecords: this.deleteGroupRecords.bind(this),
             handleToggleRecordSelection: this.toggleRecordSelection.bind(this),

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_model.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_model.js
@@ -1,7 +1,22 @@
 import { Domain } from '@web/core/domain';
 import { GoogleMapModel } from '@web_view_google_map/views/google_map/google_map_model';
 
+const EMPTY_FEATURE_COLLECTION = { type: 'FeatureCollection', features: [] };
+
 export class GoogleMapDrawingModel extends GoogleMapModel {
+    /**
+     * @override
+     * Drawing views locate records by a GeoJSON field, not lat/lng
+     */
+    _hasSearchableGeoFields() {
+        return Boolean(
+            this.viewConfig &&
+                this.viewConfig.geoJsonField &&
+                this.config.fields[this.viewConfig.geoJsonField] &&
+                this.config.fields[this.viewConfig.geoJsonField].searchable
+        );
+    }
+
     /**
      * @override
      */
@@ -10,18 +25,34 @@ export class GoogleMapDrawingModel extends GoogleMapModel {
             return this._mapDomainCache;
         }
         let result = [];
-        if (
-            this.viewConfig &&
-            this.viewConfig.geoJsonField &&
-            this.config.fields[this.viewConfig.geoJsonField] &&
-            this.config.fields[this.viewConfig.geoJsonField].searchable
-        ) {
+        if (this._hasSearchableGeoFields()) {
             result = Domain.and([
                 [[this.viewConfig.geoJsonField, '!=', null]],
-                [[this.viewConfig.geoJsonField, 'json_ne', { type: 'FeatureCollection', features: [] }]],
-            ]).toList({}); // Filter out null and empty FeatureCollection
+                [[this.viewConfig.geoJsonField, 'json_ne', EMPTY_FEATURE_COLLECTION]],
+            ]).toList(); // Filter out null and empty FeatureCollection
         }
         this._mapDomainCache = result;
+        return result;
+    }
+
+    /**
+     * @override
+     * Complement of mapDomain: no shape drawn yet, i.e. NULL or an empty
+     * FeatureCollection. json_eq never matches NULL rows, so both legs
+     * of the OR are required.
+     */
+    get notGeolocatedDomain() {
+        if (this._unlocatedDomainCache !== undefined) {
+            return this._unlocatedDomainCache;
+        }
+        let result = [];
+        if (this._hasSearchableGeoFields()) {
+            result = Domain.or([
+                [[this.viewConfig.geoJsonField, '=', null]],
+                [[this.viewConfig.geoJsonField, 'json_eq', EMPTY_FEATURE_COLLECTION]],
+            ]).toList();
+        }
+        this._unlocatedDomainCache = result;
         return result;
     }
 }


### PR DESCRIPTION
## Summary
- Adds an "Unlocated" row to the `google_map` view sidebar showing how many records in the current search are excluded from the map due to missing geolocation data, with a button to open them in a dedicated list view.
- `GoogleMapModel` gains `notGeolocatedDomain` / `unlocatedRecordsDomain` getters (the complement of `mapDomain`) and a dedicated `KeepLast` so the count RPC never races with record loads.
- `web_view_google_map_drawing` adopts the same indicator for shape-based views: `GoogleMapDrawingModel.notGeolocatedDomain` treats a `NULL` or empty `FeatureCollection` GeoJSON field as "no shape drawn yet."
- Minor cleanup along the way: unused `KanbanRecord` import removed, redundant `Domain.toList({})` arguments dropped, marker info window subtitle only renders when present.
