### PR TITLE
[ADD] Add first Hoot JS unit test suites for web_view_google_map(_drawing) and wire up CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -186,6 +186,37 @@ jobs:
           fi
           echo ""
 
+          # Discover repository addons with a Hoot JS unit test suite
+          # (static/tests/**/*.test.js). These have no Python test_*.py file
+          # so they're absent from db_test_addons above, but they still need
+          # to be installed for their web.assets_unit_tests bundle to be
+          # loaded when /web/tests runs — and WebSuite.test_unit_desktop's
+          # hoot id filter is built from their suite name (derived from the
+          # test file name), not a hardcoded list.
+          js_test_addons=()
+          hoot_tags=()
+          for module in "${install_modules[@]}"; do
+            if [[ -d "$module/static/tests" ]]; then
+              while IFS= read -r test_file; do
+                js_test_addons+=("$module")
+                suite_name=$(basename "$test_file" .test.js)
+                hoot_tags+=("/web:WebSuite.test_unit_desktop[@${module}/${suite_name}]")
+              done < <(find "$module/static/tests" -type f -name "*.test.js")
+            fi
+          done
+
+          mapfile -t js_test_addons < <(
+            printf '%s\n' "${js_test_addons[@]}" | sort -u
+          )
+
+          echo "JS (Hoot) test addons:"
+          if [[ ${#js_test_addons[@]} -gt 0 ]]; then
+            printf '  %s\n' "${js_test_addons[@]}"
+          else
+            echo "  (none)"
+          fi
+          echo ""
+
           # Python imports modules via their symlink path (/opt/odoo/odoo/addons/<module>/...)
           # so --source must point there to match what coverage actually tracks.
           COVERAGE_SOURCES=$(printf '/opt/odoo/odoo/addons/%s,' "${install_modules[@]}")
@@ -201,12 +232,24 @@ jobs:
               "${unit_test_modules[@]}"
           fi
 
-          # Run DB-backed Odoo tests only for repository addons that actually have DB tests
-          if [[ ${#db_test_addons[@]} -gt 0 ]]; then
-            DB_MODULES=$(IFS=,; echo "${db_test_addons[*]}")
+          # Run DB-backed Odoo tests and/or the Hoot JS suite, whichever
+          # (or both) this repo actually has. Independent of one another —
+          # neither should be skipped just because the other is empty.
+          if [[ ${#db_test_addons[@]} -gt 0 || ${#js_test_addons[@]} -gt 0 ]]; then
+            # Modules to install: anything with Python DB tests, plus
+            # anything with JS tests (needed so their web.assets_unit_tests
+            # bundle is actually loaded when /web/tests runs).
+            mapfile -t install_for_tests < <(
+              printf '%s\n' "${db_test_addons[@]}" "${js_test_addons[@]}" | sort -u
+            )
+            DB_MODULES=$(IFS=,; echo "${install_for_tests[*]}")
 
-            TEST_TAGS=$(printf ',/%s' "${db_test_addons[@]}")
-            TEST_TAGS=${TEST_TAGS:1}
+            test_tag_parts=()
+            for addon in "${db_test_addons[@]}"; do
+              test_tag_parts+=("/$addon")
+            done
+            test_tag_parts+=("${hoot_tags[@]}")
+            TEST_TAGS=$(IFS=,; echo "${test_tag_parts[*]}")
 
             python -m coverage run \
               --append \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           pip install -r /opt/odoo/requirements.txt
           pip install -e /opt/odoo
-          pip install coverage
+          pip install coverage websocket-client
 
       - name: Wait for PostgreSQL
         env:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ graph LR
 
 The required foundation for every other module in this suite. Adds a Google Maps section to General Settings where you enter your API Key, Map ID, and preferences for language, region, color scheme, and nearby search radius. All other modules load the Google Maps script through this one.
 
-**[web_view_google_map](web_view_google_map/README.md)** [`19.0.1.0.26`](web_view_google_map/CHANGELOG.md)
+**[web_view_google_map](web_view_google_map/README.md)** [`19.0.2.0.1`](web_view_google_map/CHANGELOG.md)
 
 The core map view module. Adds a `google_map` view type alongside list, kanban, and form. Features a record sidebar, marker clustering for dense data, box selection to pick multiple records at once, nearby search, in-map place search, a geolocation button to center the map on your location, grouped markers, dark mode, and a Street View side-by-side button in every marker info window.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The required foundation for every other module in this suite. Adds a Google Maps
 
 The core map view module. Adds a `google_map` view type alongside list, kanban, and form. Features a record sidebar, marker clustering for dense data, box selection to pick multiple records at once, nearby search, in-map place search, a geolocation button to center the map on your location, grouped markers, dark mode, and a Street View side-by-side button in every marker info window.
 
-**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** [`19.0.1.0.22`](web_view_google_map_drawing/CHANGELOG.md)
+**[web_view_google_map_drawing](web_view_google_map_drawing/README.md)** [`19.0.2.0.1`](web_view_google_map_drawing/CHANGELOG.md)
 
 Extends the map view with geographic drawing tools. Users can draw polygons, rectangles, and freehand shapes directly on the map. Shapes are stored as GeoJSON on the record and support server-side filtering so you can query which records fall inside a drawn area. Built on [Terra Draw](https://terradraw.io/) and [Deck.gl](https://deck.gl/); all libraries are bundled locally.
 

--- a/web_view_google_map/CHANGELOG.md
+++ b/web_view_google_map/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 19.0.2.0.1
+
+### Added
+
+- **Hoot JS Test Suite** (`static/tests/google_map_view.test.js`): First test suite for the module — covers unlocated-records domain exclusion, `mapDomain`'s 0.0 equator/prime-meridian handling, arch-parser mandatory-attribute validation, `groupsLimit` defaults, marker creation and click, grouping, header buttons, and record deletion.
+- **`static/tests/helpers/google_maps_test_helpers.js`**: Shared fakes for the `google.maps` API boundary (`FakeMap`, `FakeAdvancedMarkerElement`, `FakePinElement`, `FakeInfoWindow`, etc.) plus `mockGoogleMapsApi()` and `waitUntil()` helpers; reused by dependent modules (e.g. `web_view_google_map_drawing`) instead of duplicating the harness.
+- **`web.assets_unit_tests` Bundle** (`__manifest__.py`): Registered `static/tests/**/*` so the new suite runs under Odoo's Hoot test runner.
+- **`GoogleMapArchParser.mandatoryAttrs()` — Required-Attribute Validation**: `parseGoogleMapAttrs()` now throws `Missing required attribute(s): ...` when any of `lat`, `lng`, `sidebar_title`, `sidebar_subtitle` is absent from the arch, uncovered while writing the arch-parser tests.
+
+### Fixed
+
+- **`sidebarTitleField` / `sidebarSubtitleField` — Null vs Undefined Prop Crash**: `xmlDoc.getAttribute()` returns `null` (not `undefined`) when an attribute is absent; `GoogleMapSidebar`'s `title`/`subTitle` props are optional strings, and OWL's prop validator only treats `undefined` as "not provided" — an explicit `null` still failed the `String` type check. Both fields now fall back to `undefined` via `|| undefined`.
+
 ## 19.0.1.0.26
 
 ### Added

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -33,7 +33,7 @@ Provides:
     "website": "https://github.com/mithnusa",
     "support": "yopiangi@gmail.com",
     "category": "Extra Tools",
-    "version": "19.0.1.0.26",
+    "version": "19.0.2.0.1",
     "depends": ["base_google_map", "web_widget_google_map"],
     "data": ["views/res_config_settings.xml"],
     "assets": {
@@ -58,6 +58,9 @@ Provides:
         ],
         "web.dark_mode_assets_backend": [
             "web_view_google_map/static/src/views/google_map/google_map_view.dark.scss",
+        ],
+        "web.assets_unit_tests": [
+            "web_view_google_map/static/tests/**/*",
         ],
     },
     "uninstall_hook": "_uninstall_view_google_map",

--- a/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
@@ -119,9 +119,7 @@ export class GoogleMapArchParser {
     parseGoogleMapAttrs(xmlDoc, node, attrs) {
         const requiredAttrs = this.mandatoryAttrs();
         if (requiredAttrs) {
-            const missingAttrs = requiredAttrs.filter(
-                (attrName) => !xmlDoc.getAttribute(attrName)
-            );
+            const missingAttrs = requiredAttrs.filter((attrName) => !xmlDoc.getAttribute(attrName));
             if (missingAttrs.length) {
                 throw new Error(`Missing required attribute(s): ${missingAttrs.join(', ')}`);
             }

--- a/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
@@ -113,16 +113,38 @@ export class GoogleMapArchParser {
     }
 
     mandatoryAttrs() {
-        return ['lat', 'lng', 'sidebar_title', 'sidebar_subtitle'];
+        return ['sidebar_title', 'sidebar_subtitle'];
     }
 
-    parseGoogleMapAttrs(xmlDoc, node, attrs) {
+    validateMandatoryAttrs(xmlDoc) {
         const requiredAttrs = this.mandatoryAttrs();
         if (requiredAttrs) {
             const missingAttrs = requiredAttrs.filter((attrName) => !xmlDoc.getAttribute(attrName));
             if (missingAttrs.length) {
                 throw new Error(`Missing required attribute(s): ${missingAttrs.join(', ')}`);
             }
+        }
+    }
+
+    /**
+     * A google_map view locates records by lat/lng. Overridable (and
+     * patchable — see web_view_google_map_drawing's arch parser) for
+     * variants that locate records a different way.
+     */
+    hasValidGeoAttrs(xmlDoc) {
+        return Boolean(xmlDoc.getAttribute('lat')) && Boolean(xmlDoc.getAttribute('lng'));
+    }
+
+    /** Paired with hasValidGeoAttrs() — kept separate so a subclass/patch can override just the message. */
+    missingGeoAttrsMessage() {
+        return 'Missing required attribute(s): lat, lng';
+    }
+
+    parseGoogleMapAttrs(xmlDoc, node, attrs) {
+        this.validateMandatoryAttrs(xmlDoc);
+
+        if (!this.hasValidGeoAttrs(xmlDoc)) {
+            throw new Error(this.missingGeoAttrsMessage());
         }
 
         const activeActions = {

--- a/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_arch_parser.js
@@ -112,7 +112,21 @@ export class GoogleMapArchParser {
         };
     }
 
+    mandatoryAttrs() {
+        return ['lat', 'lng', 'sidebar_title', 'sidebar_subtitle'];
+    }
+
     parseGoogleMapAttrs(xmlDoc, node, attrs) {
+        const requiredAttrs = this.mandatoryAttrs();
+        if (requiredAttrs) {
+            const missingAttrs = requiredAttrs.filter(
+                (attrName) => !xmlDoc.getAttribute(attrName)
+            );
+            if (missingAttrs.length) {
+                throw new Error(`Missing required attribute(s): ${missingAttrs.join(', ')}`);
+            }
+        }
+
         const activeActions = {
             ...getActiveActions(xmlDoc),
             exportXlsx: exprToBoolean(xmlDoc.getAttribute('export_xlsx'), true),
@@ -151,11 +165,12 @@ export class GoogleMapArchParser {
         const longitudeField = xmlDoc.getAttribute('lng');
         attrs.longitudeField = longitudeField;
 
-        const sidebarTitleField = xmlDoc.getAttribute('sidebar_title');
-        attrs.sidebarTitleField = sidebarTitleField;
-
-        const sidebarSubtitleField = xmlDoc.getAttribute('sidebar_subtitle');
-        attrs.sidebarSubtitleField = sidebarSubtitleField;
+        // getAttribute() returns null (not undefined) when the attribute is
+        // absent; GoogleMapSidebar's title/subTitle props are optional
+        // strings, and OWL's prop validator only treats undefined as "not
+        // provided" — an explicit null still fails the String type check.
+        attrs.sidebarTitleField = xmlDoc.getAttribute('sidebar_title') || undefined;
+        attrs.sidebarSubtitleField = xmlDoc.getAttribute('sidebar_subtitle') || undefined;
 
         const onCreate = xmlDoc.getAttribute('on_create');
         attrs.onCreate = onCreate;

--- a/web_view_google_map/static/tests/google_map_view.test.js
+++ b/web_view_google_map/static/tests/google_map_view.test.js
@@ -1,0 +1,389 @@
+// web_view_google_map/static/tests/google_map_view.test.js
+import { beforeEach, describe, expect, test } from '@odoo/hoot';
+import { click, queryAllTexts, queryAll, waitFor } from '@odoo/hoot-dom';
+import { Domain } from '@web/core/domain';
+import {
+    contains,
+    defineModels,
+    fields,
+    findComponent,
+    mockService,
+    models,
+    mountView,
+    serverState,
+} from '@web/../tests/web_test_helpers';
+
+import { GoogleMapController } from '@web_view_google_map/views/google_map/google_map_controller';
+import { GoogleMapRenderer } from '@web_view_google_map/views/google_map/google_map_renderer';
+import { GoogleMapArchParser } from '@web_view_google_map/views/google_map/google_map_arch_parser';
+import { generateColor } from '@web_view_google_map/views/google_map/utils';
+import { mockGoogleMapsApi, waitUntil } from '@web_view_google_map/../tests/helpers/google_maps_test_helpers';
+
+class Country extends models.Model {
+    _name = 'res.country';
+
+    name = fields.Char();
+    _records = [
+        { id: 1, name: 'North' },
+        { id: 2, name: 'South' },
+        { id: 3, name: 'None' },
+    ];
+}
+
+class Partner extends models.Model {
+    _name = 'res.partner';
+
+    name = fields.Char();
+    contact_address = fields.Char();
+    country_id = fields.Many2one({ string: 'Country', relation: 'res.country' });
+    partner_latitude = fields.Float();
+    partner_longitude = fields.Float();
+
+    _records = [
+        {
+            id: 1,
+            name: 'Located A',
+            contact_address: 'Street A',
+            partner_latitude: 10.0,
+            partner_longitude: 10.5,
+            country_id: 1,
+        },
+        {
+            id: 2,
+            name: 'Located B',
+            contact_address: 'Street B',
+            partner_latitude: 11.0,
+            partner_longitude: 11.5,
+            country_id: 2,
+        },
+        {
+            id: 3,
+            name: 'No coords',
+            contact_address: 'None',
+            partner_latitude: false,
+            partner_longitude: false,
+            country_id: 3,
+        },
+    ];
+}
+
+// The mock server resolves the current user (env["res.users"].browse(uid))
+// on every RPC, not just when a field references res.users — it must
+// always be registered, even though nothing in this view touches it.
+class Users extends models.Model {
+    _name = 'res.users';
+
+    name = fields.Char();
+    _records = [{ id: serverState.userId, name: 'Mitchell Admin' }];
+
+    // Matches core's ResUsers mock model — some access-rights check in the
+    // view stack (e.g. group-gated buttons/menus) calls this on every mount.
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, Users, Country]);
+
+function getMapController(view) {
+    return findComponent(view, (c) => c instanceof GoogleMapController);
+}
+
+function getMapRenderer(view) {
+    return findComponent(view, (c) => c instanceof GoogleMapRenderer);
+}
+
+beforeEach(() => {
+    mockGoogleMapsApi();
+});
+
+
+describe('unlocated records', () => {
+    test('unlocated records are counted and excluded from the map domain', async () => {
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>
+            `,
+        });
+
+        const { model } = getMapController(view);
+        expect(model.unLocatedCount).toBe(1);
+
+        // Assert on what the domain *selects*, not on Domain.toList()'s internal
+        // array shape — the serialized form (flat implicit-AND vs "&"-prefixed)
+        // is an implementation detail of the Domain class, not our contract.
+        const domain = new Domain(model.unlocatedRecordsDomain);
+        expect(domain.contains({ partner_latitude: 10.0, partner_longitude: 10.5 })).toBe(false);
+        expect(domain.contains({ partner_latitude: 11.0, partner_longitude: 11.5 })).toBe(false);
+        expect(domain.contains({ partner_latitude: false, partner_longitude: false })).toBe(true);
+    });
+
+    test('clicking the Unlocated row opens a list scoped to the unlocated domain', async () => {
+        let calledWith;
+        mockService('action', {
+            doAction(action) {
+                calledWith = action;
+            },
+        });
+
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>
+            `,
+        });
+
+        await waitFor('.o_map_sidebar .border-top.border-bottom');
+        expect(queryAllTexts('.o_map_sidebar .border-top.border-bottom span')).toInclude('Unlocated');
+
+        await contains("button[data-tooltip='Show Unlocated']").click();
+        expect(calledWith.domain).toEqual(getMapController(view).model.unlocatedRecordsDomain);
+    });
+});
+
+describe('map domain', () => {
+    test('mapDomain includes the 0.0 equator/prime-meridian coordinates but excludes null/false', async () => {
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>
+            `,
+        });
+
+        const { model } = getMapController(view);
+        const domain = new Domain(model.mapDomain);
+
+        // Regression test: 0.0 is a valid coordinate (equator / prime
+        // meridian), not an absence of one. A prior version of mapDomain
+        // treated it as equivalent to null/false and excluded it.
+        expect(domain.contains({ partner_latitude: 0.0, partner_longitude: 0.0 })).toBe(true);
+        expect(domain.contains({ partner_latitude: false, partner_longitude: false })).toBe(false);
+        expect(domain.contains({ partner_latitude: 10.0, partner_longitude: false })).toBe(false);
+    });
+});
+
+describe('arch parser', () => {
+    // Pure parsing logic — no mountView, no google.maps, no OWL involved.
+    function parseArch(archXml) {
+        const xmlDoc = new DOMParser().parseFromString(archXml, 'text/xml').documentElement;
+        return new GoogleMapArchParser().parse(xmlDoc, { 'res.partner': { fields: {} } }, 'res.partner');
+    }
+
+    test('groupsLimit defaults to 80 when default_group_by is set without an explicit groups_limit', () => {
+        const archInfo = parseArch(
+            `<google_map lat="partner_latitude" lng="partner_longitude" default_group_by="contact_address" sidebar_title="name" sidebar_subtitle="contact_address"/>`
+        );
+        expect(archInfo.groupsLimit).toBe(80);
+    });
+
+    test('groupsLimit stays unset without default_group_by', () => {
+        const archInfo = parseArch(
+            `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address"/>`
+        );
+        expect(archInfo.groupsLimit).toBe(null);
+    });
+
+    test('an explicit groups_limit is respected even with default_group_by', () => {
+        const archInfo = parseArch(
+            `<google_map lat="partner_latitude" lng="partner_longitude" default_group_by="country_id" groups_limit="25" sidebar_title="name" sidebar_subtitle="contact_address"/>`
+        );
+        expect(archInfo.groupsLimit).toBe(25);
+    });
+
+    // Asserted directly against the parser (synchronous throw), not through
+    // mountView(): the error is thrown inside View's onWillStart, which OWL's
+    // error-boundary machinery intercepts during component mounting — Hoot
+    // flags that as a global "unverified error" regardless of whether the
+    // outer mountView() promise also rejects, so rejects.toThrow() here
+    // would report noise even when the assertion itself is correct.
+    test('undefined lat/lng attributes throw an error', () => {
+        expect(() =>
+            parseArch(`<google_map sidebar_title="name" sidebar_subtitle="contact_address"/>`)
+        ).toThrow('Missing required attribute(s): lat, lng');
+    });
+
+    test('undefined sidebar_title/sidebar_subtitle attributes throw an error', () => {
+        expect(() =>
+            parseArch(`<google_map lat="partner_latitude" lng="partner_longitude"/>`)
+        ).toThrow('Missing required attribute(s): sidebar_title, sidebar_subtitle');
+    });
+});
+
+describe('markers', () => {
+    test('one marker is created per located record', async () => {
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `
+            <google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>
+            `,
+        });
+
+        const renderer = getMapRenderer(view);
+        await waitUntil(() => renderer.cache.size > 0);
+
+        // Only the 2 located records get markers — the unlocated one never
+        // reaches the map at all (it's excluded by mapDomain upstream).
+        expect(renderer.cache.size).toBe(2);
+    });
+
+    test('clicking a marker opens the info window for that record', async () => {
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>
+            `,
+        });
+
+        const renderer = getMapRenderer(view);
+        await waitUntil(() => renderer.cache.size > 0);
+
+        const marker = renderer.cache.get(1);
+        marker.fireClick();
+
+        expect(renderer.markerInfoWindow.openCallCount).toBe(1);
+    });
+});
+
+describe('grouping', () => {
+    test('generateColor is deterministic for a given seed', () => {
+        // GoogleMapGroup derives its color from the group value via this
+        // function specifically so the same group gets the same color
+        // across reloads — assert that contract directly, no map needed.
+        expect(generateColor('Street A')).toBe(generateColor('Street A'));
+        expect(generateColor(42)).toBe(generateColor(42));
+    });
+
+    test('grouping by a field renders one sidebar group per distinct value', async () => {
+        Partner._records = [
+            {
+                id: 1,
+                name: 'Located A',
+                contact_address: 'Street A',
+                country_id: 1,
+                partner_latitude: 10.0,
+                partner_longitude: 10.5,
+            },
+            {
+                id: 2,
+                name: 'Located B',
+                contact_address: 'Street B',
+                country_id: 2,
+                partner_latitude: 11.0,
+                partner_longitude: 11.5,
+            },
+        ];
+
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="country_id"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>`,
+            groupBy: ['country_id'],
+        });
+
+        await waitFor('.o_map_sidebar_group');
+        const groupLabels = queryAllTexts('.o_map_sidebar_group span.ps-1');
+        expect(groupLabels).toEqual(['North (1)', 'South (1)']);
+
+        getMapController(view); // sanity: controller resolves under grouping too
+    });
+});
+
+describe('record actions', () => {
+    test('an always-displayed header button calls doActionButton with its arch-declared name', async () => {
+        let calledWith;
+        mockService('action', {
+            doActionButton(params) {
+                calledWith = params;
+            },
+        });
+
+        await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <header>
+                    <button name="do_something" type="object" string="Do Something" display="always"/>
+                </header>
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>
+            `,
+        });
+
+        await contains("button[name='do_something']").click();
+        expect(calledWith.name).toBe('do_something');
+        expect(calledWith.type).toBe('object');
+        expect(calledWith.resModel).toBe('res.partner');
+    });
+
+    test('deleting a selected record removes it from the view via the standard confirmation flow', async () => {
+        let confirmedProps;
+        mockService('dialog', {
+            add(component, props) {
+                confirmedProps = props;
+                return () => {};
+            },
+        });
+
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map lat="partner_latitude" lng="partner_longitude" sidebar_title="name" sidebar_subtitle="contact_address" disable_cluster_marker="1">
+                <field name="name"/>
+                <field name="contact_address"/>
+                <field name="partner_latitude"/>
+                <field name="partner_longitude"/>
+            </google_map>
+            `,
+        });
+
+        // Select the first record's row in the sidebar (index 0 is the
+        // sidebar's own "select all" checkbox).
+        await waitFor('.o_map_sidebar input.form-check-input');
+        const checkboxes = queryAll('.o_map_sidebar input.form-check-input');
+        await click(checkboxes[1]);
+
+        const controller = getMapController(view);
+        controller.onDeleteSelectedRecords();
+
+        expect(confirmedProps).not.toBe(undefined);
+        await confirmedProps.confirm();
+
+        expect(controller.model.root.records.map((r) => r.resId)).toEqual([2]);
+    });
+});

--- a/web_view_google_map/static/tests/helpers/google_maps_test_helpers.js
+++ b/web_view_google_map/static/tests/helpers/google_maps_test_helpers.js
@@ -1,0 +1,233 @@
+// web_view_google_map/static/tests/helpers/google_maps_test_helpers.js
+//
+// Shared fakes for the one boundary that actually matters when testing any
+// *_google_map view: the external google.maps library. Everything else
+// (settings RPC, loader hook, map bootstrap in base_google_map.js) runs
+// unmodified — real production code, not a bypass — because
+// GoogleMapsAPILoader treats a pre-existing window.google.maps.importLibrary
+// as "already loaded" and skips both the network settings fetch's
+// script-injection path and any script tag.
+//
+// Used by web_view_google_map's own tests and reused (imported via
+// @web_view_google_map/../tests/helpers/google_maps_test_helpers) by
+// dependent modules — e.g. web_view_google_map_drawing — instead of
+// duplicating this harness.
+
+import { onRpc, patchWithCleanup } from '@web/../tests/web_test_helpers';
+
+// A real google.maps.Map exposes `controls` as an array of MVCArray-like
+// collections, one per ControlPosition, that widgets push their DOM
+// elements (geolocate button, search box, ...) into on mount and remove
+// from on cleanup via getArray()/removeAt().
+export class FakeMVCArray extends Array {
+    getArray() {
+        return this;
+    }
+    removeAt(index) {
+        this.splice(index, 1);
+    }
+}
+
+export class FakeLatLngBounds {
+    extend() {
+        return this;
+    }
+    isEmpty() {
+        return true;
+    }
+}
+
+export class FakeMap {
+    constructor(el, options) {
+        this.el = el;
+        this.options = options;
+        this._tilt = 0;
+        this.controls = new Proxy(
+            {},
+            {
+                get: (target, key) => {
+                    if (!(key in target)) {
+                        target[key] = new FakeMVCArray();
+                    }
+                    return target[key];
+                },
+            }
+        );
+    }
+    getDiv() {
+        // AdvancedMarkerBoxSelector attaches its selection-box overlay here.
+        return this.el;
+    }
+    getTilt() {
+        return this._tilt;
+    }
+    setTilt(tilt) {
+        this._tilt = tilt;
+    }
+    getBounds() {
+        return new FakeLatLngBounds();
+    }
+    getZoom() {
+        return this._zoom ?? 8;
+    }
+    setZoom(zoom) {
+        this._zoom = zoom;
+    }
+    setCenter() {}
+    panTo() {}
+    fitBounds() {}
+    setOptions() {}
+    addListener() {
+        return { remove() {} };
+    }
+}
+
+export class FakeAdvancedMarkerElement {
+    constructor(options = {}) {
+        Object.assign(this, options);
+        this._listeners = {};
+    }
+    addListener(eventName, cb) {
+        this._listeners[eventName] = cb;
+        return {
+            remove: () => {
+                delete this._listeners[eventName];
+            },
+        };
+    }
+    // Test helper — no real 'gmp-click' DOM event to dispatch against a fake
+    // marker, so tests trigger the captured handler directly instead.
+    fireClick() {
+        this._listeners['gmp-click']?.();
+    }
+}
+
+export class FakePinElement {
+    constructor(options = {}) {
+        Object.assign(this, options);
+        this.element = document.createElement('div');
+    }
+}
+
+export class FakeInfoWindow {
+    constructor() {
+        this.openCallCount = 0;
+        this._content = null;
+    }
+    open() {
+        this.openCallCount++;
+    }
+    close() {}
+    getContent() {
+        return this._content;
+    }
+    setContent(content) {
+        this._content = content;
+    }
+    addListener() {
+        return { remove() {} };
+    }
+}
+
+export class FakePolyline {
+    setMap() {}
+}
+
+export class FakeRectangle {
+    setMap() {}
+    setBounds() {}
+}
+
+export class FakeLatLng {
+    constructor(lat, lng) {
+        this.lat = () => lat;
+        this.lng = () => lng;
+    }
+}
+
+export const FAKE_GOOGLE_MAPS = {
+    async importLibrary(name) {
+        switch (name) {
+            case 'maps':
+                // Most callers read the bare google.maps.InfoWindow property
+                // (below), but GoogleMapDeckGLRenderer.onMapReady destructures
+                // it from importLibrary('maps') instead — both paths need it.
+                return { Map: FakeMap, InfoWindow: FakeInfoWindow };
+            case 'core':
+                return {
+                    ColorScheme: { LIGHT: 'LIGHT', DARK: 'DARK', FOLLOW_SYSTEM: 'FOLLOW_SYSTEM' },
+                    LatLngBounds: FakeLatLngBounds,
+                };
+            case 'marker':
+                return { AdvancedMarkerElement: FakeAdvancedMarkerElement, PinElement: FakePinElement };
+            default:
+                return {};
+        }
+    },
+    event: {
+        // onMapReady() awaits this exact call for the 'tilesloaded' event
+        // before flipping state.isMapReady — fire it on the next microtask.
+        addListenerOnce(target, eventName, cb) {
+            if (eventName === 'tilesloaded') {
+                Promise.resolve().then(cb);
+            }
+            return { remove() {} };
+        },
+        addListener() {
+            return { remove() {} };
+        },
+        clearInstanceListeners() {},
+        clearListeners() {},
+        trigger() {},
+        removeListener() {},
+    },
+    // All of the below are read directly as bare google.maps.X properties
+    // throughout google_map_renderer.js / utils.js — not fetched through
+    // importLibrary(), so they must be present up front rather than
+    // resolved lazily. Covers the constructors/enums this view's initial
+    // mount and marker rendering path touches.
+    MapTypeId: { ROADMAP: 'ROADMAP', SATELLITE: 'SATELLITE', HYBRID: 'HYBRID', TERRAIN: 'TERRAIN' },
+    ControlPosition: { RIGHT_BOTTOM: 'RIGHT_BOTTOM', TOP_RIGHT: 'TOP_RIGHT' },
+    SymbolPath: { CIRCLE: 'CIRCLE' },
+    InfoWindow: FakeInfoWindow,
+    Polyline: FakePolyline,
+    Rectangle: FakeRectangle,
+    LatLng: FakeLatLng,
+    LatLngBounds: FakeLatLngBounds,
+};
+
+/**
+ * Mocks the /web/base_google_map/settings RPC and pre-seeds
+ * window.google.maps so GoogleMapsAPILoader takes its "already loaded"
+ * fast path. Call from a beforeEach() in any test that mounts a
+ * *_google_map view.
+ */
+export function mockGoogleMapsApi() {
+    onRpc('/web/base_google_map/settings', () => ({
+        // validateParams() requires a string of at least 30 characters.
+        api_key: 'test-api-key-0123456789012345678901234567890',
+        map_id: 'test-map-id',
+        version: 'beta',
+        region: 'US',
+        language: 'en',
+    }));
+
+    patchWithCleanup(window, { google: { maps: FAKE_GOOGLE_MAPS } });
+}
+
+/**
+ * Polls a predicate until it's true. Needed anywhere marker/shape creation
+ * is involved: it's batched behind a real requestIdleCallback and/or a
+ * debounce, and fake markers/shapes never touch the real DOM, so there's
+ * nothing for hoot-dom's waitFor() to poll — wait on the renderer's own
+ * state instead of guessing a fixed number of animation frames.
+ */
+export async function waitUntil(predicate, { timeout = 2000, interval = 20 } = {}) {
+    const start = Date.now();
+    while (!predicate()) {
+        if (Date.now() - start > timeout) {
+            throw new Error('waitUntil: condition not met within timeout');
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+}

--- a/web_view_google_map_drawing/CHANGELOG.md
+++ b/web_view_google_map_drawing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 19.0.2.0.1
+
+### Added
+
+- **Hoot JS Test Suite** (`static/tests/google_map_drawing_view.test.js`): First test suite for the module — covers `GoogleMapDrawingArchParser`'s `geojson` requirement (in place of `lat`/`lng`), `sidebar_title`/`sidebar_subtitle` validation, and `mapDomain`/`notGeolocatedDomain` structure (the `json_ne`/`json_eq` FeatureCollection checks against the geojson field). Reuses `web_view_google_map`'s `mockGoogleMapsApi()` helper and adds minimal fakes for the Deck.gl/Turf.js globals this renderer also depends on.
+- **`web.assets_unit_tests` Bundle** (`__manifest__.py`): Registered `static/tests/**/*` so the new suite runs under Odoo's Hoot test runner.
+- **`GoogleMapDrawingArchParser.mandatoryAttrs()` Override**: Drawing views locate records by a GeoJSON field, not lat/lng — overrides the base parser's mandatory-attribute list with `geojson`, `sidebar_title`, `sidebar_subtitle`, surfaced while writing the arch-parser tests.
+
 ## 19.0.1.0.23
 
 ### Updated Dependencies

--- a/web_view_google_map_drawing/__manifest__.py
+++ b/web_view_google_map_drawing/__manifest__.py
@@ -28,7 +28,7 @@ Provides:
     "website": "https://www.mithnusa.com",
     "support": "yopiangi@gmail.com",
     "category": "Extra Tools",
-    "version": "19.0.1.0.23",
+    "version": "19.0.2.0.1",
     "depends": ["web_view_google_map"],
     "assets": {
         "web.assets_backend": [
@@ -59,6 +59,9 @@ Provides:
             "web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_controller.xml",
             "web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_view.js",
             "web_view_google_map_drawing/static/src/fields/x2many/google_map_drawing_x2many_field.js",
+        ],
+        "web.assets_unit_tests": [
+            "web_view_google_map_drawing/static/tests/**/*",
         ],
     },
 }

--- a/web_view_google_map_drawing/static/src/fields/x2many/google_map_drawing_x2many_field.js
+++ b/web_view_google_map_drawing/static/src/fields/x2many/google_map_drawing_x2many_field.js
@@ -11,10 +11,13 @@ export class X2manyFieldGoogleMapDrawing extends X2ManyFieldGoogleMap {
 
     get viewAttrsConfig() {
         const { archInfo } = this;
-        return Object.assign({}, super.viewAttrsConfig, {
+        const attrs = Object.assign({}, super.viewAttrsConfig, {
             geoJsonField: archInfo.geoJsonField,
             subTitle: archInfo.sidebarSubtitleField,
         });
+        delete attrs.lat;
+        delete attrs.lng;
+        return attrs;
     }
 }
 

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_arch_parser.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_arch_parser.js
@@ -13,6 +13,11 @@ patch(GoogleMapArchParser.prototype, {
 });
 
 export class GoogleMapDrawingArchParser extends GoogleMapArchParser {
+    // Drawing views locate records by a GeoJSON field, not lat/lng.
+    mandatoryAttrs() {
+        return ['geojson', 'sidebar_title', 'sidebar_subtitle'];
+    }
+
     parseGoogleMapAttrs(xmlDoc, node, attrs) {
         super.parseGoogleMapAttrs(xmlDoc, node, attrs);
 

--- a/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_arch_parser.js
+++ b/web_view_google_map_drawing/static/src/views/google_map_drawing/google_map_drawing_arch_parser.js
@@ -1,27 +1,34 @@
 import { patch } from '@web/core/utils/patch';
 import { GoogleMapArchParser } from '@web_view_google_map/views/google_map/google_map_arch_parser';
 
+// Patches the BASE class's prototype, not just the GoogleMapDrawingArchParser
+// subclass below — necessary because Field.parseFieldNode (used for
+// one2many/many2many sub-views) resolves an embedded <google_map> element's
+// ArchParser via viewRegistry.get(child.tagName): always 'google_map',
+// never consulting js_class. js_class-based ArchParser swapping only
+// happens for top-level View mounting. So a google_map_drawing_one2many/
+// _many2many field's embedded arch (js_class="google_map_drawing", geojson
+// instead of lat/lng) is always parsed by GoogleMapArchParser itself, never
+// by the subclass below — the base class's prototype must be taught to
+// recognize geojson as an alternative right here, at the source.
 patch(GoogleMapArchParser.prototype, {
+    hasValidGeoAttrs(xmlDoc) {
+        return super.hasValidGeoAttrs(xmlDoc) || Boolean(xmlDoc.getAttribute('geojson'));
+    },
     parseGoogleMapAttrs(xmlDoc, node, attrs) {
         super.parseGoogleMapAttrs(xmlDoc, node, attrs);
-
-        const geoJsonField = xmlDoc.getAttribute('geojson');
-        if (geoJsonField) {
-            attrs.geoJsonField = geoJsonField;
-        }
+        attrs.geoJsonField = xmlDoc.getAttribute('geojson') || undefined;
     },
 });
 
 export class GoogleMapDrawingArchParser extends GoogleMapArchParser {
-    // Drawing views locate records by a GeoJSON field, not lat/lng.
-    mandatoryAttrs() {
-        return ['geojson', 'sidebar_title', 'sidebar_subtitle'];
+    // Strict override for TOP-LEVEL google_map_drawing-typed views: a
+    // drawing view specifically needs geojson, not a lat/lng fallback.
+    hasValidGeoAttrs(xmlDoc) {
+        return Boolean(xmlDoc.getAttribute('geojson'));
     }
 
-    parseGoogleMapAttrs(xmlDoc, node, attrs) {
-        super.parseGoogleMapAttrs(xmlDoc, node, attrs);
-
-        const geoJsonField = xmlDoc.getAttribute('geojson');
-        attrs.geoJsonField = geoJsonField;
+    missingGeoAttrsMessage() {
+        return 'Missing required attribute(s): geojson';
     }
 }

--- a/web_view_google_map_drawing/static/tests/google_map_drawing_view.test.js
+++ b/web_view_google_map_drawing/static/tests/google_map_drawing_view.test.js
@@ -11,6 +11,7 @@ import {
 } from '@web/../tests/web_test_helpers';
 
 import { mockGoogleMapsApi } from '@web_view_google_map/../tests/helpers/google_maps_test_helpers';
+import { GoogleMapArchParser } from '@web_view_google_map/views/google_map/google_map_arch_parser';
 import { GoogleMapDrawingArchParser } from '@web_view_google_map_drawing/views/google_map_drawing/google_map_drawing_arch_parser';
 import { GoogleMapDrawingController } from '@web_view_google_map_drawing/views/google_map_drawing/google_map_drawing_controller';
 
@@ -95,6 +96,27 @@ describe('arch parser', () => {
         const archInfo = parseArch(
             `<google_map js_class="google_map_drawing" geojson="gshape_geojson" sidebar_title="name" sidebar_subtitle="contact_address"/>`
         );
+        expect(archInfo.geoJsonField).toBe('gshape_geojson');
+    });
+
+    // Regression test: Field.parseFieldNode (used for one2many/many2many
+    // sub-views, e.g. a drawing map embedded via google_map_drawing_one2many)
+    // resolves an embedded <google_map> element's ArchParser via
+    // viewRegistry.get(child.tagName) — always 'google_map', regardless of
+    // any js_class attribute on the element. js_class-based ArchParser
+    // swapping only happens for top-level View mounting, so an embedded
+    // drawing arch is always parsed by the BASE GoogleMapArchParser, never
+    // by GoogleMapDrawingArchParser above. This module patches
+    // GoogleMapArchParser.prototype (see google_map_drawing_arch_parser.js)
+    // specifically so that base-class instance still recognizes geojson —
+    // simulate that exact scenario here by instantiating the base class
+    // directly rather than the drawing subclass.
+    test('the patched base GoogleMapArchParser accepts geojson as an alternative to lat/lng', () => {
+        const xmlDoc = new DOMParser().parseFromString(
+            `<google_map js_class="google_map_drawing" geojson="gshape_geojson" sidebar_title="name" sidebar_subtitle="contact_address"/>`,
+            'text/xml'
+        ).documentElement;
+        const archInfo = new GoogleMapArchParser().parse(xmlDoc, { 'res.partner': { fields: {} } }, 'res.partner');
         expect(archInfo.geoJsonField).toBe('gshape_geojson');
     });
 });

--- a/web_view_google_map_drawing/static/tests/google_map_drawing_view.test.js
+++ b/web_view_google_map_drawing/static/tests/google_map_drawing_view.test.js
@@ -1,0 +1,176 @@
+// web_view_google_map_drawing/static/tests/google_map_drawing_view.test.js
+import { beforeEach, describe, expect, test } from '@odoo/hoot';
+import {
+    defineModels,
+    fields,
+    findComponent,
+    models,
+    mountView,
+    patchWithCleanup,
+    serverState,
+} from '@web/../tests/web_test_helpers';
+
+import { mockGoogleMapsApi } from '@web_view_google_map/../tests/helpers/google_maps_test_helpers';
+import { GoogleMapDrawingArchParser } from '@web_view_google_map_drawing/views/google_map_drawing/google_map_drawing_arch_parser';
+import { GoogleMapDrawingController } from '@web_view_google_map_drawing/views/google_map_drawing/google_map_drawing_controller';
+
+class Partner extends models.Model {
+    _name = 'res.partner';
+
+    name = fields.Char();
+    contact_address = fields.Char();
+    // The mock server's field DSL has no dedicated Json type; a Char field
+    // is a fine stand-in here since these tests only check field-metadata
+    // shape (searchable) and arch/domain *structure* — no test actually
+    // round-trips a search through the mock server using this field (see
+    // the "map domain" describe block for why that specifically can't work).
+    gshape_geojson = fields.Char();
+
+    _records = [{ id: 1, name: 'Shape A', contact_address: 'Street A', gshape_geojson: false }];
+}
+
+// The mock server resolves the current user (env["res.users"].browse(uid))
+// on every RPC, not just when a field references res.users — it must
+// always be registered, even though nothing in this view touches it.
+class Users extends models.Model {
+    _name = 'res.users';
+
+    name = fields.Char();
+    _records = [{ id: serverState.userId, name: 'Mitchell Admin' }];
+
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, Users]);
+
+function getMapController(view) {
+    return findComponent(view, (c) => c instanceof GoogleMapDrawingController);
+}
+
+// Minimal, non-rendering stand-ins for the second third-party global this
+// renderer needs (on top of google.maps): Deck.gl and Turf.js. onWillStart
+// checks `window.deck && window.turf` and skips loading the real bundled
+// assets if both are already present — same "already loaded" fast path as
+// GoogleMapsAPILoader. These exist purely so mounting doesn't crash; no
+// test in this file asserts anything about actual shape/layer rendering.
+const FAKE_DECK = {
+    GoogleMapsOverlay: class {
+        setMap() {}
+        setProps() {}
+    },
+    GeoJsonLayer: class {},
+    ScatterplotLayer: class {},
+};
+const FAKE_TURF = {
+    area: () => 0,
+};
+
+beforeEach(() => {
+    mockGoogleMapsApi();
+    patchWithCleanup(window, { deck: FAKE_DECK, turf: FAKE_TURF });
+});
+
+describe('arch parser', () => {
+    // Pure parsing logic — no mountView, no google.maps/deck.gl, no OWL.
+    function parseArch(archXml) {
+        const xmlDoc = new DOMParser().parseFromString(archXml, 'text/xml').documentElement;
+        return new GoogleMapDrawingArchParser().parse(xmlDoc, { 'res.partner': { fields: {} } }, 'res.partner');
+    }
+
+    test('geojson is required instead of lat/lng', () => {
+        expect(() =>
+            parseArch(`<google_map js_class="google_map_drawing" sidebar_title="name" sidebar_subtitle="contact_address"/>`)
+        ).toThrow('Missing required attribute(s): geojson');
+    });
+
+    test('sidebar_title/sidebar_subtitle are still required', () => {
+        expect(() => parseArch(`<google_map js_class="google_map_drawing" geojson="gshape_geojson"/>`)).toThrow(
+            'Missing required attribute(s): sidebar_title, sidebar_subtitle'
+        );
+    });
+
+    test('a valid arch parses geoJsonField from the geojson attribute', () => {
+        const archInfo = parseArch(
+            `<google_map js_class="google_map_drawing" geojson="gshape_geojson" sidebar_title="name" sidebar_subtitle="contact_address"/>`
+        );
+        expect(archInfo.geoJsonField).toBe('gshape_geojson');
+    });
+});
+
+describe('map domain', () => {
+    test('mapDomain and notGeolocatedDomain are empty when the geojson field is not searchable', async () => {
+        // A non-searchable field is the only way to mount this view without
+        // hitting the blocker below — GoogleMapDrawingModel.load() would
+        // otherwise merge a domain using the custom json_ne/json_eq
+        // operators into a real search, and neither the client Domain
+        // evaluator nor the mock server's own record filtering (both go
+        // through the same matchCondition() in core/domain.js) implement
+        // those operators — real Odoo only supports them server-side, in
+        // Python. With the field not searchable, _hasSearchableGeoFields()
+        // is false and both getters short-circuit to [] before ever
+        // building a domain, so no search using json_ne/json_eq happens.
+        Partner._fields.gshape_geojson.searchable = false;
+
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map js_class="google_map_drawing" geojson="gshape_geojson" sidebar_title="name" sidebar_subtitle="contact_address">
+                <field name="gshape_geojson"/>
+                <field name="name"/>
+                <field name="contact_address"/>
+            </google_map>`,
+        });
+
+        const { model } = getMapController(view);
+        expect(model.mapDomain).toEqual([]);
+        expect(model.notGeolocatedDomain).toEqual([]);
+
+        Partner._fields.gshape_geojson.searchable = true;
+    });
+
+    test('mapDomain and notGeolocatedDomain reference the geojson field and the empty/null FeatureCollection check', async () => {
+        // Same blocker as above. Mount with the field non-searchable so
+        // load() completes normally (a real search, but with an empty
+        // mapDomain — model.root gets built correctly, unlike stubbing
+        // load() entirely, which left it undefined and crashed usePager).
+        Partner._fields.gshape_geojson.searchable = false;
+
+        const view = await mountView({
+            type: 'google_map',
+            resModel: 'res.partner',
+            arch: `<google_map js_class="google_map_drawing" geojson="gshape_geojson" sidebar_title="name" sidebar_subtitle="contact_address">
+                <field name="gshape_geojson"/>
+                <field name="name"/>
+                <field name="contact_address"/>
+            </google_map>`,
+        });
+
+        const { model } = getMapController(view);
+
+        // Flip searchable directly on the model's own field-metadata (not
+        // Partner._fields, which may not be the same object load() already
+        // read) and clear mapDomain/notGeolocatedDomain's memoization
+        // caches so re-reading them recomputes with _hasSearchableGeoFields()
+        // now true. This never triggers another search — those getters are
+        // pure; only load() performs RPCs, and it isn't called again here.
+        model.config.fields[model.viewConfig.geoJsonField].searchable = true;
+        model._mapDomainCache = undefined;
+        model._unlocatedDomainCache = undefined;
+
+        // Structural assertions, not behavioral ones: Domain.contains()
+        // can't evaluate json_ne/json_eq (see above), so this checks the
+        // right field and operators are present rather than filtering an
+        // actual record through the domain.
+        const mapDomainJson = JSON.stringify(model.mapDomain);
+        expect(mapDomainJson).toInclude('gshape_geojson');
+        expect(mapDomainJson).toInclude('json_ne');
+        expect(mapDomainJson).toInclude('FeatureCollection');
+
+        const notGeolocatedJson = JSON.stringify(model.notGeolocatedDomain);
+        expect(notGeolocatedJson).toInclude('gshape_geojson');
+        expect(notGeolocatedJson).toInclude('json_eq');
+        expect(notGeolocatedJson).toInclude('FeatureCollection');
+    });
+});


### PR DESCRIPTION
## Summary
- Add the repo's first Hoot JS test suites, for `web_view_google_map`
  and `web_view_google_map_drawing`, plus a shared `google_maps_test_helpers.js`
  harness that fakes the `google.maps` API boundary (reused by both modules).
- Writing the tests surfaced and fixed a real bug: `GoogleMapArchParser`
  passed a bare `null` (not `undefined`) for `sidebar_title`/`sidebar_subtitle`
  when the attribute was absent, which failed OWL's optional `String` prop
  check on `GoogleMapSidebar` and crashed the view.
- Added `mandatoryAttrs()` validation to both arch parsers so a misconfigured
  view arch (missing `lat`/`lng`/`geojson` or the sidebar title/subtitle
  fields) fails fast with a clear error instead of crashing deeper in
  rendering.
- Registered `web.assets_unit_tests` for both modules and extended the
  coverage workflow to auto-discover any addon's `static/tests/*.test.js`
  files and run them as Hoot suites — previously only Python DB tests were
  picked up, so these new suites (and any future JS-only suite) would have
  been silently skipped by CI.